### PR TITLE
chore(ci): bump runner image macos-14 → macos-15 (Sequoia)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   lint:
     name: SwiftLint
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -27,7 +27,7 @@ jobs:
 
   pre-commit:
     name: pre-commit hooks
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -82,7 +82,7 @@ jobs:
 
   test:
     name: Build and Test
-    runs-on: macos-14
+    runs-on: macos-15
     needs: [lint, pre-commit]
     steps:
       - name: Checkout code
@@ -256,7 +256,7 @@ jobs:
 
   build:
     name: Build Release
-    runs-on: macos-14
+    runs-on: macos-15
     needs: test
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

`macos-15` (Sequoia) has been generally available for GitHub Actions since April 10, 2025 and became the `macos-latest` default in August 2025. Bumping all four jobs to pin `macos-15` explicitly so we're on the current supported image rather than waiting for the eventual `macos-14` deprecation notice.

## Changes

All four `runs-on: macos-14` → `runs-on: macos-15` (jobs `lint`, `pre-commit`, `test`, `build`). No other steps change.

## Xcode compatibility

Verified against [`actions/runner-images` macos-15 readme](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md): Xcode 16.2 is still pre-installed at `/Applications/Xcode_16.2.app/`. The existing `sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer` step continues to resolve without any change. For reference, the image also ships 16.0 / 16.1 / 16.3 / 16.4 (default) — easy future upgrade path.

## Test plan

- [x] `pre-commit run --files .github/workflows/ci.yml` — passes
- [x] Xcode 16.2 path confirmed in the macos-15 image manifest
- [ ] PR CI run — real integration test; catches any Xcode / toolchain regression
- [ ] Post-merge main CI

Pairs with [#48](https://github.com/CloudbrokerAz/mac-speech-to-text/pull/48) (Node 24 action majors) — together bring the CI surface to current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)