### PR TITLE
feat(notes): ClinicalNotesProcessor — transcript → StructuredNotes (retry-once)

### DIFF
--- a/Sources/Services/ClinicalNotesProcessor.swift
+++ b/Sources/Services/ClinicalNotesProcessor.swift
@@ -1,0 +1,238 @@
+import Foundation
+
+/// Orchestrates the transcript → `StructuredNotes` pipeline.
+///
+/// **Issue #5.** Wires three previously-landed pieces:
+/// - `ClinicalNotesPromptBuilder` (#4) for prompt assembly + JSON
+///   schema validation,
+/// - `LLMProvider` (#3 protocol slice) for local inference,
+/// - `ManipulationsRepository` (#6) for the taxonomy the prompt
+///   enumerates and the response maps back to.
+///
+/// The concrete `LLMProvider` will be `MLXGemmaProvider` once the
+/// MLX-Swift concrete implementation lands (same ticket, follow-up
+/// PR). Tests exercise this actor against `MockLLMProvider`.
+///
+/// ### Retry-once contract
+/// On a `SchemaError` from the first response, the processor issues a
+/// second `generate` call with a short "fix the JSON" prompt that
+/// quotes the invalid output and restates the schema requirement. The
+/// quote is load-bearing: deterministic defaults (`temperature: 0`,
+/// fixed `seed`) would otherwise reproduce the same invalid output,
+/// making naive retries pointless. Including the prior bad response in
+/// the prompt perturbs the context enough for the model to attempt a
+/// correction.
+///
+/// ### Fallback contract
+/// Any path that doesn't yield a valid `StructuredNotes` resolves to
+/// `.rawTranscriptFallback(reason:)` so the ReviewScreen (#13) can
+/// surface the raw transcript and the practitioner's work is never
+/// lost. The `reason` is a structural sentinel — **never** a PHI-
+/// bearing error message. See `.claude/references/phi-handling.md`.
+///
+/// ### PHI
+/// `transcript`, the prompt derived from it, and the LLM response all
+/// contain patient data. They flow through this actor in-memory only
+/// and are never logged or persisted. Error messages from the LLM
+/// provider can contain input fragments; the processor therefore
+/// refuses to interpolate a caught error's text into the fallback
+/// reason — only the structural tag `"llm_error"` is returned.
+actor ClinicalNotesProcessor {
+    /// Result of a single `process(transcript:)` call.
+    enum Outcome: Sendable, Equatable {
+        /// A schema-valid SOAP note was produced (possibly after one
+        /// retry). The payload is ready for `SessionStore.setDraftNotes`.
+        case success(StructuredNotes)
+        /// The pipeline could not produce a valid note. The caller
+        /// should render the raw transcript and let the practitioner
+        /// compose the note manually. `reason` is a structural sentinel
+        /// for telemetry / UI branching — never PHI.
+        case rawTranscriptFallback(reason: String)
+    }
+
+    /// Structural sentinel emitted when any `LLMProvider.generate` call
+    /// throws. Deliberately opaque — provider error descriptions can
+    /// quote input tokens, so we discard the caught error's text.
+    static let reasonLLMError = "llm_error"
+
+    /// Structural sentinel emitted when both the first and the retry
+    /// responses fail schema validation.
+    static let reasonInvalidJSONAfterRetry = "invalid_json_after_retry"
+
+    // MARK: - Dependencies
+
+    private let provider: any LLMProvider
+    private let promptBuilder: ClinicalNotesPromptBuilder
+    private let manipulations: ManipulationsRepository
+    private let options: LLMOptions
+
+    init(
+        provider: any LLMProvider,
+        promptBuilder: ClinicalNotesPromptBuilder,
+        manipulations: ManipulationsRepository,
+        options: LLMOptions = LLMOptions()
+    ) {
+        self.provider = provider
+        self.promptBuilder = promptBuilder
+        self.manipulations = manipulations
+        self.options = options
+    }
+
+    // MARK: - Pipeline
+
+    /// Drive a transcript through the LLM and parse the response.
+    ///
+    /// Never throws. All failure modes resolve to
+    /// `.rawTranscriptFallback(reason:)`.
+    func process(transcript: String) async -> Outcome {
+        let initialPrompt = promptBuilder.buildPrompt(transcript: transcript)
+
+        let firstResponse: String
+        do {
+            firstResponse = try await provider.generate(
+                prompt: initialPrompt,
+                options: options
+            )
+        } catch {
+            logLLMError(error, attempt: 1)
+            return .rawTranscriptFallback(reason: Self.reasonLLMError)
+        }
+
+        switch promptBuilder.validate(json: firstResponse) {
+        case .success(let draft):
+            return .success(map(draft))
+        case .failure(let schemaError):
+            // Record the case tag only — structural, not PHI. See
+            // `.claude/references/phi-handling.md`; SchemaError
+            // payloads are keyPaths + case names + numeric scores only.
+            logSchemaError(schemaError, attempt: 1)
+        }
+
+        let retryPrompt = buildRetryPrompt(
+            originalPrompt: initialPrompt,
+            badResponse: firstResponse
+        )
+
+        let secondResponse: String
+        do {
+            secondResponse = try await provider.generate(
+                prompt: retryPrompt,
+                options: options
+            )
+        } catch {
+            logLLMError(error, attempt: 2)
+            return .rawTranscriptFallback(reason: Self.reasonLLMError)
+        }
+
+        switch promptBuilder.validate(json: secondResponse) {
+        case .success(let draft):
+            return .success(map(draft))
+        case .failure(let schemaError):
+            logSchemaError(schemaError, attempt: 2)
+            return .rawTranscriptFallback(
+                reason: Self.reasonInvalidJSONAfterRetry
+            )
+        }
+    }
+
+    // MARK: - Logging (structural only — no PHI)
+
+    /// Record the Swift type name of a caught LLM error. `type(of:)`
+    /// is the *class* of error (e.g. `URLError`, `MLXError`), never the
+    /// `localizedDescription`, which can quote input tokens.
+    private nonisolated func logLLMError(_ error: any Error, attempt: Int) {
+        let kind = String(describing: type(of: error))
+        AppLogger.service.error(
+            "ClinicalNotesProcessor: llm_error attempt=\(attempt, privacy: .public) kind=\(kind, privacy: .public)"
+        )
+    }
+
+    /// Record the SchemaError case tag. `String(describing:)` on a
+    /// `SchemaError` prints the case and its structural payload
+    /// (keyPaths, numeric scores) — deliberately designed to be
+    /// PHI-safe per #4.
+    private nonisolated func logSchemaError(_ error: SchemaError, attempt: Int) {
+        AppLogger.service.warning(
+            "ClinicalNotesProcessor: schema_invalid attempt=\(attempt, privacy: .public) kind=\(String(describing: error), privacy: .public)"
+        )
+    }
+
+    // MARK: - Retry prompt
+
+    /// Build the second-attempt prompt. Re-sending the original prompt
+    /// against a deterministic provider would reproduce the same
+    /// invalid output; quoting the bad response and restating the
+    /// requirement perturbs the model enough to attempt a correction.
+    private nonisolated func buildRetryPrompt(
+        originalPrompt: String,
+        badResponse: String
+    ) -> String {
+        """
+        \(originalPrompt)
+
+        Your previous response could not be parsed as a JSON object
+        matching the schema above:
+
+        ---
+        \(badResponse)
+        ---
+
+        Return ONLY the JSON object. No Markdown code fences, no
+        commentary before or after the object, no prose. Keep the same
+        content; correct the structural error.
+        """
+    }
+
+    // MARK: - Draft → StructuredNotes mapping
+
+    /// Resolve a `RawLLMDraft` to a `StructuredNotes`. SOAP strings
+    /// pass through verbatim; `manipulations[].name` is matched back
+    /// to a taxonomy id (see `resolveManipulationID`); unmatchable
+    /// names are silently dropped so the practitioner re-adds them
+    /// from the ReviewScreen checklist. Order is preserved; duplicate
+    /// ids are removed.
+    private nonisolated func map(_ draft: RawLLMDraft) -> StructuredNotes {
+        var seen: Set<String> = []
+        var ids: [String] = []
+        for suggested in draft.manipulations {
+            guard let resolved = resolveManipulationID(for: suggested.name) else {
+                continue
+            }
+            guard seen.insert(resolved).inserted else { continue }
+            ids.append(resolved)
+        }
+
+        return StructuredNotes(
+            subjective: draft.subjective,
+            objective: draft.objective,
+            assessment: draft.assessment,
+            plan: draft.plan,
+            selectedManipulationIDs: ids,
+            excluded: draft.excludedContent
+        )
+    }
+
+    /// Match an LLM-returned manipulation `name` back to a taxonomy id.
+    ///
+    /// Permissive: the prompt enumerates each manipulation as
+    /// `"- id: <id>, name: <display>"`, so the model can legitimately
+    /// emit either form. Matching is case-insensitive after trimming
+    /// surrounding whitespace. Id match wins if both happen to apply.
+    /// Returns `nil` if neither form matches — the unmatchable entry
+    /// is then dropped by `map`.
+    private nonisolated func resolveManipulationID(
+        for name: String
+    ) -> String? {
+        let key = name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard !key.isEmpty else { return nil }
+        for manipulation in manipulations.all where manipulation.id.lowercased() == key {
+            return manipulation.id
+        }
+        for manipulation in manipulations.all where manipulation.displayName.lowercased() == key {
+            return manipulation.id
+        }
+        return nil
+    }
+}

--- a/Sources/Services/ClinicalNotesProcessor.swift
+++ b/Sources/Services/ClinicalNotesProcessor.swift
@@ -227,12 +227,18 @@ actor ClinicalNotesProcessor {
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
         guard !key.isEmpty else { return nil }
-        for manipulation in manipulations.all where manipulation.id.lowercased() == key {
-            return manipulation.id
+
+        // Single pass; id match wins if it appears anywhere in the
+        // list. Remember the first displayName match as a fallback.
+        var nameMatch: String?
+        for manipulation in manipulations.all {
+            if manipulation.id.lowercased() == key {
+                return manipulation.id
+            }
+            if nameMatch == nil, manipulation.displayName.lowercased() == key {
+                nameMatch = manipulation.id
+            }
         }
-        for manipulation in manipulations.all where manipulation.displayName.lowercased() == key {
-            return manipulation.id
-        }
-        return nil
+        return nameMatch
     }
 }

--- a/Tests/SpeechToTextTests/Services/ClinicalNotesProcessorTests.swift
+++ b/Tests/SpeechToTextTests/Services/ClinicalNotesProcessorTests.swift
@@ -1,0 +1,320 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+// Covers issue #5 acceptance criteria:
+//   - Happy path returns `.success`.
+//   - Invalid-then-valid JSON triggers retry, returns `.success`.
+//   - Invalid-twice triggers `.rawTranscriptFallback(reason: ...)`.
+//   - LLM throws at either attempt → `.rawTranscriptFallback(reason: "llm_error")`.
+//   - No retries if the first response is valid.
+//   - No network, no on-disk writes.
+//   - `RawLLMDraft → StructuredNotes` mapping: id match, displayName
+//     match, case-insensitive, unmatchable dropped, duplicates removed,
+//     order preserved.
+
+@Suite("ClinicalNotesProcessor", .tags(.fast))
+struct ClinicalNotesProcessorTests {
+
+    // MARK: - Shared fixtures
+
+    private static let simpleTemplate = """
+    MANIPULATIONS:
+    {{manipulations_list}}
+
+    TRANSCRIPT:
+    {{transcript}}
+    """
+
+    private static let sampleRepo = ManipulationsRepository(all: [
+        Manipulation(id: "diversified_hvla", displayName: "Diversified HVLA", clinikoCode: nil),
+        Manipulation(id: "activator", displayName: "Activator", clinikoCode: nil),
+        Manipulation(id: "drop_table", displayName: "Drop Table", clinikoCode: nil)
+    ])
+
+    private static func promptBuilder(
+        repo: ManipulationsRepository = sampleRepo
+    ) -> ClinicalNotesPromptBuilder {
+        ClinicalNotesPromptBuilder(template: simpleTemplate, manipulations: repo)
+    }
+
+    private static func processor(
+        provider: any LLMProvider,
+        repo: ManipulationsRepository = sampleRepo
+    ) -> ClinicalNotesProcessor {
+        ClinicalNotesProcessor(
+            provider: provider,
+            promptBuilder: promptBuilder(repo: repo),
+            manipulations: repo
+        )
+    }
+
+    private static let validJSON = #"""
+    {
+      "subjective": "neck pain for 3 days",
+      "objective": "reduced cervical rotation R",
+      "assessment": "cervical facet restriction",
+      "plan": "follow up in 1 week",
+      "manipulations": [
+        { "name": "Diversified HVLA", "confidence": 0.91 }
+      ],
+      "excluded_content": ["chatter about weekend"]
+    }
+    """#
+
+    // A response that will fail validate(json:) — no JSON object at all.
+    private static let invalidJSON = "sorry, I can't produce JSON right now."
+
+    // MARK: - Happy path
+
+    @Test("Valid JSON on first attempt returns .success with mapped fields")
+    func happyPath_returnsSuccess() async {
+        let provider = MockLLMProvider(response: Self.validJSON)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        let expected = StructuredNotes(
+            subjective: "neck pain for 3 days",
+            objective: "reduced cervical rotation R",
+            assessment: "cervical facet restriction",
+            plan: "follow up in 1 week",
+            selectedManipulationIDs: ["diversified_hvla"],
+            excluded: ["chatter about weekend"]
+        )
+        #expect(outcome == .success(expected))
+    }
+
+    @Test("No retry when the first response is valid")
+    func happyPath_noRetry() async {
+        let provider = MockLLMProvider(response: Self.validJSON)
+        let proc = Self.processor(provider: provider)
+
+        _ = await proc.process(transcript: "t")
+
+        #expect(await provider.callCount() == 1)
+    }
+
+    // MARK: - Retry flow
+
+    @Test("Invalid-then-valid JSON retries once and returns .success")
+    func retry_invalidThenValid_returnsSuccess() async {
+        let provider = MockLLMProvider(
+            responses: [Self.invalidJSON, Self.validJSON]
+        )
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        guard case .success = outcome else {
+            Issue.record("Expected .success, got \(outcome)")
+            return
+        }
+        #expect(await provider.callCount() == 2)
+    }
+
+    @Test("Retry prompt quotes the invalid first response so the model can correct it")
+    func retry_promptQuotesBadOutput() async {
+        let provider = MockLLMProvider(
+            responses: [Self.invalidJSON, Self.validJSON]
+        )
+        let proc = Self.processor(provider: provider)
+
+        _ = await proc.process(transcript: "t")
+
+        let calls = await provider.calls()
+        #expect(calls.count == 2)
+        let retryPrompt = calls.last?.prompt ?? ""
+        #expect(retryPrompt.contains(Self.invalidJSON))
+        // The retry prompt must also include the schema/instruction so
+        // the model has something structural to anchor against.
+        #expect(retryPrompt.contains("JSON"))
+    }
+
+    @Test("Invalid JSON on both attempts returns .rawTranscriptFallback(invalid_json_after_retry)")
+    func retry_invalidTwice_fallback() async {
+        let provider = MockLLMProvider(
+            responses: [Self.invalidJSON, Self.invalidJSON]
+        )
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        #expect(outcome == .rawTranscriptFallback(
+            reason: ClinicalNotesProcessor.reasonInvalidJSONAfterRetry
+        ))
+        #expect(await provider.callCount() == 2)
+    }
+
+    // MARK: - LLM failure
+
+    @Test("LLM throws on first attempt → .rawTranscriptFallback(llm_error), no retry")
+    func llmThrows_firstAttempt_fallbackWithoutRetry() async {
+        let provider = MockLLMProvider(error: SampleError.boom)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        #expect(outcome == .rawTranscriptFallback(
+            reason: ClinicalNotesProcessor.reasonLLMError
+        ))
+        // One call: the throw aborts the pipeline; no retry on LLM
+        // throws per the acceptance criteria.
+        #expect(await provider.callCount() == 1)
+    }
+
+    @Test("LLM throws on retry → .rawTranscriptFallback(llm_error)")
+    func llmThrows_secondAttempt_fallback() async {
+        // Single-element queue: first call pops invalidJSON (forces
+        // retry); second call exhausts the queue, mock throws
+        // responseQueueExhausted. That throw is indistinguishable from
+        // a real provider error from the processor's perspective.
+        let provider = MockLLMProvider(responses: [Self.invalidJSON])
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        #expect(outcome == .rawTranscriptFallback(
+            reason: ClinicalNotesProcessor.reasonLLMError
+        ))
+        #expect(await provider.callCount() == 2)
+    }
+
+    // MARK: - Manipulation mapping
+
+    @Test("Mapping matches by Manipulation.id")
+    func mapping_matchesByID() async {
+        let json = Self.soapJSON(manipulations: [("activator", 0.5)])
+        let provider = MockLLMProvider(response: json)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        guard case .success(let notes) = outcome else {
+            Issue.record("Expected .success, got \(outcome)")
+            return
+        }
+        #expect(notes.selectedManipulationIDs == ["activator"])
+    }
+
+    @Test("Mapping matches by displayName, case-insensitively")
+    func mapping_matchesByDisplayName_caseInsensitive() async {
+        let json = Self.soapJSON(manipulations: [("dIvErSiFiEd HvLa", 0.4)])
+        let provider = MockLLMProvider(response: json)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        guard case .success(let notes) = outcome else {
+            Issue.record("Expected .success, got \(outcome)")
+            return
+        }
+        #expect(notes.selectedManipulationIDs == ["diversified_hvla"])
+    }
+
+    @Test("Unmatchable manipulation name is silently dropped")
+    func mapping_unmatchableDropped() async {
+        let json = Self.soapJSON(manipulations: [
+            ("Diversified HVLA", 0.8),
+            ("totally made up technique", 0.4)
+        ])
+        let provider = MockLLMProvider(response: json)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        guard case .success(let notes) = outcome else {
+            Issue.record("Expected .success, got \(outcome)")
+            return
+        }
+        #expect(notes.selectedManipulationIDs == ["diversified_hvla"])
+    }
+
+    @Test("Duplicate manipulation matches are de-duped; first occurrence wins order")
+    func mapping_deDupesPreservingOrder() async {
+        let json = Self.soapJSON(manipulations: [
+            ("Activator", 0.7),
+            ("Diversified HVLA", 0.9),
+            ("activator", 0.3),    // same as first after lowercasing
+            ("Drop Table", 0.5)
+        ])
+        let provider = MockLLMProvider(response: json)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        guard case .success(let notes) = outcome else {
+            Issue.record("Expected .success, got \(outcome)")
+            return
+        }
+        #expect(notes.selectedManipulationIDs == [
+            "activator", "diversified_hvla", "drop_table"
+        ])
+    }
+
+    @Test("Empty manipulations list round-trips to empty selectedManipulationIDs")
+    func mapping_empty() async {
+        let json = Self.soapJSON(manipulations: [])
+        let provider = MockLLMProvider(response: json)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        guard case .success(let notes) = outcome else {
+            Issue.record("Expected .success, got \(outcome)")
+            return
+        }
+        #expect(notes.selectedManipulationIDs.isEmpty)
+    }
+
+    @Test("excluded_content passes through verbatim")
+    func mapping_excludedPassthrough() async {
+        let json = Self.soapJSON(
+            manipulations: [("Activator", 0.5)],
+            excluded: ["weekend small talk", "coffee banter"]
+        )
+        let provider = MockLLMProvider(response: json)
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        guard case .success(let notes) = outcome else {
+            Issue.record("Expected .success, got \(outcome)")
+            return
+        }
+        #expect(notes.excluded == ["weekend small talk", "coffee banter"])
+    }
+
+    // MARK: - Helpers
+
+    /// Render a minimal SOAP JSON response with the given manipulations
+    /// and excluded-content list. Uses static SOAP strings so mapping
+    /// tests can focus on the manipulations array.
+    private static func soapJSON(
+        manipulations: [(name: String, confidence: Double)],
+        excluded: [String] = []
+    ) -> String {
+        let manipulationsJSON = manipulations.map { entry in
+            #"{ "name": "\#(entry.name)", "confidence": \#(entry.confidence) }"#
+        }.joined(separator: ",\n    ")
+        let excludedJSON = excluded.map { #""\#($0)""# }.joined(separator: ", ")
+        return #"""
+        {
+          "subjective": "s",
+          "objective": "o",
+          "assessment": "a",
+          "plan": "p",
+          "manipulations": [
+            \#(manipulationsJSON)
+          ],
+          "excluded_content": [\#(excludedJSON)]
+        }
+        """#
+    }
+}
+
+// MARK: - Test fixtures
+
+private enum SampleError: Error, Equatable, Sendable {
+    case boom
+}


### PR DESCRIPTION
## Summary

Orchestrator for GitHub issue #5. Actor-scoped pipeline that wires the three foundation pieces — `ClinicalNotesPromptBuilder` (#4), `LLMProvider` (#51), `ManipulationsRepository` (#6) — into the transcript → SOAP-JSON → `StructuredNotes` flow. Ships the retry-once contract and the raw-transcript fallback path locked in EPIC #1.

### Flow

1. `buildPrompt(transcript:)` → `provider.generate(...)` with deterministic `LLMOptions()` defaults.
2. `validate(json:)` on the response. Success → `map → .success`.
3. First schema failure → second `generate` call with a "fix the JSON" prompt that **quotes the invalid response** and restates the schema requirement. Required to break determinism against temperature `0` + fixed seed — the same prompt would reproduce the same bad output.
4. Second success → `.success(StructuredNotes)`. Second failure → `.rawTranscriptFallback(reason: "invalid_json_after_retry")`.
5. Any `generate` throw at either attempt → `.rawTranscriptFallback(reason: "llm_error")`.

### PHI handling (binding)

- Fallback reasons are structural sentinels only, defined as `static let` on the type so tests and callers can reference them without magic strings.
- Caught LLM errors: `type(of: error)` only (structural — `URLError`, `MLXError`, etc.). `localizedDescription` is never interpolated because it can quote input tokens. `privacy: .public` only on the type name.
- `SchemaError` is PHI-safe by design (#4's doc comment enforces that — keyPaths + case names + numeric scores, never the offending value). Logged via `AppLogger.service.warning` with `String(describing: schemaError)`.
- Transcript / prompt / response text never touches `OSLog`, `fatalError`, `assertionFailure`, or `preconditionFailure`.

### `RawLLMDraft → StructuredNotes` mapping

- SOAP strings pass through.
- `manipulations[].name` resolves to a `Manipulation.id` by case-insensitive, whitespace-trimmed match against either `id` or `displayName` (the prompt enumerates both, so the model can legitimately emit either form).
- Unmatchable names dropped silently — practitioner re-adds from the ReviewScreen manipulation checklist (#13).
- Duplicates de-duped preserving first-occurrence order.
- Confidence dropped in v1; `StructuredNotes.selectedManipulationIDs` has no confidence slot and the practitioner unticks over-selected entries in the checklist.
- `excluded_content` pass-through.

### SessionStore write is the caller's responsibility

Deliberately — the issue body says "write `StructuredNotes` into the active `ClinicalSession`", but keeping the processor pure:
- makes the `@MainActor` (SessionStore) ↔ actor (processor) hop the caller's problem, not this type's,
- keeps all tests synchronous-ish with no MainActor shenanigans,
- lets `.rawTranscriptFallback` callers choose whether to leave `draftNotes = nil` or set it to the raw transcript wrapper (the ReviewScreen #13 logic decides).

### Visibility

`internal`, matching the existing Clinical Notes types (`SessionStore`, `StructuredNotes`, `ClinicalNotesPromptBuilder`, `ManipulationsRepository`). The issue sketch showed `public actor` but the project convention trumps.

## Pre-PR checks

- [x] `swift build` — clean.
- [x] `swift test --parallel` (CI-filter set) — 101 tests pass, 13 new (all tagged `.fast`).
- [x] `pre-commit run` — all hooks green.
- [x] Pre-PR review via `pr-review-toolkit:code-reviewer` Opus — **no blockers**; nice-to-haves (mock-coupling comment, lookup dict, retry prompt truncation) either already addressed or YAGNI.
- [x] Pre-PR review via `pr-review-toolkit:silent-failure-hunter` Opus — **no blockers**. Folded in:
  - Structural logging of the LLM error type name + SchemaError case tag (silent-failure-hunter #2 + #3) so ops has something to grep on without violating PHI rules.
  - Test fix: `retry_invalidThenValid_returnsSuccess` used `if case … else { Issue.record(…) }` without `return`, which would double-report on fallback. Switched to `guard case … else { … return }`.

## Test plan

- [x] New tests pass locally.
- [x] Existing test suite unaffected.
- [ ] CI green on PR.
- [ ] Post-merge main CI green.

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)