### PR TITLE
chore(workflow): Gemini Code Assist + Opus-subagent mandate + session-start AGENTS.md load

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## 🚨 Read this first — every session
+
+**Before responding to the user's first message in any new session, you MUST:**
+
+1. **Read `AGENTS.md` at the project root** — `/Users/aarone/Documents/repos/mac-speech-to-text/AGENTS.md` on the host, `/workspace/AGENTS.md` in the devcontainer. It holds the Correctness Checklist (always/never rules), the Topic Router for `.claude/references/*.md`, and the tech-stack + commands reference. The `@../AGENTS.md` import below is defence-in-depth; if it resolves, great — **either way, read the file explicitly with the `Read` tool before any substantive work.**
+2. **Read any `.claude/references/<topic>.md` files relevant to the task** — concurrency, testing conventions, PHI, Cliniko, MLX, menu-bar — per the Topic Router in AGENTS.md. Do not load all of them; load only what the task needs.
+3. **Pick up the GitHub issue(s) you've been asked to work on** with `gh issue view <N> -R CloudbrokerAz/mac-speech-to-text`.
+
+If the user asks "did you read AGENTS.md?" at any point in a session, the correct answer is "yes, I read it at session start" — not "let me check now." This checklist is the contract that makes that true.
+
+@../AGENTS.md
+
 **Project Type**: macOS native application for local speech-to-text capture
 **Language**: Swift 6.x (compiler) with Swift 5.9 language mode (Package.swift)
 **Platform**: macOS 14+ (minimum), macOS 26+ (development)
@@ -23,7 +35,7 @@ gh issue view <N> --comments   # for any specific issue you pick up
 
 ### Operating rules (binding)
 
-1. **Use multiple Opus subagents liberally.** For any research/exploration spanning more than a couple of files, spawn parallel `Explore` / `general-purpose` agents. Keep the main thread for decisions and orchestration. Review-type agents (`pr-review-toolkit:code-reviewer`) run after substantive changes.
+1. **Use Opus subagents liberally — and ALWAYS pass `model: "opus"` explicitly.** For any research/exploration spanning more than a couple of files, spawn parallel `Explore` / `general-purpose` agents with `model: "opus"` on every `Agent` tool call. Do not rely on the agent-definition default — several agents default to Sonnet and will silently downgrade if you omit the override. Review agents (`pr-review-toolkit:code-reviewer`, `pr-review-toolkit:comment-analyzer`, `pr-review-toolkit:silent-failure-hunter`, `pr-review-toolkit:type-design-analyzer`) run after substantive changes and **also** take `model: "opus"`. Keep the main thread for decisions and orchestration.
 2. **Test everything.** Every new service gets a unit test; every new SwiftUI view gets a ViewInspector crash test; ReviewScreen + SafetyDisclaimer get snapshot tests. New pure-logic/async tests use **Swift Testing** (`@Test` / `#expect`) — see `Tests/SpeechToTextTests/Utilities/SwiftTestingExemplarTests.swift` for the canonical idiom. UI + ViewInspector stay on **XCTest**. Tag Swift Testing tests with `.fast` / `.slow` / `.requiresHardware` from `Tests/SpeechToTextTests/Utilities/TestTags.swift`; CI filters via `--skip-tag requiresHardware` where applicable. Acceptance criteria in every GH issue call out the test expectations.
 3. **Talk to the tickets.** Three comment checkpoints per issue: (a) starting — plan + branch name, (b) PR opened — link + "awaiting CI", (c) **merged** — PR link + merge commit SHA + one-line summary. Link PRs with `Closes #N` so GitHub auto-closes. Also post an "unblocked by" comment on any downstream issue when its blocker merges. **Tick EPIC task-list checkboxes manually** when the child merges — GitHub only auto-ticks entries formatted as a bare `- [ ] #N`, which our EPICs usually aren't. **Always verify the post-merge main-branch workflow run** (`gh run list --branch main --limit 3`) before declaring a merge-batch done — the PR's CI and main's CI are separate runs. Keep discussion in GitHub, not in chat.
 4. **Point to docs, don't duplicate.** In PRs, issue comments, and subagent prompts, reference `AGENTS.md` (and, once #25 lands, `.claude/references/*.md` — a topic-router split) instead of restating context inline.
@@ -67,9 +79,7 @@ gh issue view <N> --comments   # for any specific issue you pick up
 
 ## Primary Reference
 
-Please see the root `./AGENTS.md` in this same directory for the main project documentation and guidance.
-
-@/workspace/AGENTS.md
+The root `AGENTS.md` (at the project root, one level up from this file) is the primary project documentation. The session-start checklist at the top of this file requires you to read it before doing any work — don't rely solely on the `@` import, as imports can silently fail when paths don't resolve (which is exactly what bit us when this file previously imported `@/workspace/AGENTS.md` from the host).
 
 ## Additional Component-Specific Guidance
 
@@ -77,10 +87,22 @@ For detailed module-specific implementation guides, also check for AGENTS.md fil
 
 These component-specific AGENTS.md files contain targeted guidance for working with those particular areas of the codebase.
 
-## Important: Use Subagents Liberally
+## Important: Use Subagents Liberally (and always Opus)
 
 When performing any research, concurrent subagents can be used for performance and isolation.
 Use parallel tool calls and tasks where possible.
+
+**Mandatory:** every `Agent` tool call must pass `model: "opus"`. Several subagent definitions default to Sonnet and will silently downgrade if you omit the override. This applies to `Explore`, `general-purpose`, and every `pr-review-toolkit:*` reviewer.
+
+## Code review pipeline (three layers)
+
+For every non-trivial PR, exercise all three:
+
+1. **Pre-PR (local):** spawn a `pr-review-toolkit:code-reviewer` subagent with `model: "opus"` over the diff before pushing. For PHI / concurrency / HTTP / Keychain work, also spawn `pr-review-toolkit:silent-failure-hunter` in parallel (and `pr-review-toolkit:type-design-analyzer` if new types are introduced). Apply blockers before pushing.
+2. **Automated (on PR open):** **Gemini Code Assist** runs automatically via the GitHub App, driven by `.gemini/config.yaml` + `.gemini/styleguide.md` at the repo root. Address its inline comments as peer review. Re-trigger with a `/gemini review` comment if the PR materially changed. Gemini Code Assist docs: https://developers.google.com/gemini-code-assist/docs/review-github-code
+3. **On-demand deep dive:** invoke the `/code-review` slash command (the `code-review:code-review` skill) for large, multi-subsystem, or comment-heavy PRs. It operates on the PR surface (including review comments) rather than the local diff.
+
+"Non-trivial" = any diff touching PHI, concurrency, HTTP, Keychain, `@Observable`, actors, or >~30 lines across Sources/. Pure test additions and doc-only changes can skip layer 1.
 
 ## Quick Reference: Project Structure
 

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,58 @@
+# Gemini Code Assist — repo-level configuration
+#
+# Docs: https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
+# Style guide companion: see ./styleguide.md
+#
+# This config targets a single-repo macOS-Swift project that carries PHI
+# obligations. We keep the signal-to-noise ratio high (MEDIUM threshold,
+# capped comment count) and exclude machine-generated / vendored / binary
+# paths from analysis.
+
+have_fun: false
+
+# Paths excluded from analysis. Use glob syntax.
+ignore_patterns:
+  # Build outputs + IDE caches
+  - ".build/**"
+  - "build/**"
+  - "DerivedData/**"
+  - "xcode-project/**"
+  - "*.xcodeproj/**"
+  # Vendored dependencies
+  - "Vendor/**"
+  # Large on-disk ML / audio artifacts — not source code
+  - "Sources/Resources/Models/**"
+  - "**/*.onnx"
+  - "**/*.mlpackage/**"
+  - "**/*.wav"
+  # Test fixtures are curated by humans and must not contain PHI; the
+  # review signal here is low and false-positive noise is high.
+  - "Tests/SpeechToTextTests/Fixtures/**"
+  # Generated docs + checked-in lockfiles
+  - "Package.resolved"
+  # Claude tooling + skills (these are agent config, not product code)
+  - ".claude/**"
+
+memory_config:
+  # Enable cross-repo memory if the org turns it on — at single-repo scale
+  # this is a no-op.
+  disabled: false
+
+code_review:
+  disable: false
+  # Only surface MEDIUM+ findings by default — drops stylistic nits that
+  # SwiftLint --strict already enforces pre-push.
+  comment_severity_threshold: MEDIUM
+  # Keep reviews focused. If a PR genuinely needs more than 25 comments
+  # it probably needs a human reviewer first.
+  max_review_comments: 25
+  pull_request_opened:
+    # "Help" intro is noisy for a small team.
+    help: false
+    # Summary is genuinely useful — keep.
+    summary: true
+    # Full review on every PR open.
+    code_review: true
+    # Don't review drafts — they're still in flight and the author
+    # doesn't want early-stage feedback.
+    include_drafts: false

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,157 @@
+# Gemini Code Assist — styleguide
+
+> Read `AGENTS.md` at the project root (and `.claude/references/*.md`)
+> before reviewing a PR in this repo. Those documents are the authoritative
+> rules; this file is a reviewer-oriented summary that calibrates
+> Gemini's output to match the project's conventions.
+
+## Project at a glance
+
+A privacy-focused local-first macOS speech-to-text menu-bar app, being
+extended into a clinical documentation assistant for chiropractors.
+Swift 5.9 language mode / Swift 6.2 compiler. macOS 14+ baseline, macOS
+26 for development. Swift Package Manager. SwiftLint `--strict` + two
+custom concurrency rules. FluidAudio (Parakeet v3) for ASR; MLX Swift +
+Gemma 3 4B-IT (bundled) for the clinical-notes LLM; URLSession actor for
+Cliniko API. **No cloud services** — only egress is the doctor-initiated
+`POST /treatment_notes` to their own Cliniko tenant over TLS.
+
+---
+
+## What to prioritise in every review
+
+### Security & PHI (highest priority — block on violations)
+
+- **PHI must never appear in logs, crash-report messages, UserDefaults,
+  on-disk caches, or external tooling.** PHI in this project means:
+  consultation transcripts, generated SOAP notes, suggested
+  manipulations, excluded-content snippets, patient demographics, and
+  `treatment_note` bodies.
+- `OSLog` / `Logger` calls: any non-structural interpolation of PHI is a
+  blocker. `privacy: .public` is reserved for structural values only
+  (HTTP status, error-case name, path template, method). Everything
+  else must be `privacy: .private`.
+- `fatalError` / `preconditionFailure` / `assertionFailure` messages:
+  **never** interpolate PHI. These show up in crash reports.
+- Secrets, API keys, `.env` files, entitlements with hardcoded team
+  IDs, GitHub PATs — never. Cliniko API keys live in Keychain via the
+  `SecureStore` protocol with
+  `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`.
+- `AuditStore` entries must carry metadata only: timestamp, patient_id
+  (opaque string), appointment_id, note_id (from Cliniko response),
+  HTTP status, app version. **Never** request/response body,
+  transcript, or patient name.
+- Test fixtures must use obviously-synthetic data (`@example.test`
+  domains, placeholder IDs). Flag any fixture that looks like copied
+  production data.
+
+### Concurrency correctness (block on violations)
+
+- Any `any SomeActorProtocol` / any actor-existential field on an
+  `@Observable` class **must** be marked `@ObservationIgnored`.
+  Omitting this causes an ARM64 pointer-authentication crash on first
+  Observation scan. SwiftLint rule
+  `observable_actor_existential_warning` catches most cases — flag any
+  usage the rule may have missed.
+- Core Audio / Carbon / `DispatchSource` callbacks must run through a
+  `nonisolated` entry and hop to `@MainActor` via
+  `Task { @MainActor … }` for state mutation. Never call a `@MainActor`
+  method directly from an audio-thread callback.
+- `nonisolated(unsafe)` is tolerated only for: (a) `deinit` cleanup,
+  (b) audio/system callbacks with a self-synchronised data type,
+  (c) internally thread-safe value types. Flag every other usage for
+  justification — the custom SwiftLint rule
+  `nonisolated_unsafe_warning` surfaces them.
+- Actors cannot be subclassed, so mocks must go through an
+  `Actor`-constrained protocol. Flag any mock-by-subclass on an actor.
+- Every new `@Observable` view model requires a ViewInspector render /
+  crash-detection test. Flag PRs that add a view model without one.
+
+### Code quality
+
+- **No** force-unwraps (`!`) without a justifying comment and a `guard`
+  above them. Flag every `!`.
+- **No** `try!` outside test code. `try?` is only legitimate where
+  `nil` is a genuine "absent" signal, not to swallow errors.
+- **No** `@ObservedObject` / `@StateObject` / `ObservableObject` — this
+  project is on the `@Observable` macro. Flag any legacy
+  ObservableObject usage.
+- Prefer `let` unless mutation is required.
+- No emoji in source or test fixtures unless the user has asked for
+  them.
+- No "nice-to-have" comments that just restate the code. Comments
+  should explain *why*, not *what*. Flag large docstring blocks that
+  paraphrase the implementation.
+
+### Testing
+
+- New pure-logic and async tests go in **Swift Testing**
+  (`@Test` / `@Suite` / `#expect`), tagged with `.fast` / `.slow` /
+  `.requiresHardware` from
+  `Tests/SpeechToTextTests/Utilities/TestTags.swift`. The canonical
+  idiom lives in `SwiftTestingExemplarTests.swift`.
+- UI / ViewInspector / XCUITest stay on **XCTest**.
+- Snapshot tests (`pointfreeco/swift-snapshot-testing`) are scoped to
+  `ReviewScreen` + `SafetyDisclaimerView` only. Don't encourage broader
+  snapshot coverage.
+- **Never** encourage a test that hits real Keychain / real Cliniko /
+  real LLM inference in the default CI path. Use `InMemorySecureStore`
+  / `URLProtocolStub` + fixtures / `MockLLMProvider`. Golden-file LLM
+  tests are gated behind `RUN_MLX_GOLDEN=1` (nightly only).
+- Every service that touches PHI needs an invariant test asserting it
+  doesn't leak (e.g. snapshot `UserDefaults.standard.dictionaryRepresentation()`
+  before/after a lifecycle).
+
+### Workflow hygiene
+
+- `pre-commit run --all-files` is assumed to be green before push.
+  SwiftLint strict + gitleaks are mandatory hooks. Flag any PR that
+  looks like it was pushed without them.
+- Every GH issue closes via `Closes #N` in the PR body.
+- PRs should carry three issue-level checkpoint comments (start / PR
+  opened / merged) — absence is a process smell but not a code smell;
+  flag only in the PR summary, not as inline comments.
+
+### Locked technical decisions — do not re-litigate
+
+The following are intentional and live in the EPIC + `.claude/CLAUDE.md`:
+
+| Area | Decision |
+|---|---|
+| LLM runtime | MLX Swift in-process (no XPC / daemon) |
+| LLM model v1 | Gemma 3 4B-IT (MLX 4-bit); Gemma 4 E4B migration gated on `ml-explore/mlx-swift#389` |
+| Model delivery | Bundled in the `.app` (DMG distribution, not App Store) |
+| Persistence | Session-only, cleared on export/quit — no on-disk PHI |
+| Cliniko | API integration in v1, direct from doctor's Mac to doctor's tenant |
+| UI entry | Settings toggle + "Generate Notes" action after recording |
+| Review layout | Two-column (SOAP editor / Manipulations + Excluded drawer) — wireframe in issue #13 |
+| Safety | One-time "not a diagnostic tool" disclaimer, UserDefaults ack (#12) |
+| Test frameworks | Swift Testing (new) + XCTest (UI / ViewInspector) |
+| HTTP mocking | Hand-rolled `URLProtocolStub` (zero deps) |
+| Keychain mocking | `SecureStore` protocol + `InMemorySecureStore` actor fake |
+
+**Do not suggest:** switching to a different LLM runtime, adding cloud
+telemetry, shipping via the Mac App Store, persisting PHI, introducing a
+third-party HTTP mocking library, or replacing SwiftLint with a
+different linter. These have been evaluated and rejected.
+
+---
+
+## PR summary style
+
+When summarising a PR, lead with the behavioural change in one sentence,
+then call out PHI / concurrency risks (if any) and the test coverage
+delta (what was added, what's intentionally deferred). Keep it to ~150
+words. Reviewers here are time-pressed.
+
+## When to stay quiet
+
+- Style nits already enforced by SwiftLint `--strict` or by pre-commit
+  hooks (trailing whitespace, import ordering, closure spacing).
+  Comment only if the hook is somehow bypassed.
+- Test-coverage "should also test X" comments when the PR explicitly
+  defers X to a tracked issue. Cross-check the PR body and linked
+  issues before suggesting new tests.
+- Refactors / abstractions that aren't justified by the PR's scope.
+  The project prefers "three similar lines over a premature
+  abstraction."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,34 @@ belong in PR review, not in the hard-rules file.
   testing stack) without an explicit user ask — they live in the
   EPIC body and `.claude/CLAUDE.md`.
 
+### Subagents & code review
+
+- **Always** pass `model: "opus"` explicitly when calling the `Agent`
+  tool. The parent session is Opus; several subagent definitions default
+  to Sonnet and will silently downgrade if you omit the override. This
+  applies to every `Agent` invocation — `Explore`, `general-purpose`,
+  and every `pr-review-toolkit:*` reviewer.
+- **Always** run the three-layer review pipeline on a non-trivial PR:
+  1. **Pre-PR (local):** spawn a `pr-review-toolkit:code-reviewer`
+     subagent with `model: "opus"` over the diff before you push, and
+     apply/fold in its blockers. For PHI-sensitive or concurrency-heavy
+     changes also spawn `pr-review-toolkit:silent-failure-hunter` and
+     (for new types) `pr-review-toolkit:type-design-analyzer` in
+     parallel.
+  2. **Automated (on PR open):** Gemini Code Assist runs automatically
+     via the GitHub App (see `.gemini/config.yaml` +
+     `.gemini/styleguide.md`). Its summary + inline comments are
+     treated as peer review; address them before merging. Re-trigger
+     with a `/gemini review` comment if the PR materially changed.
+  3. **On-demand deep dive:** invoke the `/code-review` skill
+     (`code-review:code-review`) when the PR is large, touches
+     multiple subsystems, or has review comments that need triage.
+     Prefer it over re-running the subagent because it operates on the
+     PR surface (including comments) rather than the local diff.
+- **Never** skip the pre-PR subagent pass on substantive changes. A
+  `wc -l` >~30 on the diff, or anything touching PHI / concurrency /
+  HTTP / Keychain, is substantive.
+
 ---
 
 ## Tech stack quick reference


### PR DESCRIPTION
## Summary

Three workflow-hardening changes bundled. Docs + config only; no source code.

1. **Gemini Code Assist on PRs** — adds `.gemini/config.yaml` + `.gemini/styleguide.md` so the Gemini GitHub App can auto-review every PR alongside our existing local `pr-review-toolkit:code-reviewer` subagent pass.
2. **Session-start AGENTS.md load, fixed for real this time** — `.claude/CLAUDE.md` previously imported `@/workspace/AGENTS.md`, a devcontainer-absolute path that silently failed on the host. Replaces with an explicit top-of-file "Read this first" mandate + a portable `@../AGENTS.md` relative import.
3. **Opus-subagent mandate** — tightens operating rule #1 to require `model: "opus"` explicitly on every `Agent` tool call, and documents a three-layer review pipeline (pre-PR subagent → Gemini on PR open → on-demand `/code-review` slash command).

## What changed

### `.gemini/config.yaml` (new)

- `comment_severity_threshold: MEDIUM` — drops stylistic nits SwiftLint already blocks.
- `max_review_comments: 25` — forces focus; a PR that needs more needs a human reviewer first.
- `include_drafts: false` — no feedback on in-flight drafts.
- `ignore_patterns`: `.build/`, build outputs, Xcode artefacts, vendored deps, ONNX / `.mlpackage` / `.wav`, `Sources/Resources/Models/`, `Tests/SpeechToTextTests/Fixtures/`, `.claude/`, `Package.resolved`. Keeps the review focused on actual product code.

### `.gemini/styleguide.md` (new)

Reviewer-oriented summary of the project's rules, calibrated for Gemini Code Assist per Google's docs (natural-language Markdown, used to supplement the standard review prompt):

- **Security / PHI** — the always/never rules from `phi-handling.md`, written as blockers.
- **Concurrency correctness** — the `@Observable` + actor-existential rule, the audio-callback pattern, `nonisolated(unsafe)` guardrails.
- **Code quality** — no force-unwraps, no `try!`, no `@ObservedObject`/`ObservableObject`, `@Observable` only.
- **Testing** — Swift Testing vs XCTest split, tagging, mocking fakes, snapshot scope.
- **Locked technical decisions** — MLX Swift, Gemma 3 4B-IT, bundled .app, session-only PHI, hand-rolled `URLProtocolStub`, `SecureStore` protocol. Explicit "do not suggest" list to stop the reviewer from proposing previously-rejected ideas.
- **When to stay quiet** — style nits SwiftLint already blocks, test-coverage asks when deferred to tracked issues, premature abstractions.

### `.claude/CLAUDE.md`

- Prominent "🚨 Read this first — every session" block at the top mandating explicit `Read AGENTS.md` before the first response. Explains *why* (the old `@/workspace/` import silently failed on the host).
- Replaces `@/workspace/AGENTS.md` with `@../AGENTS.md` — resolves correctly from both the host and the devcontainer.
- Rewrites the "Primary Reference" section to acknowledge imports can fail silently and the Read-tool call is the contract.
- Rewrites "Use Subagents Liberally" → "Use Subagents Liberally (and always Opus)" with the `model: "opus"` mandate.
- New "Code review pipeline (three layers)" section: pre-PR subagent → Gemini on PR open → `/code-review` on-demand. Defines "non-trivial" so I know when to exercise layer 1.

### `AGENTS.md`

- Tightens operating rule #1 to require `model: "opus"` on every `Agent` call.
- Adds a "Subagents & code review" block to the Correctness Checklist with the three-layer pipeline as always/never rules.

## What the user still needs to do

The GitHub App itself can't be installed via CLI — **please install it manually** at https://github.com/apps/gemini-code-assist, grant access to `CloudbrokerAz/mac-speech-to-text`, and accept the ToS. On the next PR after install, Gemini should auto-summarise + review. Per Google's docs, `.gemini/config.yaml` + `.gemini/styleguide.md` take effect as soon as they land on `main`.

## Review surface

Once this merges, the next feature PR I open (#6 candidate) becomes a live test of the full pipeline:
- Pre-PR: `pr-review-toolkit:code-reviewer` with `model: "opus"`
- PR open: Gemini Code Assist auto-review (assuming you've installed the App)
- If large: `/code-review` for the deep dive

## Test plan

- [x] `pre-commit run --files ...` — all hooks pass
- [x] YAML + markdown syntax clean
- [ ] GitHub Actions CI (expected to be no-op since no source changed, but confirms pre-commit scope hits nothing)
- [ ] User installs Gemini Code Assist GitHub App
- [ ] Next feature PR exercises all three review layers and we sanity-check the Gemini output

🤖 Generated with [Claude Code](https://claude.com/claude-code)