### PR TITLE
feat(prompt): ClinicalNotesPromptBuilder + RawLLMDraft + soap_v1 template

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,8 @@ let package = Package(
             resources: [
                 .process("Resources/app_logov2.png"),
                 .copy("Resources/Models"),
-                .copy("Resources/Manipulations")
+                .copy("Resources/Manipulations"),
+                .copy("Resources/Prompts")
             ],
             swiftSettings: [
                 .enableUpcomingFeature("BareSlashRegexLiterals"),

--- a/Sources/Models/RawLLMDraft.swift
+++ b/Sources/Models/RawLLMDraft.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Byte-for-byte mirror of the JSON the local LLM returns for a clinical
+/// note, per the contract locked in EPIC #1.
+///
+/// **Not the UI model.** `ReviewScreen` (#13) binds to `StructuredNotes`,
+/// which uses `selectedManipulationIDs: [String]` — stable ids from
+/// `ManipulationsRepository`. The `RawLLMDraft → StructuredNotes`
+/// mapping resolves the LLM's free-text `manipulations[].name` back to
+/// an `id` via the taxonomy; that mapping lives in
+/// `ClinicalNotesProcessor` (#5), not here.
+///
+/// **All PHI.** SOAP strings, excluded snippets, and manipulation names
+/// can all contain transcript content. Never log, persist, or serialise
+/// instances of this type outside the live session. See
+/// `.claude/references/phi-handling.md`.
+struct RawLLMDraft: Codable, Sendable, Equatable {
+    let subjective: String
+    let objective: String
+    let assessment: String
+    let plan: String
+    let manipulations: [SuggestedManipulation]
+    let excludedContent: [String]
+
+    /// A single manipulation the LLM believes was performed, matched
+    /// back to the taxonomy by `name` in `ClinicalNotesProcessor` (#5).
+    struct SuggestedManipulation: Codable, Sendable, Equatable {
+        let name: String
+        /// Model-reported confidence. Contract: `[0.0, 1.0]`.
+        /// `ClinicalNotesPromptBuilder.validate(json:)` rejects values
+        /// outside that range.
+        let confidence: Double
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case subjective, objective, assessment, plan, manipulations
+        case excludedContent = "excluded_content"
+    }
+}

--- a/Sources/Resources/Prompts/soap_v1.txt
+++ b/Sources/Resources/Prompts/soap_v1.txt
@@ -1,0 +1,29 @@
+You are a clinical documentation drafting assistant for a chiropractor.
+You are a drafting assistant, not a diagnostic tool; defer all clinical judgement to the reviewing practitioner.
+
+Task: Convert the CONSULTATION TRANSCRIPT below into a structured SOAP note for a chiropractic appointment, and identify which manipulation techniques (if any) from the AVAILABLE MANIPULATIONS list were performed.
+
+Output rules:
+- Return ONLY a single valid JSON object matching the schema below. No prose outside the JSON object. No markdown code fences.
+- Strip small talk, social pleasantries, unrelated tangents, and any content that does not belong in a clinical note. Return those excluded snippets verbatim in "excluded_content" so the reviewing practitioner can re-add anything worth keeping.
+- "manipulations" must reference techniques from AVAILABLE MANIPULATIONS by their "name" exactly as listed. Include a confidence score in the closed interval [0.0, 1.0]. Do not invent techniques that are not on the list.
+- If the transcript does not describe any manipulation, return "manipulations": [].
+- Empty SOAP sections are acceptable when the transcript genuinely does not contain that information — return "" (not null) for the section.
+
+JSON schema:
+{
+  "subjective": "string",
+  "objective": "string",
+  "assessment": "string",
+  "plan": "string",
+  "manipulations": [{ "name": "string", "confidence": 0.0 }],
+  "excluded_content": ["string"]
+}
+
+AVAILABLE MANIPULATIONS:
+{{manipulations_list}}
+
+CONSULTATION TRANSCRIPT:
+{{transcript}}
+
+JSON output:

--- a/Sources/Services/ClinicalNotesPromptBuilder.swift
+++ b/Sources/Services/ClinicalNotesPromptBuilder.swift
@@ -1,0 +1,290 @@
+import Foundation
+
+/// Assembles the prompt sent to the local LLM, and validates the JSON
+/// returned against the contract locked in EPIC #1.
+///
+/// **Issue #4.** Pure-logic service: no PHI persistence, no HTTP, no
+/// actor isolation. Transcript content passes through `buildPrompt` and
+/// LLM response text passes through `validate` in-memory only.
+///
+/// **Template.** `Resources/Prompts/soap_v1.txt`, loadable so the prompt
+/// can be tuned without recompiling the app. Two placeholders:
+/// `{{manipulations_list}}` (rendered from `ManipulationsRepository`) and
+/// `{{transcript}}`.
+///
+/// **Validation.** `validate(json:)` is forgiving about cosmetic wrapping
+/// (whitespace, code fences, trailing commentary) and strict about the
+/// schema — a response that does not decode to `RawLLMDraft` or whose
+/// `manipulations[].confidence` falls outside `[0, 1]` is rejected with a
+/// typed `SchemaError`.
+struct ClinicalNotesPromptBuilder: Sendable {
+    let template: String
+    let manipulations: ManipulationsRepository
+
+    /// Load the bundled prompt template.
+    ///
+    /// - Throws: `ClinicalNotesPromptBuilderError.templateNotFound` if
+    ///   the named template is missing from the bundle.
+    static func loadFromBundle(
+        _ bundle: Bundle = .module,
+        templateResource: String = "soap_v1",
+        templateSubdirectory: String = "Prompts",
+        manipulations: ManipulationsRepository
+    ) throws -> ClinicalNotesPromptBuilder {
+        guard let url = bundle.url(
+            forResource: templateResource,
+            withExtension: "txt",
+            subdirectory: templateSubdirectory
+        ) else {
+            throw ClinicalNotesPromptBuilderError.templateNotFound(
+                resource: templateResource,
+                subdirectory: templateSubdirectory
+            )
+        }
+        let template = try String(contentsOf: url, encoding: .utf8)
+        return ClinicalNotesPromptBuilder(
+            template: template,
+            manipulations: manipulations
+        )
+    }
+
+    // MARK: - Prompt assembly
+
+    /// Substitute the template placeholders with the live taxonomy and
+    /// the supplied transcript. The manipulations list is rendered as
+    /// `- id: <id>, name: <display_name>` lines so the LLM can map its
+    /// free-text `name` output back to a stable id downstream.
+    ///
+    /// Substitution order is load-bearing: `{{manipulations_list}}` is
+    /// replaced first, then `{{transcript}}`. Doing manipulations first
+    /// means a transcript that literally contains the string
+    /// `{{manipulations_list}}` (or `{{transcript}}`) is inserted
+    /// verbatim without re-triggering substitution.
+    func buildPrompt(transcript: String) -> String {
+        let list = manipulations.all
+            .map { "- id: \($0.id), name: \($0.displayName)" }
+            .joined(separator: "\n")
+        return template
+            .replacingOccurrences(of: "{{manipulations_list}}", with: list)
+            .replacingOccurrences(of: "{{transcript}}", with: transcript)
+    }
+
+    // MARK: - Response validation
+
+    /// Parse and validate the LLM's JSON response.
+    ///
+    /// Tolerates: leading / trailing whitespace, ```` ```json … ``` ````
+    /// and bare ```` ``` … ``` ```` code fences, and trailing commentary
+    /// after the final closing brace.
+    ///
+    /// Rejects:
+    /// - empty or whitespace-only input → `.emptyInput`
+    /// - input with no recognisable JSON object → `.noJSONFound`
+    /// - JSON that doesn't decode to `RawLLMDraft` → `.decodingFailed`
+    /// - any `manipulations[].confidence` outside `[0, 1]`
+    ///   → `.confidenceOutOfRange(name:value:)`
+    func validate(json: String) -> Result<RawLLMDraft, SchemaError> {
+        let trimmed = json.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return .failure(.emptyInput)
+        }
+
+        let unfenced = Self.stripCodeFence(trimmed)
+
+        guard let object = Self.firstJSONObject(in: unfenced) else {
+            return .failure(.noJSONFound)
+        }
+
+        do {
+            let draft = try JSONDecoder().decode(
+                RawLLMDraft.self,
+                from: Data(object.utf8)
+            )
+            if let offender = draft.manipulations.first(where: {
+                $0.confidence < 0 || $0.confidence > 1
+            }) {
+                return .failure(.confidenceOutOfRange(
+                    name: offender.name,
+                    value: offender.confidence
+                ))
+            }
+            return .success(draft)
+        } catch {
+            return .failure(.decodingFailed(Self.redact(error)))
+        }
+    }
+
+    /// Map `DecodingError` into a PHI-safe structural description. Only
+    /// schema-level context is preserved — never the offending value.
+    ///
+    /// `DecodingError`'s default `debugDescription` can quote the value
+    /// that failed to decode (e.g. "Expected Double but found a String
+    /// instead: \"high\""). If that value ever came from a transcript-
+    /// derived SOAP field, interpolating the raw error description into a
+    /// log or telemetry line would leak PHI. By capturing only the
+    /// `codingPath` we keep the diagnostic useful while staying within
+    /// the rules in `.claude/references/phi-handling.md`.
+    private static func redact(_ error: any Error) -> DecodingFailureKind {
+        guard let decodingError = error as? DecodingError else {
+            return .other
+        }
+        switch decodingError {
+        case .keyNotFound(let key, let context):
+            return .missingKey(keyPath: keyPath(context.codingPath + [key]))
+        case .valueNotFound(_, let context):
+            return .missingKey(keyPath: keyPath(context.codingPath))
+        case .typeMismatch(_, let context):
+            return .typeMismatch(keyPath: keyPath(context.codingPath))
+        case .dataCorrupted(let context):
+            return .dataCorrupted(keyPath: keyPath(context.codingPath))
+        @unknown default:
+            return .other
+        }
+    }
+
+    /// Render a `DecodingError.Context.codingPath` as a dotted string
+    /// using schema keys + integer array indices only. Both are static
+    /// structural values — never PHI.
+    private static func keyPath(_ path: [any CodingKey]) -> String {
+        path.map { key in
+            if let intValue = key.intValue {
+                return String(intValue)
+            }
+            return key.stringValue
+        }.joined(separator: ".")
+    }
+
+    // MARK: - Private helpers
+
+    /// Strip a single outer ``` or ```json fence, if present. Idempotent
+    /// on unfenced input.
+    private static func stripCodeFence(_ input: String) -> String {
+        var body = input
+        if body.hasPrefix("```json") {
+            body = String(body.dropFirst("```json".count))
+        } else if body.hasPrefix("```") {
+            body = String(body.dropFirst("```".count))
+        }
+        body = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        if body.hasSuffix("```") {
+            body = String(body.dropLast("```".count))
+        }
+        return body.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Return the substring of the first balanced top-level JSON object
+    /// in `input`, or `nil` if none is found. Walks the string
+    /// brace-by-brace, tracking string literals + escapes so that braces
+    /// inside JSON strings are not counted.
+    private static func firstJSONObject(in input: String) -> String? {
+        guard let start = input.firstIndex(of: "{") else { return nil }
+        var state = BraceScanner()
+        var idx = start
+        while idx < input.endIndex {
+            if state.step(input[idx]) {
+                return String(input[start...idx])
+            }
+            idx = input.index(after: idx)
+        }
+        return nil
+    }
+}
+
+/// Private state machine for `ClinicalNotesPromptBuilder.firstJSONObject`.
+/// Tracks brace depth + in-string / escape context so a `{` or `}`
+/// inside a JSON string literal does not confuse the top-level scan.
+/// Extracted so each step fits under SwiftLint's cyclomatic-complexity
+/// limit.
+private struct BraceScanner {
+    private var depth = 0
+    private var inString = false
+    private var escaped = false
+
+    /// Consume one character. Returns `true` iff this character closes
+    /// the outer JSON object (i.e. depth returned to zero on a `}`).
+    mutating func step(_ char: Character) -> Bool {
+        if escaped {
+            escaped = false
+            return false
+        }
+        if inString {
+            stepInString(char)
+            return false
+        }
+        return stepOutsideString(char)
+    }
+
+    private mutating func stepInString(_ char: Character) {
+        if char == "\\" {
+            escaped = true
+        } else if char == "\"" {
+            inString = false
+        }
+    }
+
+    private mutating func stepOutsideString(_ char: Character) -> Bool {
+        switch char {
+        case "\"":
+            inString = true
+        case "{":
+            depth += 1
+        case "}":
+            depth -= 1
+            return depth == 0
+        default:
+            break
+        }
+        return false
+    }
+}
+
+/// Errors surfaced by `ClinicalNotesPromptBuilder.validate(json:)`.
+///
+/// Every case is structural only. No PHI (transcript content, patient
+/// data, SOAP body text, or decoded values) is carried in any payload —
+/// payloads are schema key names, integer array indices, and the
+/// technique name returned by the model (which is drawn from the static
+/// taxonomy, not patient data).
+enum SchemaError: Error, Equatable {
+    /// Input was empty or whitespace-only.
+    case emptyInput
+    /// No `{ … }` JSON object could be located in the input.
+    case noJSONFound
+    /// JSON parsed, but did not match the `RawLLMDraft` shape. The
+    /// associated kind carries only the schema key path that failed —
+    /// never the offending value. See `DecodingFailureKind` for detail.
+    case decodingFailed(DecodingFailureKind)
+    /// A `manipulations[]` entry carried a `confidence` outside the
+    /// locked `[0, 1]` range. `name` is the technique name returned by
+    /// the model (one of the taxonomy entries); it is not patient data.
+    case confidenceOutOfRange(name: String, value: Double)
+}
+
+/// PHI-safe structural description of a `DecodingError`.
+///
+/// The raw `DecodingError.debugDescription` can quote the offending
+/// value, which in this pipeline may have been derived from transcript
+/// text. This type preserves only the schema `codingPath` (dotted
+/// schema keys + integer array indices), which is never PHI.
+enum DecodingFailureKind: Error, Equatable, Sendable {
+    /// A required schema key was missing (or its value was `null` on a
+    /// non-optional field). `keyPath` is the dotted schema path — e.g.
+    /// `"plan"` or `"manipulations.0.confidence"`.
+    case missingKey(keyPath: String)
+    /// A value at `keyPath` was present but of the wrong type. The
+    /// offending value is deliberately not captured.
+    case typeMismatch(keyPath: String)
+    /// JSON parsed to the expected outer shape but failed a deeper
+    /// data-corruption check (e.g. malformed nested structure).
+    case dataCorrupted(keyPath: String)
+    /// Any other decoding failure (future `DecodingError` variants).
+    case other
+}
+
+/// Failures surfaced by `ClinicalNotesPromptBuilder.loadFromBundle(_:)`.
+enum ClinicalNotesPromptBuilderError: Error, Equatable {
+    /// The named template resource is missing from the bundle. Usually a
+    /// build-system misconfiguration (e.g. a missing `.copy(...)` entry
+    /// in `Package.swift`).
+    case templateNotFound(resource: String, subdirectory: String)
+}

--- a/Sources/Services/ClinicalNotesPromptBuilder.swift
+++ b/Sources/Services/ClinicalNotesPromptBuilder.swift
@@ -100,12 +100,12 @@ struct ClinicalNotesPromptBuilder: Sendable {
                 RawLLMDraft.self,
                 from: Data(object.utf8)
             )
-            if let offender = draft.manipulations.first(where: {
-                $0.confidence < 0 || $0.confidence > 1
+            if let offender = draft.manipulations.enumerated().first(where: { _, manipulation in
+                manipulation.confidence < 0 || manipulation.confidence > 1
             }) {
                 return .failure(.confidenceOutOfRange(
-                    name: offender.name,
-                    value: offender.confidence
+                    keyPath: "manipulations.\(offender.offset).confidence",
+                    value: offender.element.confidence
                 ))
             }
             return .success(draft)
@@ -241,10 +241,9 @@ private struct BraceScanner {
 /// Errors surfaced by `ClinicalNotesPromptBuilder.validate(json:)`.
 ///
 /// Every case is structural only. No PHI (transcript content, patient
-/// data, SOAP body text, or decoded values) is carried in any payload —
-/// payloads are schema key names, integer array indices, and the
-/// technique name returned by the model (which is drawn from the static
-/// taxonomy, not patient data).
+/// data, SOAP body text, LLM-returned names, or decoded values derived
+/// from patient input) is carried in any payload — payloads are schema
+/// key names, integer array indices, and numeric scores.
 enum SchemaError: Error, Equatable {
     /// Input was empty or whitespace-only.
     case emptyInput
@@ -255,9 +254,12 @@ enum SchemaError: Error, Equatable {
     /// never the offending value. See `DecodingFailureKind` for detail.
     case decodingFailed(DecodingFailureKind)
     /// A `manipulations[]` entry carried a `confidence` outside the
-    /// locked `[0, 1]` range. `name` is the technique name returned by
-    /// the model (one of the taxonomy entries); it is not patient data.
-    case confidenceOutOfRange(name: String, value: Double)
+    /// locked `[0, 1]` range. `keyPath` is the structural JSON path
+    /// (e.g. `"manipulations.0.confidence"`); `value` is the numeric
+    /// score. Neither is PHI — deliberately we do *not* carry the
+    /// model-returned `name`, which could contain hallucinated or
+    /// prompt-injected transcript content.
+    case confidenceOutOfRange(keyPath: String, value: Double)
 }
 
 /// PHI-safe structural description of a `DecodingError`.

--- a/Tests/SpeechToTextTests/Services/ClinicalNotesPromptBuilderTests.swift
+++ b/Tests/SpeechToTextTests/Services/ClinicalNotesPromptBuilderTests.swift
@@ -1,0 +1,384 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+// Covers issue #4 acceptance criteria:
+//   - Prompt loadable from a Resources text file (checks `loadFromBundle`
+//     + safety line from soap_v1.txt).
+//   - `validate(json:)` returns `Result<..., SchemaError>`; we return
+//     `RawLLMDraft` not `StructuredNotes` — see the design
+//     reconciliation note on #4. The downstream `RawLLMDraft →
+//     StructuredNotes` mapping is tested in #5.
+//   - Handles extra whitespace, code-fence-wrapped JSON, and trailing
+//     commentary gracefully.
+//   - Unit coverage: valid JSON, missing key, wrong type, empty
+//     manipulations, confidence outside [0, 1].
+//
+// Style: Swift Testing only, `.fast` via the suite. See
+// `.claude/references/testing-conventions.md`.
+
+@Suite("ClinicalNotesPromptBuilder", .tags(.fast))
+struct ClinicalNotesPromptBuilderTests {
+
+    // MARK: - Shared fixtures
+
+    private static let simpleTemplate = """
+    MANIPULATIONS:
+    {{manipulations_list}}
+
+    TRANSCRIPT:
+    {{transcript}}
+    """
+
+    private static let sampleRepo = ManipulationsRepository(all: [
+        Manipulation(id: "diversified_hvla", displayName: "Diversified HVLA", clinikoCode: nil),
+        Manipulation(id: "activator", displayName: "Activator", clinikoCode: nil)
+    ])
+
+    private static func builder(
+        template: String = simpleTemplate,
+        repo: ManipulationsRepository = sampleRepo
+    ) -> ClinicalNotesPromptBuilder {
+        ClinicalNotesPromptBuilder(template: template, manipulations: repo)
+    }
+
+    private static let validJSON = #"""
+    {
+      "subjective": "neck pain for 3 days",
+      "objective": "reduced cervical rotation R",
+      "assessment": "cervical facet restriction",
+      "plan": "follow up in 1 week",
+      "manipulations": [
+        { "name": "Diversified HVLA", "confidence": 0.91 }
+      ],
+      "excluded_content": ["chatter about weekend"]
+    }
+    """#
+
+    // MARK: - Prompt assembly
+
+    @Test("buildPrompt renders every manipulation id + display_name and embeds the transcript")
+    func buildPrompt_rendersTaxonomyAndTranscript() {
+        let prompt = Self.builder().buildPrompt(transcript: "Patient says hello.")
+
+        #expect(prompt.contains("- id: diversified_hvla, name: Diversified HVLA"))
+        #expect(prompt.contains("- id: activator, name: Activator"))
+        #expect(prompt.contains("Patient says hello."))
+        #expect(!prompt.contains("{{manipulations_list}}"))
+        #expect(!prompt.contains("{{transcript}}"))
+    }
+
+    @Test("buildPrompt with empty taxonomy renders an empty manipulations block")
+    func buildPrompt_emptyTaxonomy() {
+        let emptyRepo = ManipulationsRepository(all: [])
+        let prompt = Self.builder(repo: emptyRepo).buildPrompt(transcript: "x")
+        #expect(prompt.contains("MANIPULATIONS:\n\n"))
+    }
+
+    @Test("bundled soap_v1 template includes the locked safety line")
+    func bundledTemplate_includesSafetyLine() throws {
+        let builder = try ClinicalNotesPromptBuilder.loadFromBundle(
+            manipulations: Self.sampleRepo
+        )
+        let prompt = builder.buildPrompt(transcript: "x")
+        #expect(prompt.contains("drafting assistant"))
+        #expect(prompt.contains("not a diagnostic tool"))
+    }
+
+    @Test("loadFromBundle surfaces typed templateNotFound for a missing resource")
+    func loadFromBundle_missingResource_throws() {
+        #expect(throws: ClinicalNotesPromptBuilderError.self) {
+            _ = try ClinicalNotesPromptBuilder.loadFromBundle(
+                templateResource: "does-not-exist",
+                manipulations: Self.sampleRepo
+            )
+        }
+    }
+
+    // MARK: - validate() happy path
+
+    @Test("validate returns RawLLMDraft for well-formed JSON")
+    func validate_happyPath() {
+        let result = Self.builder().validate(json: Self.validJSON)
+        guard case let .success(draft) = result else {
+            Issue.record("expected success, got \(result)")
+            return
+        }
+        #expect(draft.subjective == "neck pain for 3 days")
+        #expect(draft.objective == "reduced cervical rotation R")
+        #expect(draft.assessment == "cervical facet restriction")
+        #expect(draft.plan == "follow up in 1 week")
+        #expect(draft.manipulations.count == 1)
+        #expect(draft.manipulations[0].name == "Diversified HVLA")
+        #expect(draft.manipulations[0].confidence == 0.91)
+        #expect(draft.excludedContent == ["chatter about weekend"])
+    }
+
+    @Test("validate accepts an empty manipulations array")
+    func validate_emptyManipulations() {
+        let json = #"""
+        {
+          "subjective": "",
+          "objective": "",
+          "assessment": "",
+          "plan": "",
+          "manipulations": [],
+          "excluded_content": []
+        }
+        """#
+        guard case let .success(draft) = Self.builder().validate(json: json) else {
+            Issue.record("expected success")
+            return
+        }
+        #expect(draft.manipulations.isEmpty)
+        #expect(draft.excludedContent.isEmpty)
+    }
+
+    // MARK: - Tolerant parsing
+
+    @Test("validate strips a ```json ... ``` code fence")
+    func validate_stripsJsonCodeFence() {
+        let wrapped = "```json\n" + Self.validJSON + "\n```"
+        guard case .success = Self.builder().validate(json: wrapped) else {
+            Issue.record("expected success for fenced JSON")
+            return
+        }
+    }
+
+    @Test("validate strips a bare ``` ... ``` code fence")
+    func validate_stripsBareCodeFence() {
+        let wrapped = "```\n" + Self.validJSON + "\n```"
+        guard case .success = Self.builder().validate(json: wrapped) else {
+            Issue.record("expected success for bare-fenced JSON")
+            return
+        }
+    }
+
+    @Test("validate tolerates trailing commentary after the JSON object")
+    func validate_toleratesTrailingCommentary() {
+        let noisy = Self.validJSON + "\n\nLet me know if you'd like me to adjust this!"
+        guard case .success = Self.builder().validate(json: noisy) else {
+            Issue.record("expected success when trailing commentary follows the JSON")
+            return
+        }
+    }
+
+    @Test("validate tolerates leading whitespace + a leading newline")
+    func validate_toleratesLeadingWhitespace() {
+        let padded = "   \n\n\t" + Self.validJSON
+        guard case .success = Self.builder().validate(json: padded) else {
+            Issue.record("expected success with leading whitespace")
+            return
+        }
+    }
+
+    @Test("validate is not fooled by braces inside string literals")
+    func validate_bracesInStringsDoNotBreakExtraction() {
+        let withBraceInString = #"""
+        {
+          "subjective": "patient quoted: \"{not json}\" earlier",
+          "objective": "",
+          "assessment": "",
+          "plan": "",
+          "manipulations": [],
+          "excluded_content": []
+        }
+        """#
+        guard case let .success(draft) = Self.builder().validate(json: withBraceInString) else {
+            Issue.record("expected success — inner braces are in a string literal")
+            return
+        }
+        #expect(draft.subjective.contains("{not json}"))
+    }
+
+    // MARK: - Error cases
+
+    @Test("validate returns emptyInput for whitespace-only input")
+    func validate_emptyInput() {
+        #expect(Self.builder().validate(json: "   \n\t") == .failure(.emptyInput))
+        #expect(Self.builder().validate(json: "") == .failure(.emptyInput))
+    }
+
+    @Test("validate returns noJSONFound when the input has no JSON object")
+    func validate_noJSONFound() {
+        let notJSON = "I don't know what to say about this consultation."
+        #expect(Self.builder().validate(json: notJSON) == .failure(.noJSONFound))
+    }
+
+    @Test("validate returns decodingFailed(.missingKey) for a missing required key — with a PHI-safe keyPath")
+    func validate_decodingFailed_missingKey() {
+        let missingPlan = #"""
+        {
+          "subjective": "x",
+          "objective": "x",
+          "assessment": "x",
+          "manipulations": [],
+          "excluded_content": []
+        }
+        """#
+        let result = Self.builder().validate(json: missingPlan)
+        #expect(result == .failure(.decodingFailed(.missingKey(keyPath: "plan"))))
+    }
+
+    @Test("validate returns decodingFailed(.typeMismatch) when confidence is the wrong type, without leaking the offending value")
+    func validate_decodingFailed_wrongType() {
+        // The word "suspicious" is used as the bogus confidence value so
+        // that we can assert it does *not* appear anywhere in the typed
+        // error — proving the PHI-safe redaction path.
+        let wrongType = #"""
+        {
+          "subjective": "x",
+          "objective": "x",
+          "assessment": "x",
+          "plan": "x",
+          "manipulations": [{ "name": "Activator", "confidence": "suspicious" }],
+          "excluded_content": []
+        }
+        """#
+        let result = Self.builder().validate(json: wrongType)
+        guard case let .failure(.decodingFailed(kind)) = result else {
+            Issue.record("expected decodingFailed")
+            return
+        }
+        guard case let .typeMismatch(keyPath) = kind else {
+            Issue.record("expected .typeMismatch, got \(kind)")
+            return
+        }
+        #expect(keyPath.hasPrefix("manipulations"))
+        #expect(keyPath.contains("confidence"))
+        // B1 PHI-safety invariant: the offending value must not surface
+        // in the rendered error description.
+        let rendered = String(describing: result)
+        #expect(!rendered.contains("suspicious"), "PHI-safe error must not quote the offending value")
+    }
+
+    @Test("validate returns decodingFailed(.typeMismatch) when a SOAP section is the wrong type, without leaking the offending value")
+    func validate_decodingFailed_soapSectionTypeMismatch_redacted() {
+        // Integer in a String field — same PHI-safety invariant as above.
+        let wrongType = #"""
+        {
+          "subjective": 424242,
+          "objective": "x",
+          "assessment": "x",
+          "plan": "x",
+          "manipulations": [],
+          "excluded_content": []
+        }
+        """#
+        let result = Self.builder().validate(json: wrongType)
+        guard case let .failure(.decodingFailed(kind)) = result else {
+            Issue.record("expected decodingFailed")
+            return
+        }
+        guard case .typeMismatch(keyPath: "subjective") = kind else {
+            Issue.record("expected .typeMismatch(keyPath: \"subjective\"), got \(kind)")
+            return
+        }
+        let rendered = String(describing: result)
+        #expect(!rendered.contains("424242"), "PHI-safe error must not quote the offending value")
+    }
+
+    @Test("validate returns confidenceOutOfRange when confidence > 1")
+    func validate_confidenceAboveOne() {
+        let json = #"""
+        {
+          "subjective": "",
+          "objective": "",
+          "assessment": "",
+          "plan": "",
+          "manipulations": [{ "name": "Activator", "confidence": 1.25 }],
+          "excluded_content": []
+        }
+        """#
+        #expect(
+            Self.builder().validate(json: json)
+            == .failure(.confidenceOutOfRange(name: "Activator", value: 1.25))
+        )
+    }
+
+    @Test("validate returns confidenceOutOfRange when confidence < 0")
+    func validate_confidenceBelowZero() {
+        let json = #"""
+        {
+          "subjective": "",
+          "objective": "",
+          "assessment": "",
+          "plan": "",
+          "manipulations": [{ "name": "Gonstead", "confidence": -0.1 }],
+          "excluded_content": []
+        }
+        """#
+        #expect(
+            Self.builder().validate(json: json)
+            == .failure(.confidenceOutOfRange(name: "Gonstead", value: -0.1))
+        )
+    }
+
+    @Test("validate accepts confidence at the inclusive bounds 0.0 and 1.0")
+    func validate_confidenceBounds_inclusive() {
+        let json = #"""
+        {
+          "subjective": "",
+          "objective": "",
+          "assessment": "",
+          "plan": "",
+          "manipulations": [
+            { "name": "Activator", "confidence": 0.0 },
+            { "name": "Gonstead",  "confidence": 1.0 }
+          ],
+          "excluded_content": []
+        }
+        """#
+        guard case .success = Self.builder().validate(json: json) else {
+            Issue.record("expected success for bounds 0.0 and 1.0")
+            return
+        }
+    }
+
+    // MARK: - Edge cases pinned by pre-PR review
+
+    @Test("validate returns noJSONFound for an unbalanced JSON object (open brace, no close)")
+    func validate_unbalancedJSON_returnsNoJSONFound() {
+        // Pins N1: the brace walker returns nil for an unbalanced input,
+        // which surfaces as `.noJSONFound` rather than `.decodingFailed`.
+        // Behaviour is load-bearing for the retry-once orchestration in
+        // #5 — swapping this to a different failure kind would change
+        // which retries fire.
+        let unbalanced = #"{ "subjective": "x", "objective": "y""#
+        #expect(Self.builder().validate(json: unbalanced) == .failure(.noJSONFound))
+    }
+
+    @Test("validate accepts an uppercase ```JSON fence (dual-path via firstJSONObject fallback)")
+    func validate_stripsUppercaseJsonFence() {
+        // Pins N2: `stripCodeFence` only strips lowercase `json`, but the
+        // overall validate path recovers via `firstJSONObject` on any
+        // leftover preamble.
+        let wrapped = "```JSON\n" + Self.validJSON + "\n```"
+        guard case .success = Self.builder().validate(json: wrapped) else {
+            Issue.record("expected success for uppercase JSON fence")
+            return
+        }
+    }
+
+    @Test("buildPrompt embeds a transcript containing triple-backticks verbatim without breaking template substitution")
+    func buildPrompt_tripleBackticksInTranscript_roundTrip() {
+        // Pins N3: a transcript that contains ``` must flow straight
+        // through `{{transcript}}` substitution. Nothing in the builder
+        // should try to re-interpret or strip fences on the input side.
+        let transcript = "Patient said: ```hello``` and went home."
+        let prompt = Self.builder().buildPrompt(transcript: transcript)
+        #expect(prompt.contains(transcript))
+        #expect(!prompt.contains("{{transcript}}"))
+    }
+
+    @Test("buildPrompt inserts a transcript containing {{manipulations_list}} literally, without re-substitution")
+    func buildPrompt_placeholderInTranscript_notResubstituted() {
+        // Pins the substitution-order invariant documented on
+        // `buildPrompt`: manipulations_list is substituted before
+        // transcript, so a transcript that literally contains
+        // `{{manipulations_list}}` stays verbatim.
+        let transcript = "Literal placeholder: {{manipulations_list}} — should stay."
+        let prompt = Self.builder().buildPrompt(transcript: transcript)
+        #expect(prompt.contains("Literal placeholder: {{manipulations_list}} — should stay."))
+    }
+}

--- a/Tests/SpeechToTextTests/Services/ClinicalNotesPromptBuilderTests.swift
+++ b/Tests/SpeechToTextTests/Services/ClinicalNotesPromptBuilderTests.swift
@@ -278,7 +278,7 @@ struct ClinicalNotesPromptBuilderTests {
         #expect(!rendered.contains("424242"), "PHI-safe error must not quote the offending value")
     }
 
-    @Test("validate returns confidenceOutOfRange when confidence > 1")
+    @Test("validate returns confidenceOutOfRange with a structural keyPath when confidence > 1")
     func validate_confidenceAboveOne() {
         let json = #"""
         {
@@ -292,11 +292,11 @@ struct ClinicalNotesPromptBuilderTests {
         """#
         #expect(
             Self.builder().validate(json: json)
-            == .failure(.confidenceOutOfRange(name: "Activator", value: 1.25))
+            == .failure(.confidenceOutOfRange(keyPath: "manipulations.0.confidence", value: 1.25))
         )
     }
 
-    @Test("validate returns confidenceOutOfRange when confidence < 0")
+    @Test("validate returns confidenceOutOfRange with a structural keyPath when confidence < 0")
     func validate_confidenceBelowZero() {
         let json = #"""
         {
@@ -310,7 +310,59 @@ struct ClinicalNotesPromptBuilderTests {
         """#
         #expect(
             Self.builder().validate(json: json)
-            == .failure(.confidenceOutOfRange(name: "Gonstead", value: -0.1))
+            == .failure(.confidenceOutOfRange(keyPath: "manipulations.0.confidence", value: -0.1))
+        )
+    }
+
+    @Test("confidenceOutOfRange does not carry the LLM-returned name (prompt-injection / hallucination PHI guard)")
+    func validate_confidenceOutOfRange_doesNotCarryName() {
+        // If the LLM hallucinates a "name" that contains transcript-
+        // derived text (patient name, DOB, quoted symptom, …), the
+        // resulting error must not carry it. This test embeds a
+        // PHI-looking token in the manipulation name and asserts it
+        // never appears in the rendered error.
+        let phiLooking = "Alice Smith DOB 1983-04-12"
+        let json = """
+        {
+          "subjective": "",
+          "objective": "",
+          "assessment": "",
+          "plan": "",
+          "manipulations": [{ "name": "\(phiLooking)", "confidence": 1.9 }],
+          "excluded_content": []
+        }
+        """
+        let result = Self.builder().validate(json: json)
+        #expect(
+            result == .failure(.confidenceOutOfRange(keyPath: "manipulations.0.confidence", value: 1.9))
+        )
+        let rendered = String(describing: result)
+        #expect(!rendered.contains("Alice"), "PHI-safe error must not quote the LLM-returned name")
+        #expect(!rendered.contains("1983"), "PHI-safe error must not quote the LLM-returned name")
+    }
+
+    @Test("confidenceOutOfRange keyPath reports the first offender index for a later manipulation entry")
+    func validate_confidenceOutOfRange_reportsCorrectIndex() {
+        // Pins that `offender.offset` is the array index of the first
+        // offending entry, so downstream diagnostics can map back to
+        // exactly which manipulation misbehaved.
+        let json = #"""
+        {
+          "subjective": "",
+          "objective": "",
+          "assessment": "",
+          "plan": "",
+          "manipulations": [
+            { "name": "Activator", "confidence": 0.5 },
+            { "name": "Gonstead",  "confidence": 0.9 },
+            { "name": "Toggle Recoil", "confidence": 42.0 }
+          ],
+          "excluded_content": []
+        }
+        """#
+        #expect(
+            Self.builder().validate(json: json)
+            == .failure(.confidenceOutOfRange(keyPath: "manipulations.2.confidence", value: 42.0))
         )
     }
 


### PR DESCRIPTION
## Summary

- Prompt-assembly + JSON-schema guard layer for EPIC #1: `RawLLMDraft` (Codable, byte-for-byte mirror of the locked LLM JSON contract) + `ClinicalNotesPromptBuilder` (pure-logic service with `buildPrompt(transcript:)` and `validate(json:) -> Result<RawLLMDraft, SchemaError>`).
- Versioned `Resources/Prompts/soap_v1.txt` template with `{{manipulations_list}}` and `{{transcript}}` placeholders and the locked "drafting assistant, not a diagnostic tool" safety line.
- PHI-safe error surface: `SchemaError.decodingFailed` carries a structural `DecodingFailureKind` (schema `keyPath` + case kind) — never the offending value. Two dedicated tests assert the invariant.
- 23 Swift Testing tests tagged `.fast`, total runtime ~5ms.

Closes #4. Unblocks #5 (ClinicalNotesProcessor — retry-once orchestration).

## Files

| Path | Purpose |
|---|---|
| `Sources/Models/RawLLMDraft.swift` | `struct RawLLMDraft: Codable, Sendable, Equatable` with nested `SuggestedManipulation { name, confidence }` and snake-case `CodingKeys` for `excluded_content`. |
| `Sources/Services/ClinicalNotesPromptBuilder.swift` | `struct ClinicalNotesPromptBuilder: Sendable`. Bundle loader, prompt assembly, forgiving JSON validator with private `BraceScanner` state machine. Typed `SchemaError` + `DecodingFailureKind` + `ClinicalNotesPromptBuilderError`. |
| `Sources/Resources/Prompts/soap_v1.txt` | Versioned prompt template (SOAP task description, JSON schema, safety line, placeholders). |
| `Tests/SpeechToTextTests/Services/ClinicalNotesPromptBuilderTests.swift` | Swift Testing suite (23 tests, `.fast`). |
| `Package.swift` | `.copy("Resources/Prompts")` alongside `Resources/Models` and `Resources/Manipulations`. |

## Design reconciliation (flagged upstream in [the #4 starting-plan comment](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/4#issuecomment-4312379842))

Issue #4's body listed `Sources/Models/StructuredNotes.swift (Codable)` as a file to modify and said `validate(json:)` should return `Result<StructuredNotes, SchemaError>`. That text predates #2.

Today `StructuredNotes` is the **UI model** (`selectedManipulationIDs: [String]`, `excluded: [String]`) bound to the locked ReviewScreen wireframe — its fields do not match the LLM JSON shape (`manipulations: [{name, confidence}]`, `excluded_content`). Rather than break the `SessionStore` contract that already shipped in #2, this PR introduces `RawLLMDraft` as a **separate** Codable type mirroring the JSON byte-for-byte. The `RawLLMDraft → StructuredNotes` mapping (resolving free-text `name` back to a taxonomy `id`) naturally lives in #5 where `ManipulationsRepository` is already in scope.

Net effect on acceptance criteria: unchanged — the prompt + JSON contract are still enforced here; the UI model binding is still honoured downstream.

## PHI safety — pre-PR reviewer Blocker B1

`SchemaError.decodingFailed(String)` originally wrapped `String(describing: error)`. `DecodingError.dataCorrupted` and `.typeMismatch` regularly include `debugDescription` quoting the offending value — which in this pipeline may have been derived from transcript text. Interpolating that into a log line from #5's retry logic would leak PHI.

Fix: `SchemaError.decodingFailed(DecodingFailureKind)` with `.missingKey(keyPath:)`, `.typeMismatch(keyPath:)`, `.dataCorrupted(keyPath:)`, `.other`. `keyPath` is built from `DecodingError.context.codingPath.map { $0.stringValue / intValue }` — schema keys + integer array indices, never values. Two tests (`validate_decodingFailed_wrongType...` and `validate_decodingFailed_soapSectionTypeMismatch_redacted`) deliberately embed "suspicious"/"424242" as the offending value and assert `String(describing: result)` does not contain it.

## Acceptance-criteria coverage (issue #4)

- [x] Prompt loadable from a Resources text file (versioned `soap_v1.txt`).
- [x] A `validate(json:)` function returns `Result<…, SchemaError>` (the payload is `RawLLMDraft` per the reconciliation above).
- [x] Handles extra whitespace, code-fence-wrapped JSON (`json`, bare, uppercase `JSON`), and trailing commentary gracefully.
- [x] Unit tests cover: valid JSON, missing key, wrong type, empty manipulations, non-[0,1] confidence (above + below + inclusive bounds).

## Test plan

- [x] `swift test --parallel --filter ClinicalNotesPromptBuilderTests` — 23/23 passing, ~5ms
- [x] `swift test --parallel` with CI skip list — exits 0, 70 tests across 7 suites
- [x] `swiftlint lint --strict` — 0 violations (one complexity split via `BraceScanner`; one autocorrect-removed redundant memberwise init)
- [x] `pre-commit run --files <diff>` — all hooks pass
- [x] Pre-PR `pr-review-toolkit:code-reviewer` (Opus) — B1 Blocker resolved (PHI-safe error shape) + N1/N2/N3 Nice-to-haves folded in (unbalanced JSON pin, uppercase JSON fence test, triple-backticks injection pin)
- [ ] CI on this PR
- [ ] Gemini Code Assist review
- [ ] Post-merge `gh run list --branch main --limit 3`

## Notes

- PHI-adjacent (transcript in-flight through `buildPrompt`, LLM response text through `validate`) but no persistence, no logging, no HTTP, no Keychain, no actor isolation. Pure-logic.
- Deferred to #5: `RawLLMDraft → StructuredNotes` mapping, async orchestration, retry-once on invalid JSON.
- Deferred to #3: the actual `LLMProvider` / `MLXGemmaProvider` that consumes the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)