### PR TITLE
chore(ci): bump actions/* to Node.js 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install SwiftLint
         run: brew install swiftlint
@@ -30,14 +30,14 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Need history back to the PR base so pre-commit can diff against it
           # and only check files changed in this PR.
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -86,7 +86,7 @@ jobs:
     needs: [lint, pre-commit]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
@@ -97,7 +97,7 @@ jobs:
           swift --version
 
       - name: Cache Swift Package Manager dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .build
@@ -107,7 +107,7 @@ jobs:
             spm-${{ runner.os }}-
 
       - name: Cache sherpa-onnx xcframework
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Frameworks/sherpa-onnx.xcframework
           key: sherpa-onnx-v1.12.20-${{ runner.os }}
@@ -219,7 +219,7 @@ jobs:
 
       - name: Upload coverage artifact
         if: ${{ !cancelled() && hashFiles('coverage.lcov') != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-report
           path: coverage.lcov
@@ -260,13 +260,13 @@ jobs:
     needs: test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
 
       - name: Cache Swift Package Manager dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .build
@@ -276,7 +276,7 @@ jobs:
             spm-${{ runner.os }}-
 
       - name: Cache sherpa-onnx xcframework
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: Frameworks/sherpa-onnx.xcframework
           key: sherpa-onnx-v1.12.20-${{ runner.os }}
@@ -292,7 +292,7 @@ jobs:
           swift build -c release 2>&1 | tee build.log
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: release-build
           path: .build/release/


### PR DESCRIPTION
## Summary

Resolves the Node.js 20 deprecation warnings that have been showing up on every CI run since GitHub's September 2025 announcement. Node.js 24 becomes the default on 2026-06-02; Node.js 20 is removed on 2026-09-16.

Bumps (first-party `actions/*` scope):

| Action | Before | After | Release note |
|---|---|---|---|
| `actions/checkout` | `v4` | `v5` | [v5.0.0](https://github.com/actions/checkout/releases/tag/v5.0.0) — Node 24 transition |
| `actions/setup-python` | `v5` | `v6` | [v6.0.0](https://github.com/actions/setup-python/releases/tag/v6.0.0) — Node 24 transition |
| `actions/cache` | `v4` | `v5` | [v5.0.0](https://github.com/actions/cache/releases/tag/v5.0.0) — Node 24 transition |
| `actions/upload-artifact` | `v4` | `v5` | [v5.0.0](https://github.com/actions/upload-artifact/releases/tag/v5.0.0) — Node 24 transition |

Each pinned to the **first Node-24 major** per the action's own release notes — minimises behavioural drift vs going to very latest (`v6` checkout, `v7` upload-artifact). We can bump further in a later pass if we want specific new features.

## Left as-is (intentional)

- `codecov/codecov-action@v5` — already Node 24 compatible.
- `pre-commit/action@v3.0.1` — third-party; no Node-24 release yet. Tracks upstream, will resolve on their side.

## Runner compatibility

v2.327.1 minimum required per release notes. GitHub-hosted `macos-14` runners are on ≥ v2.330 so no impact.

## Test plan

- [x] `pre-commit run --files .github/workflows/ci.yml` — all hooks pass
- [ ] This PR's CI run itself — acts as the real integration test (if the new majors break a step, we'll see it here)
- [ ] Post-merge main CI run confirms main stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)