### PR TITLE
chore(concurrency): PermissionService deinit nonisolated copy + deviceIdSize let

### DIFF
--- a/Sources/Services/AudioCaptureService.swift
+++ b/Sources/Services/AudioCaptureService.swift
@@ -236,7 +236,7 @@ class AudioCaptureService {
         // Get the Core Audio device ID from the AVCaptureDevice
         // AVCaptureDevice's uniqueID for audio devices corresponds to the Core Audio device UID
         var deviceId: AudioDeviceID = 0
-        var deviceIdSize = UInt32(MemoryLayout<AudioDeviceID>.size)
+        let deviceIdSize = UInt32(MemoryLayout<AudioDeviceID>.size)
         var address = AudioObjectPropertyAddress(
             mSelector: kAudioHardwarePropertyDeviceForUID,
             mScope: kAudioObjectPropertyScopeGlobal,

--- a/Sources/Services/PermissionService.swift
+++ b/Sources/Services/PermissionService.swift
@@ -142,8 +142,15 @@ class PermissionService: PermissionChecker {
     /// Flag to signal polling should stop
     private var shouldStopPolling: Bool = false
 
-    /// App activation observer for immediate permission detection
+    /// App activation observer for immediate permission detection.
+    /// The nonisolated copy is the one `deinit` reads — `deinit` runs
+    /// nonisolated and Swift 6 strict-concurrency warns when it accesses
+    /// a main-actor-isolated `NSObjectProtocol` property (which is not
+    /// `Sendable`). Keep `activationObserver` as the main-actor source
+    /// of truth and mirror every write into `deinitActivationObserver`
+    /// for cleanup. Pattern matches `VoiceTriggerMonitoringService.swift`.
     private var activationObserver: NSObjectProtocol?
+    private nonisolated(unsafe) var deinitActivationObserver: NSObjectProtocol?
 
     /// Callback for when permission is granted during polling with activation observer
     private var onPermissionGrantedCallback: (@MainActor @Sendable () -> Void)?
@@ -164,10 +171,13 @@ class PermissionService: PermissionChecker {
     }
 
     deinit {
-        // Clean up NotificationCenter observer to prevent memory leak
-        // Note: NotificationCenter.removeObserver is thread-safe, so we can call it from deinit
-        // even though the class is @MainActor isolated
-        if let observer = activationObserver {
+        // Clean up NotificationCenter observer to prevent memory leak.
+        // `NotificationCenter.removeObserver` is thread-safe, so calling
+        // it from a nonisolated `deinit` is fine — but reading the
+        // `@MainActor`-isolated `activationObserver` property from here
+        // isn't (NSObjectProtocol is not Sendable). Read from the
+        // nonisolated mirror instead.
+        if let observer = deinitActivationObserver {
             NotificationCenter.default.removeObserver(observer)
         }
     }
@@ -183,6 +193,7 @@ class PermissionService: PermissionChecker {
         if let observer = activationObserver {
             NotificationCenter.default.removeObserver(observer)
             activationObserver = nil
+            deinitActivationObserver = nil
         }
         onPermissionGrantedCallback = nil
     }
@@ -551,10 +562,11 @@ class PermissionService: PermissionChecker {
         if let existing = activationObserver {
             NotificationCenter.default.removeObserver(existing)
             activationObserver = nil
+            deinitActivationObserver = nil
         }
 
         // Create new observer
-        activationObserver = NotificationCenter.default.addObserver(
+        let observer = NotificationCenter.default.addObserver(
             forName: NSApplication.didBecomeActiveNotification,
             object: nil,
             queue: .main
@@ -583,6 +595,8 @@ class PermissionService: PermissionChecker {
                 }
             }
         }
+        activationObserver = observer
+        deinitActivationObserver = observer
     }
 
     // MARK: - Enhanced Permission Request with Validation


### PR DESCRIPTION
## Summary

Part of #40 (Swift 6 warning cleanup). First of four staged PRs — low-risk pattern match only.

### Two fixes

1. **`Sources/Services/PermissionService.swift`** — add a `nonisolated(unsafe) var deinitActivationObserver` mirror so `deinit` can clean up the notification observer without reading a `@MainActor`-isolated non-`Sendable` property. Pattern matches `VoiceTriggerMonitoringService.swift`'s existing `deinitSilenceTimer` / `deinitMaxDurationTimer`. All four write sites pair both fields.
2. **`Sources/Services/AudioCaptureService.swift:239`** — `var deviceIdSize` → `let`. Never mutated, only read at line 286.

### Why

- Clears the `deinit` NSObjectProtocol-Sendability warning — a Swift 6 strict-concurrency error once the project flips language mode.
- The `nonisolated(unsafe)` annotation is justified per `.claude/references/concurrency.md` §2 (deinit cleanup is the canonical legitimate use) and the inline doc-comment is the audit trail SwiftLint's custom `nonisolated_unsafe_warning` rule exists to encourage.

### Review

- **Pre-PR Opus review** (`pr-review-toolkit:code-reviewer`) — **LGTM / ship it.** Walked the 4 write-site ordering and confirmed no torn-read window; verified the sibling pattern; confirmed `@ObservationIgnored` is *not* needed here because `PermissionService` is a plain `@MainActor class` (not `@Observable`).

### Remaining #40 work

| PR | Scope | Next |
|---|---|---|
| 40b | CFString / AudioDeviceID inout-pointer in AudioCaptureService (real Core Audio lifetime concern) | After this merges |
| 40c | MainActor isolation — AppDelegate.swift:293/294 + ParticleVortexWaveform.swift:149 | Then |
| 40d | FluidAudioService.asrManager sending (architectural) | Last; design discussion first |

## Test plan

- [x] `swift build -c release` — PermissionService + deviceIdSize warnings cleared
- [x] SwiftLint strict — 0 violations
- [x] Pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)