### PR TITLE
fix(test): widen PendingWritesCounter wait budget 200ms → 500ms

### DIFF
--- a/Tests/SpeechToTextTests/Services/AudioCaptureServiceTests.swift
+++ b/Tests/SpeechToTextTests/Services/AudioCaptureServiceTests.swift
@@ -406,9 +406,12 @@ final class PendingWritesCounterTests: XCTestCase {
         let elapsed = CFAbsoluteTimeGetCurrent() - startTime
 
         // Then
-        // Should wait at least 50ms but less than 200ms
+        // Should wait at least 50ms (proves the method actually blocks
+        // on the outstanding write) but comfortably under 500ms (catches
+        // a pathological "wait forever" regression). The upper bound was
+        // 200ms, which flaked on busy CI runners — see issue #38.
         XCTAssertGreaterThan(elapsed, 0.04)
-        XCTAssertLessThan(elapsed, 0.2)
+        XCTAssertLessThan(elapsed, 0.5)
         XCTAssertTrue(counter.isEmpty)
     }
 


### PR DESCRIPTION
## Summary

Closes #38.

Widens the upper bound on `AudioCaptureServiceTests.swift:411` from 0.2s → 0.5s. Lower bound stays at 0.04s so the test still verifies `waitForCompletion()` actually blocks on the outstanding write.

## Why

`PendingWritesCounterTests.test_waitForCompletion_waitsForPendingWrites` flaked on PR #37's post-merge main CI run — elapsed time was 0.204s, 4ms over budget. Classic CI scheduler-jitter flake. 500ms keeps the "catches pathological wait-forever" property while tolerating busy runners.

## Scope

Test-only. No production-code change. No subagent review pipeline needed (AGENTS.md operating rule: full pipeline triggers on substantive changes — PHI, concurrency, HTTP, Keychain, or >~30 LOC; this is a 2-line guard rail).

## Test plan

- [x] Run locally: 8/8 PendingWritesCounterTests pass (flaky one at 59ms)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)