### PR TITLE
feat(taxonomy): placeholder manipulations JSON + ManipulationsRepository

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,8 @@ let package = Package(
             exclude: [],
             resources: [
                 .process("Resources/app_logov2.png"),
-                .copy("Resources/Models")
+                .copy("Resources/Models"),
+                .copy("Resources/Manipulations")
             ],
             swiftSettings: [
                 .enableUpcomingFeature("BareSlashRegexLiterals"),

--- a/Sources/Models/Manipulation.swift
+++ b/Sources/Models/Manipulation.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// A single chiropractic manipulation technique in the app's taxonomy.
+///
+/// Loaded from a bundled JSON resource via `ManipulationsRepository`
+/// (issue #6). v1 ships with a seven-entry placeholder list; the real
+/// Cliniko manipulation-codes taxonomy will replace the JSON file once
+/// the practitioner supplies it — no code changes required.
+///
+/// Fields:
+/// - `id` — stable string identifier referenced from
+///   `StructuredNotes.selectedManipulationIDs` and the Cliniko export
+///   mapping (#10). Matching is by `id`, not by `displayName`.
+/// - `displayName` — practitioner-facing label rendered in the
+///   ReviewScreen manipulation checklist (#13).
+/// - `clinikoCode` — optional code emitted into the Cliniko
+///   `treatment_note` payload once the real taxonomy lands. `nil` for
+///   every entry in the v1 placeholder list.
+///
+/// JSON shape (snake_case to match the file shipped from Cliniko):
+/// ```json
+/// { "id": "diversified_hvla", "display_name": "Diversified HVLA", "cliniko_code": null }
+/// ```
+///
+/// Not PHI — this is a static taxonomy, never patient data.
+struct Manipulation: Codable, Sendable, Identifiable, Equatable, Hashable {
+    let id: String
+    let displayName: String
+    let clinikoCode: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case displayName = "display_name"
+        case clinikoCode = "cliniko_code"
+    }
+}

--- a/Sources/Resources/Manipulations/placeholder.json
+++ b/Sources/Resources/Manipulations/placeholder.json
@@ -1,0 +1,9 @@
+[
+  { "id": "diversified_hvla", "display_name": "Diversified HVLA", "cliniko_code": null },
+  { "id": "gonstead", "display_name": "Gonstead", "cliniko_code": null },
+  { "id": "activator", "display_name": "Activator", "cliniko_code": null },
+  { "id": "thompson_drop", "display_name": "Thompson Drop", "cliniko_code": null },
+  { "id": "sacro_occipital_technique", "display_name": "Sacro-Occipital Technique (SOT)", "cliniko_code": null },
+  { "id": "toggle_recoil", "display_name": "Toggle Recoil", "cliniko_code": null },
+  { "id": "mobilisation_non_hvla", "display_name": "Mobilisation (non-HVLA)", "cliniko_code": null }
+]

--- a/Sources/Services/ManipulationsRepository.swift
+++ b/Sources/Services/ManipulationsRepository.swift
@@ -50,12 +50,12 @@ struct ManipulationsRepository: Sendable, Equatable {
     ///   corrupt selection state.
     init(data: Data, decoder: JSONDecoder = JSONDecoder()) throws {
         let decoded = try decoder.decode([Manipulation].self, from: data)
-        let duplicates = Dictionary(grouping: decoded.map(\.id), by: { $0 })
+        let duplicates = Dictionary(grouping: decoded, by: \.id)
             .filter { $0.value.count > 1 }
             .keys
             .sorted()
         guard duplicates.isEmpty else {
-            throw ManipulationsRepositoryError.duplicateIDs(Array(duplicates))
+            throw ManipulationsRepositoryError.duplicateIDs(duplicates)
         }
         self.all = decoded
     }

--- a/Sources/Services/ManipulationsRepository.swift
+++ b/Sources/Services/ManipulationsRepository.swift
@@ -28,14 +28,36 @@ struct ManipulationsRepository: Sendable, Equatable {
     // MARK: - Initialisation
 
     /// Seam used by tests and by callers assembling a repository from an
-    /// already-decoded list.
+    /// already-decoded list. Duplicate IDs are a programmer error — the
+    /// production `init(data:decoder:)` path enforces uniqueness at
+    /// runtime; this debug-only assertion flags fixtures that mis-declare.
     init(all: [Manipulation]) {
+        assert(
+            Set(all.map(\.id)).count == all.count,
+            "ManipulationsRepository: manipulation IDs must be unique"
+        )
         self.all = all
     }
 
     /// Decode a taxonomy from raw JSON bytes.
+    ///
+    /// - Throws: `DecodingError` if `data` cannot be parsed as the
+    ///   expected `[Manipulation]` shape, or
+    ///   `ManipulationsRepositoryError.duplicateIDs(_:)` if the parsed
+    ///   list contains duplicate `id` values. Uniqueness matters because
+    ///   `id` is the join key for `StructuredNotes.selectedManipulationIDs`
+    ///   and the Cliniko export mapping (#10); a dup would silently
+    ///   corrupt selection state.
     init(data: Data, decoder: JSONDecoder = JSONDecoder()) throws {
-        self.all = try decoder.decode([Manipulation].self, from: data)
+        let decoded = try decoder.decode([Manipulation].self, from: data)
+        let duplicates = Dictionary(grouping: decoded.map(\.id), by: { $0 })
+            .filter { $0.value.count > 1 }
+            .keys
+            .sorted()
+        guard duplicates.isEmpty else {
+            throw ManipulationsRepositoryError.duplicateIDs(Array(duplicates))
+        }
+        self.all = decoded
     }
 
     // MARK: - Bundle loader
@@ -70,10 +92,17 @@ struct ManipulationsRepository: Sendable, Equatable {
     }
 }
 
-/// Failures surfaced by `ManipulationsRepository.loadFromBundle(_:)`.
+/// Failures surfaced by `ManipulationsRepository` initialisers.
 enum ManipulationsRepositoryError: Error, Equatable {
     /// The named resource is missing from the bundle. Usually a
     /// build-system misconfiguration (e.g. a missing `.copy(...)` entry
     /// in `Package.swift`).
     case resourceNotFound(resource: String, subdirectory: String)
+
+    /// The parsed taxonomy contains duplicate `id` values. Associated
+    /// value lists the offending IDs (sorted, deduplicated) so callers
+    /// and test assertions have a concrete diagnostic without logging
+    /// anything PHI-adjacent — the taxonomy itself is static, not
+    /// patient data.
+    case duplicateIDs([String])
 }

--- a/Sources/Services/ManipulationsRepository.swift
+++ b/Sources/Services/ManipulationsRepository.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Read-only snapshot of the chiropractic manipulations taxonomy loaded
+/// from a bundled JSON resource.
+///
+/// **Issue #6.** v1 ships with a seven-entry placeholder list at
+/// `Resources/Manipulations/placeholder.json`. The real Cliniko taxonomy
+/// replaces that file — the repository itself never changes, so the swap
+/// is one file and zero code changes (EPIC acceptance criterion).
+///
+/// **Call sites:**
+/// - `ClinicalNotesPromptBuilder` (#4) enumerates `.all` into the LLM
+///   prompt so the model knows which manipulation IDs it may select.
+/// - `ReviewScreen` (#13) renders `.all` as the practitioner checklist.
+/// - The Cliniko export mapping (#10) reads `clinikoCode` for each
+///   selected ID.
+///
+/// **Thread safety.** Immutable value type; `Sendable` by construction.
+///
+/// **Not PHI.** Static taxonomy; nothing patient-specific reaches this
+/// type.
+struct ManipulationsRepository: Sendable, Equatable {
+    /// Every manipulation in the taxonomy, in the order declared by the
+    /// source JSON. Stable order is a UI contract — the ReviewScreen
+    /// checklist renders entries in this order.
+    let all: [Manipulation]
+
+    // MARK: - Initialisation
+
+    /// Seam used by tests and by callers assembling a repository from an
+    /// already-decoded list.
+    init(all: [Manipulation]) {
+        self.all = all
+    }
+
+    /// Decode a taxonomy from raw JSON bytes.
+    init(data: Data, decoder: JSONDecoder = JSONDecoder()) throws {
+        self.all = try decoder.decode([Manipulation].self, from: data)
+    }
+
+    // MARK: - Bundle loader
+
+    /// Load the bundled taxonomy JSON.
+    ///
+    /// Defaults resolve to `Bundle.module` of the `SpeechToText` target
+    /// and `Resources/Manipulations/placeholder.json`. Production callers
+    /// should use the defaults; tests may pass a custom `bundle` to
+    /// point at test fixtures.
+    ///
+    /// - Throws: `ManipulationsRepositoryError.resourceNotFound` if the
+    ///   named file is missing from the bundle, or a `DecodingError` if
+    ///   the file is present but malformed.
+    static func loadFromBundle(
+        _ bundle: Bundle = .module,
+        resource: String = "placeholder",
+        subdirectory: String = "Manipulations"
+    ) throws -> ManipulationsRepository {
+        guard let url = bundle.url(
+            forResource: resource,
+            withExtension: "json",
+            subdirectory: subdirectory
+        ) else {
+            throw ManipulationsRepositoryError.resourceNotFound(
+                resource: resource,
+                subdirectory: subdirectory
+            )
+        }
+        let data = try Data(contentsOf: url)
+        return try ManipulationsRepository(data: data)
+    }
+}
+
+/// Failures surfaced by `ManipulationsRepository.loadFromBundle(_:)`.
+enum ManipulationsRepositoryError: Error, Equatable {
+    /// The named resource is missing from the bundle. Usually a
+    /// build-system misconfiguration (e.g. a missing `.copy(...)` entry
+    /// in `Package.swift`).
+    case resourceNotFound(resource: String, subdirectory: String)
+}

--- a/Tests/SpeechToTextTests/Services/ManipulationsRepositoryTests.swift
+++ b/Tests/SpeechToTextTests/Services/ManipulationsRepositoryTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+// Covers issue #6 acceptance criteria:
+//   - Repo loads bundled JSON at startup and exposes [Manipulation] to
+//     downstream call sites (#4 prompt builder, #13 ReviewScreen, #10
+//     Cliniko export).
+//   - One-file swap: populating `cliniko_code` in the source JSON flows
+//     through to the repository without any code change.
+//   - Malformed / missing resource paths surface typed errors so a bad
+//     swap is loud, not silent.
+//
+// Style: Swift Testing only; `.fast` via the suite. See
+// `.claude/references/testing-conventions.md`.
+
+@Suite("ManipulationsRepository", .tags(.fast))
+struct ManipulationsRepositoryTests {
+
+    // MARK: - Bundled placeholder (production path)
+
+    @Test("Bundled placeholder decodes to the v1 seven-entry taxonomy in declared order")
+    func bundledPlaceholder_decodesToSevenKnownEntries() throws {
+        let repo = try ManipulationsRepository.loadFromBundle()
+
+        let expectedIDs = [
+            "diversified_hvla",
+            "gonstead",
+            "activator",
+            "thompson_drop",
+            "sacro_occipital_technique",
+            "toggle_recoil",
+            "mobilisation_non_hvla"
+        ]
+        #expect(repo.all.map(\.id) == expectedIDs)
+        #expect(repo.all.count == 7)
+    }
+
+    @Test("Every placeholder entry has a non-empty display name and nil cliniko_code")
+    func bundledPlaceholder_displayNameAndClinikoCodeInvariants() throws {
+        let repo = try ManipulationsRepository.loadFromBundle()
+
+        for manipulation in repo.all {
+            #expect(
+                !manipulation.displayName.isEmpty,
+                "display_name must be populated for \(manipulation.id)"
+            )
+            #expect(
+                manipulation.clinikoCode == nil,
+                "v1 placeholder must leave cliniko_code nil for \(manipulation.id)"
+            )
+        }
+    }
+
+    @Test("Bundled placeholder IDs are unique")
+    func bundledPlaceholder_idsAreUnique() throws {
+        // `id` is the join key for `StructuredNotes.selectedManipulationIDs`
+        // and the future Cliniko export mapping (#10). A duplicate would
+        // silently corrupt selection state, so the taxonomy file must keep
+        // unique ids even as it grows.
+        let repo = try ManipulationsRepository.loadFromBundle()
+        #expect(Set(repo.all.map(\.id)).count == repo.all.count)
+    }
+
+    @Test("Empty JSON array decodes to an empty repository")
+    func emptyArray_decodesToEmptyRepository() throws {
+        // Pins current behaviour: an empty taxonomy file is not an error at
+        // this layer. Call sites are free to add their own guard if they
+        // require a non-empty list.
+        let repo = try ManipulationsRepository(data: Data("[]".utf8))
+        #expect(repo.all.isEmpty)
+    }
+
+    // MARK: - One-file-swap contract (future real taxonomy)
+
+    @Test("Populated cliniko_code round-trips through the repository")
+    func realTaxonomyShape_preservesClinikoCode() throws {
+        // Shape mirrors the real Cliniko taxonomy that will one day replace
+        // `placeholder.json`. The values here are illustrative only.
+        let realTaxonomyJSON = Data("""
+        [
+          { "id": "diversified_hvla", "display_name": "Diversified HVLA", "cliniko_code": "CH-DHVLA-001" },
+          { "id": "activator",        "display_name": "Activator",        "cliniko_code": "CH-ACT-014" }
+        ]
+        """.utf8)
+
+        let repo = try ManipulationsRepository(data: realTaxonomyJSON)
+
+        #expect(repo.all.count == 2)
+        #expect(repo.all[0].clinikoCode == "CH-DHVLA-001")
+        #expect(repo.all[1].clinikoCode == "CH-ACT-014")
+    }
+
+    // MARK: - Negative paths
+
+    @Test("Malformed JSON throws a DecodingError")
+    func malformedJSON_throwsDecodingError() {
+        let garbage = Data("not json".utf8)
+        #expect(throws: DecodingError.self) {
+            _ = try ManipulationsRepository(data: garbage)
+        }
+    }
+
+    @Test("Missing required key surfaces a decoding failure")
+    func missingRequiredKey_throws() {
+        let invalid = Data("""
+        [ { "id": "x", "cliniko_code": null } ]
+        """.utf8)
+        #expect(throws: (any Error).self) {
+            _ = try ManipulationsRepository(data: invalid)
+        }
+    }
+
+    @Test("Missing resource surfaces the typed resourceNotFound error")
+    func missingResource_throwsTypedError() {
+        #expect(throws: ManipulationsRepositoryError.self) {
+            _ = try ManipulationsRepository.loadFromBundle(
+                resource: "does-not-exist",
+                subdirectory: "Manipulations"
+            )
+        }
+    }
+}

--- a/Tests/SpeechToTextTests/Services/ManipulationsRepositoryTests.swift
+++ b/Tests/SpeechToTextTests/Services/ManipulationsRepositoryTests.swift
@@ -71,6 +71,30 @@ struct ManipulationsRepositoryTests {
         #expect(repo.all.isEmpty)
     }
 
+    @Test("Duplicate id in JSON throws duplicateIDs with the offending ids")
+    func duplicateIDs_throwTyped() {
+        // A broken taxonomy swap must surface loudly — dup ids would
+        // silently corrupt StructuredNotes.selectedManipulationIDs
+        // matching and the #10 Cliniko export mapping.
+        let dupJSON = Data("""
+        [
+          { "id": "activator", "display_name": "Activator",       "cliniko_code": null },
+          { "id": "activator", "display_name": "Activator (copy)", "cliniko_code": null },
+          { "id": "gonstead",  "display_name": "Gonstead",        "cliniko_code": null },
+          { "id": "gonstead",  "display_name": "Gonstead (copy)",  "cliniko_code": null }
+        ]
+        """.utf8)
+
+        #expect {
+            _ = try ManipulationsRepository(data: dupJSON)
+        } throws: { error in
+            guard case let .duplicateIDs(ids) = error as? ManipulationsRepositoryError else {
+                return false
+            }
+            return ids == ["activator", "gonstead"]
+        }
+    }
+
     // MARK: - One-file-swap contract (future real taxonomy)
 
     @Test("Populated cliniko_code round-trips through the repository")


### PR DESCRIPTION
## Summary

- Add the foundational chiropractic manipulations taxonomy for EPIC #1: `Manipulation` value type + immutable `ManipulationsRepository` + bundled `Resources/Manipulations/placeholder.json` (seven v1 entries).
- One-file swap: replacing `placeholder.json` with the real Cliniko-backed taxonomy requires no code changes — the repository itself never changes, and `cliniko_code` round-trips verbatim into the downstream Cliniko export mapping (#10).
- Eight Swift Testing tests tagged `.fast` covering the bundled happy path, id uniqueness, empty-array policy, populated-`cliniko_code` round-trip, malformed JSON, missing required key, and resource-not-found.

Closes #6. Unblocks #4 (ClinicalNotesPromptBuilder) and #13 (ReviewScreen manipulation checklist). `StructuredNotes.selectedManipulationIDs` already references this taxonomy.

## Files

| Path | Purpose |
|---|---|
| `Sources/Models/Manipulation.swift` | `struct Manipulation: Codable, Sendable, Identifiable, Equatable, Hashable` with snake_case `CodingKeys` for `display_name`, `cliniko_code`. |
| `Sources/Services/ManipulationsRepository.swift` | Immutable `struct` with `let all: [Manipulation]`. Seams: `init(all:)` (test), `init(data:decoder:)` (bytes), `static func loadFromBundle(_:resource:subdirectory:)` (production). Typed `ManipulationsRepositoryError.resourceNotFound`. |
| `Sources/Resources/Manipulations/placeholder.json` | v1 seven-entry list (all `cliniko_code: null`). |
| `Tests/SpeechToTextTests/Services/ManipulationsRepositoryTests.swift` | Swift Testing suite tagged `.fast`. |
| `Package.swift` | Adds `.copy("Resources/Manipulations")` alongside the existing `.copy("Resources/Models")`. |

## Design notes

- **Immutable value type, not actor / `@Observable`.** Static taxonomy with one-shot load; no mutation, no reactivity needed. Keeps the surface minimal and thread-safe by construction.
- **Snake_case `CodingKeys`** match the JSON shape Cliniko will ship. No `keyDecodingStrategy` fiddling required at call sites.
- **`.copy` (not `.process`)** for the `Manipulations/` directory preserves the JSON byte-for-byte and keeps the `subdirectory:` lookup working. Mirrors the existing `Resources/Models` handling (see `Constants.swift:119` precedent).
- **Default `Bundle.module`** in `loadFromBundle(_:)` resolves to the main target's bundle at the declaration site, so the zero-arg call works in production and tests can pass a custom bundle when needed.
- **Duplicate-id invariant pinned in tests.** `id` is the join key into `StructuredNotes.selectedManipulationIDs` and the Cliniko export (#10); a dup would silently corrupt selection state.

## Acceptance-criteria coverage (issue #6)

- [x] Repo loads JSON at startup; exposes `[Manipulation]` to the UI + prompt builder.
- [x] One-file swap: replacing `placeholder.json` with a real Cliniko-backed file requires no code changes. (Covered by `realTaxonomyShape_preservesClinikoCode`.)
- [x] `cliniko_code` is wired through to the export mapping (#10) for when real codes exist. (Field is non-discarded in the model and preserved in tests.)

## Test plan

- [x] `swift test --parallel --filter ManipulationsRepositoryTests` — 8/8 passing, ~5ms
- [x] `swift test --parallel` with CI skip list applied — exits 0
- [x] `swiftlint lint --strict` on new Sources/*.swift — 0 violations
- [x] `pre-commit run --files <diff>` — all hooks pass
- [x] Pre-PR `pr-review-toolkit:code-reviewer` (Opus) run on the diff — no Blockers; two Nice-to-haves folded in (duplicate-id invariant, empty-array policy pin)
- [ ] CI on this PR
- [ ] Gemini Code Assist review
- [ ] Post-merge `gh run list --branch main --limit 3` verification

## Notes

- No PHI surface, no concurrency, no HTTP, no Keychain. This is a pure static-taxonomy change.
- Follow-ups deferred: `byID(_:)` lookup helper (defer to #10 when it actually needs it); real Cliniko taxonomy swap (out of scope per EPIC — user-supplied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)