### PR TITLE
F3: SecureStore protocol + KeychainSecureStore + InMemory fake (closes #22)

### DIFF
--- a/Sources/Services/KeychainSecureStore.swift
+++ b/Sources/Services/KeychainSecureStore.swift
@@ -15,7 +15,12 @@ import Security
 /// name but never the value.
 public actor KeychainSecureStore: SecureStore {
     public enum Failure: Swift.Error, CustomStringConvertible, Equatable, Sendable {
+        /// The keychain returned an unexpected OSStatus for an operation.
         case osStatus(OSStatus, Operation)
+        /// `SecItemCopyMatching` succeeded but returned a value that was not
+        /// `Data`. Indicates keychain corruption or a cross-class match and
+        /// MUST NOT be silently mapped to "missing".
+        case unexpectedItemType(Operation)
 
         public enum Operation: String, Sendable {
             case set, get, delete, deleteAll
@@ -25,6 +30,8 @@ public actor KeychainSecureStore: SecureStore {
             switch self {
             case let .osStatus(status, op):
                 return "KeychainSecureStore: \(op.rawValue) failed (OSStatus \(status))"
+            case let .unexpectedItemType(op):
+                return "KeychainSecureStore: \(op.rawValue) returned a non-Data item"
             }
         }
     }
@@ -42,8 +49,14 @@ public actor KeychainSecureStore: SecureStore {
             kSecAttrService as String: service,
             kSecAttrAccount as String: key
         ]
+        // Include accessibility in the update payload too. If an item already
+        // exists with a looser policy (e.g. created by an older build before
+        // the ThisDeviceOnly guard was introduced), `SecItemUpdate` otherwise
+        // leaves `kSecAttrAccessible` unchanged and silently preserves the
+        // looser policy — defeating the iCloud-sync guard.
         let attributesToUpdate: [String: Any] = [
-            kSecValueData as String: data
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         ]
         let updateStatus = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
 
@@ -51,17 +64,46 @@ public actor KeychainSecureStore: SecureStore {
         case errSecSuccess:
             return
         case errSecItemNotFound:
-            var addQuery = query
-            addQuery[kSecValueData as String] = data
-            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
-            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-            if addStatus != errSecSuccess {
-                logger.error("set failed (add) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(addStatus)")
-                throw Failure.osStatus(addStatus, .set)
-            }
+            try addItem(key: key, data: data, query: query, retryOnDuplicate: true)
         default:
             logger.error("set failed (update) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(updateStatus)")
             throw Failure.osStatus(updateStatus, .set)
+        }
+    }
+
+    /// `SecItemAdd` with a one-shot retry when another process races us
+    /// between our `SecItemUpdate` miss and `SecItemAdd`. The alternative
+    /// (`errSecDuplicateItem` bubbling to the caller) is a flake that would
+    /// rarely fire but ship to users.
+    private func addItem(
+        key: String,
+        data: Data,
+        query: [String: Any],
+        retryOnDuplicate: Bool
+    ) throws {
+        var addQuery = query
+        addQuery[kSecValueData as String] = data
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+
+        switch addStatus {
+        case errSecSuccess:
+            return
+        case errSecDuplicateItem where retryOnDuplicate:
+            let updateStatus = SecItemUpdate(
+                query as CFDictionary,
+                [
+                    kSecValueData as String: data,
+                    kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+                ] as CFDictionary
+            )
+            if updateStatus != errSecSuccess {
+                logger.error("set failed (retry-update) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(updateStatus)")
+                throw Failure.osStatus(updateStatus, .set)
+            }
+        default:
+            logger.error("set failed (add) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(addStatus)")
+            throw Failure.osStatus(addStatus, .set)
         }
     }
 
@@ -77,7 +119,15 @@ public actor KeychainSecureStore: SecureStore {
         let status = SecItemCopyMatching(query as CFDictionary, &item)
         switch status {
         case errSecSuccess:
-            return item as? Data
+            // Keychain said "success" but returned something other than Data
+            // (class mismatch, corruption, etc.). The SecureStore contract is
+            // "missing returns nil, anything else throws" — silently returning
+            // nil here would hide a real problem.
+            guard let data = item as? Data else {
+                logger.error("get returned non-Data item service=\(self.service, privacy: .public) key=\(key, privacy: .public)")
+                throw Failure.unexpectedItemType(.get)
+            }
+            return data
         case errSecItemNotFound:
             return nil
         default:

--- a/Sources/Services/KeychainSecureStore.swift
+++ b/Sources/Services/KeychainSecureStore.swift
@@ -1,0 +1,113 @@
+import Foundation
+import os.log
+import Security
+
+/// Real Keychain-backed implementation of `SecureStore`. Uses
+/// `kSecClassGenericPassword` scoped by a service identifier that namespaces
+/// every item belonging to this store (e.g. `"com.speechtotext.cliniko"`).
+///
+/// Accessibility is pinned to
+/// `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` to prevent secrets from
+/// syncing via iCloud Keychain — important for credentials tied to a specific
+/// practitioner's workstation.
+///
+/// Item values are never logged. Error-path logs include the service and key
+/// name but never the value.
+public actor KeychainSecureStore: SecureStore {
+    public enum Failure: Swift.Error, CustomStringConvertible, Equatable, Sendable {
+        case osStatus(OSStatus, Operation)
+
+        public enum Operation: String, Sendable {
+            case set, get, delete, deleteAll
+        }
+
+        public var description: String {
+            switch self {
+            case let .osStatus(status, op):
+                return "KeychainSecureStore: \(op.rawValue) failed (OSStatus \(status))"
+            }
+        }
+    }
+
+    private let service: String
+    private let logger = Logger(subsystem: "com.speechtotext", category: "KeychainSecureStore")
+
+    public init(service: String) {
+        self.service = service
+    }
+
+    public func set(_ data: Data, forKey key: String) async throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        let attributesToUpdate: [String: Any] = [
+            kSecValueData as String: data
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributesToUpdate as CFDictionary)
+
+        switch updateStatus {
+        case errSecSuccess:
+            return
+        case errSecItemNotFound:
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+            let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+            if addStatus != errSecSuccess {
+                logger.error("set failed (add) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(addStatus)")
+                throw Failure.osStatus(addStatus, .set)
+            }
+        default:
+            logger.error("set failed (update) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(updateStatus)")
+            throw Failure.osStatus(updateStatus, .set)
+        }
+    }
+
+    public func get(forKey key: String) async throws -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        switch status {
+        case errSecSuccess:
+            return item as? Data
+        case errSecItemNotFound:
+            return nil
+        default:
+            logger.error("get failed service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(status)")
+            throw Failure.osStatus(status, .get)
+        }
+    }
+
+    public func delete(forKey key: String) async throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            logger.error("delete failed service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(status)")
+            throw Failure.osStatus(status, .delete)
+        }
+    }
+
+    public func deleteAll() async throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            logger.error("deleteAll failed service=\(self.service, privacy: .public) status=\(status)")
+            throw Failure.osStatus(status, .deleteAll)
+        }
+    }
+}

--- a/Sources/Services/SecureStore.swift
+++ b/Sources/Services/SecureStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Abstraction over the system Keychain so services can be unit-tested with an
+/// in-memory fake without touching the real login keychain.
+///
+/// Implementations must be thread-safe and `Sendable`. Reads of a missing key
+/// return `nil` rather than throwing; `throws` is reserved for underlying OS
+/// errors (e.g. access denied) that should propagate.
+public protocol SecureStore: Sendable {
+    /// Store `data` under `key`, overwriting any existing value.
+    func set(_ data: Data, forKey key: String) async throws
+
+    /// Retrieve the value for `key`, or `nil` if not present.
+    func get(forKey key: String) async throws -> Data?
+
+    /// Remove the value for `key`. No-op if missing.
+    func delete(forKey key: String) async throws
+
+    /// Remove every item owned by this store's namespace. Intended for "log
+    /// out" / "clear credentials" flows and for tests.
+    func deleteAll() async throws
+}
+
+public extension SecureStore {
+    /// Convenience: store a UTF-8 string.
+    func setString(_ string: String, forKey key: String) async throws {
+        try await set(Data(string.utf8), forKey: key)
+    }
+
+    /// Convenience: retrieve a UTF-8 string, or `nil` if missing.
+    func getString(forKey key: String) async throws -> String? {
+        guard let data = try await get(forKey: key) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+}

--- a/Tests/SpeechToTextTests/Utilities/InMemorySecureStore.swift
+++ b/Tests/SpeechToTextTests/Utilities/InMemorySecureStore.swift
@@ -1,0 +1,39 @@
+import Foundation
+@testable import SpeechToText
+
+/// In-memory fake for `SecureStore` used in unit tests. Never touches the
+/// real Keychain. Thread-safe via actor isolation.
+///
+/// Use this anywhere a test needs a credentials store — the real
+/// `KeychainSecureStore` is only exercised via manual smoke tests, not in CI.
+public actor InMemorySecureStore: SecureStore {
+    private var storage: [String: Data]
+
+    public init(initial: [String: Data] = [:]) {
+        self.storage = initial
+    }
+
+    public func set(_ data: Data, forKey key: String) async throws {
+        storage[key] = data
+    }
+
+    public func get(forKey key: String) async throws -> Data? {
+        storage[key]
+    }
+
+    public func delete(forKey key: String) async throws {
+        storage.removeValue(forKey: key)
+    }
+
+    public func deleteAll() async throws {
+        storage.removeAll(keepingCapacity: false)
+    }
+
+    // MARK: - Test helpers
+
+    /// Number of items currently held. Test-only.
+    public func count() async -> Int { storage.count }
+
+    /// Sorted list of keys currently held. Test-only.
+    public func keys() async -> [String] { storage.keys.sorted() }
+}

--- a/Tests/SpeechToTextTests/Utilities/InMemorySecureStoreTests.swift
+++ b/Tests/SpeechToTextTests/Utilities/InMemorySecureStoreTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+@testable import SpeechToText
+
+/// Tests for `InMemorySecureStore`, the test-only `SecureStore` fake.
+///
+/// These tests also exercise the default protocol extension (`setString` /
+/// `getString`), so they act as a contract-test for any future
+/// `SecureStore` implementation.
+final class InMemorySecureStoreTests: XCTestCase {
+
+    // MARK: - Data API
+
+    func test_getMissing_returnsNil() async throws {
+        let store = InMemorySecureStore()
+        let value = try await store.get(forKey: "missing")
+        XCTAssertNil(value)
+    }
+
+    func test_setThenGet_returnsSameData() async throws {
+        let store = InMemorySecureStore()
+        let expected = Data("secret".utf8)
+        try await store.set(expected, forKey: "api-key")
+        let actual = try await store.get(forKey: "api-key")
+        XCTAssertEqual(actual, expected)
+    }
+
+    func test_overwrite_replacesValue() async throws {
+        let store = InMemorySecureStore()
+        try await store.set(Data("old".utf8), forKey: "k")
+        try await store.set(Data("new".utf8), forKey: "k")
+        let actual = try await store.get(forKey: "k")
+        XCTAssertEqual(actual, Data("new".utf8))
+    }
+
+    func test_delete_removesValue() async throws {
+        let store = InMemorySecureStore()
+        try await store.set(Data("x".utf8), forKey: "k")
+        try await store.delete(forKey: "k")
+        let actual = try await store.get(forKey: "k")
+        XCTAssertNil(actual)
+    }
+
+    func test_deleteMissing_isNoOp() async throws {
+        let store = InMemorySecureStore()
+        try await store.delete(forKey: "never-existed")
+        let count = await store.count()
+        XCTAssertEqual(count, 0)
+    }
+
+    func test_deleteAll_clearsEveryItem() async throws {
+        let store = InMemorySecureStore(initial: [
+            "a": Data("1".utf8),
+            "b": Data("2".utf8)
+        ])
+
+        let countBefore = await store.count()
+        XCTAssertEqual(countBefore, 2)
+
+        try await store.deleteAll()
+
+        let countAfter = await store.count()
+        XCTAssertEqual(countAfter, 0)
+    }
+
+    // MARK: - String convenience (default protocol extension)
+
+    func test_setString_getString_roundTrip() async throws {
+        let store = InMemorySecureStore()
+        try await store.setString("hello", forKey: "greeting")
+        let value = try await store.getString(forKey: "greeting")
+        XCTAssertEqual(value, "hello")
+    }
+
+    func test_getString_missing_returnsNil() async throws {
+        let store = InMemorySecureStore()
+        let value = try await store.getString(forKey: "missing")
+        XCTAssertNil(value)
+    }
+
+    // MARK: - Initial state
+
+    func test_initial_state_isReflected() async throws {
+        let initial: [String: Data] = [
+            "alpha": Data("A".utf8),
+            "bravo": Data("B".utf8)
+        ]
+        let store = InMemorySecureStore(initial: initial)
+
+        let keys = await store.keys()
+        XCTAssertEqual(keys, ["alpha", "bravo"])
+
+        let alpha = try await store.get(forKey: "alpha")
+        XCTAssertEqual(alpha, Data("A".utf8))
+    }
+}

--- a/Tests/SpeechToTextTests/Utilities/InMemorySecureStoreTests.swift
+++ b/Tests/SpeechToTextTests/Utilities/InMemorySecureStoreTests.swift
@@ -86,10 +86,71 @@ final class InMemorySecureStoreTests: XCTestCase {
         ]
         let store = InMemorySecureStore(initial: initial)
 
-        let keys = await store.keys()
-        XCTAssertEqual(keys, ["alpha", "bravo"])
-
+        // Assert via the public `get` API (not the `keys()` helper) so a
+        // future divergence between internal state and the public contract
+        // is caught.
         let alpha = try await store.get(forKey: "alpha")
         XCTAssertEqual(alpha, Data("A".utf8))
+
+        let bravo = try await store.get(forKey: "bravo")
+        XCTAssertEqual(bravo, Data("B".utf8))
+
+        let missing = try await store.get(forKey: "charlie")
+        XCTAssertNil(missing)
+    }
+
+    // MARK: - Byte-transparency
+
+    func test_roundTrip_preservesBinaryContent() async throws {
+        // Null bytes + non-UTF-8 bytes. Catches any future refactor that
+        // silently routes through `String` and corrupts arbitrary-byte secrets.
+        let store = InMemorySecureStore()
+        let bytes: [UInt8] = [0x00, 0xFF, 0xFE, 0x00, 0xC3, 0x28, 0x00]
+        let expected = Data(bytes)
+
+        try await store.set(expected, forKey: "binary-blob")
+        let actual = try await store.get(forKey: "binary-blob")
+
+        XCTAssertEqual(actual, expected)
+        XCTAssertEqual(actual?.count, expected.count)
+    }
+
+    // MARK: - Bulk delete edge
+
+    func test_deleteAll_onEmptyStore_isNoOp() async throws {
+        let store = InMemorySecureStore()
+        try await store.deleteAll()
+        let count = await store.count()
+        XCTAssertEqual(count, 0)
+    }
+
+    // MARK: - Concurrency contract
+
+    func test_concurrent_setsAndGets_doNotCorruptState() async throws {
+        // Fires N concurrent writes and reads through the actor to lock in
+        // the serialisation contract the type advertises. If the actor is
+        // ever refactored to a class with a data-race bug, this test should
+        // start failing under ThreadSanitizer.
+        let store = InMemorySecureStore()
+        let count = 128
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<count {
+                group.addTask {
+                    let key = "key-\(i)"
+                    let value = Data("value-\(i)".utf8)
+                    try? await store.set(value, forKey: key)
+                    _ = try? await store.get(forKey: key)
+                }
+            }
+        }
+
+        let finalCount = await store.count()
+        XCTAssertEqual(finalCount, count)
+
+        for i in 0..<count {
+            let value = try await store.get(forKey: "key-\(i)")
+            XCTAssertEqual(value, Data("value-\(i)".utf8), "key-\(i) value mismatch")
+        }
     }
 }


### PR DESCRIPTION
## Summary

Third PR from the [Testing + Workflow Framework EPIC (#19)](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/19). Closes #22 (F3). Independent of #26 (F1) and #27 (F2) — branched from `main`. **Unblocks #7** (KeychainCredentialStore + Cliniko settings UI).

Adds the credential-storage abstraction that #7 + the Cliniko work will depend on: a `Sendable` protocol, a real Keychain-backed actor implementation, and a test-only in-memory fake. CI unit tests use only the fake — no runner ever hits the real Keychain.

## What's here

### Protocol — `Sources/Services/SecureStore.swift`

```swift
public protocol SecureStore: Sendable {
    func set(_ data: Data, forKey key: String) async throws
    func get(forKey key: String) async throws -> Data?
    func delete(forKey key: String) async throws
    func deleteAll() async throws
}
```

Plus default `setString` / `getString` for UTF-8 payloads. Missing keys return `nil` rather than throwing — `throws` is reserved for OS errors (access denied, etc.).

### Real impl — `Sources/Services/KeychainSecureStore.swift`

- `kSecClassGenericPassword` scoped by a service identifier injected at init (e.g. `"com.speechtotext.cliniko"`).
- Accessibility pinned to `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` — **prevents iCloud Keychain sync** of practitioner secrets. Critical for PHI-adjacent storage.
- Error paths log service + key names (`privacy: .public`) but **never** the item value.
- Actor-isolated for thread-safety.

### Test fake — `Tests/SpeechToTextTests/Utilities/InMemorySecureStore.swift`

- Actor-isolated `[String: Data]`. Does not import `Security` and never touches the real Keychain.
- `count()` / `keys()` test helpers for inspecting internal state in assertions.
- Seedable via `init(initial:)` for tests that need a pre-populated store.

### Tests — `InMemorySecureStoreTests.swift` (9 tests)

Covers: get-missing returns nil, set+get round-trip, overwrite, delete, delete-missing no-op, `deleteAll()` clears everything, string convenience round-trip, `initial:` construction. Also acts as a contract test for any future `SecureStore` implementation.

## Why no real-keychain tests in CI

CI runners have no user Keychain to authenticate against; touching `SecItem*` either fails or prompts for a password and hangs. The real `KeychainSecureStore` is covered by manual smoke-tests and by integration-testing the eventual Cliniko credential UI (#7) on a real Mac. See also the pattern established in F1 (#20): hardware-dependent work stays on the remote-Mac pre-push hook.

## Validated locally

- [x] `swift build --target SpeechToText` — clean.
- [x] `swift test --filter InMemorySecureStoreTests` — **9/9 pass**.
- [x] `swift test --parallel` with the F1 CI skip-list — **732/732 pass, 0 failures**.
- [x] `swiftlint lint --strict` on the new files — clean (`sorted_imports` auto-fixed case-insensitive order).
- [x] `pre-commit run` on changed files — all hooks pass.

## Test plan for CI

- [ ] `lint` job passes.
- [ ] `pre-commit` job passes (if #26 has merged; otherwise only `lint` runs pre-F1).
- [ ] `test` job — `InMemorySecureStoreTests` appears green in the test report.

## References

- EPIC #19 — Testing + Workflow Framework.
- Issue #22 — F3 spec + acceptance criteria.
- Issue #7 — KeychainCredentialStore (downstream consumer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)