### PR TITLE
fix(tests): debounce-rapid-keystrokes flake on CI runner (post #9)

### DIFF
--- a/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
+++ b/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
@@ -44,11 +44,17 @@ struct PatientPickerViewModelTests {
         let patients = FakePatientSearcher(result: .success([]))
         let appointments = FakeAppointmentLoader(result: .success([]))
         let store = SessionStore()
+        // Tiny debounce so the test budget for the post-keystroke wait
+        // gives a wide margin without slowing the suite. The previous
+        // 30ms / 150ms shape flaked on a loaded GitHub-Actions macOS
+        // runner — Task.sleep schedule jitter on a busy host can spike
+        // past the debounce window even when the wait is technically
+        // longer in wall-clock terms. 5ms / 250ms gives ~50× headroom.
         let vm = PatientPickerViewModel(
             patientService: patients,
             appointmentService: appointments,
             sessionStore: store,
-            debounceMillis: 30
+            debounceMillis: 5
         )
 
         vm.updateQuery("S")
@@ -57,9 +63,7 @@ struct PatientPickerViewModelTests {
         vm.updateQuery("Samp")
         vm.updateQuery("Sample")
 
-        // Wait long enough for the debounce + a small buffer, then settle
-        // any continuations.
-        try await Task.sleep(nanoseconds: 150_000_000)
+        try await Task.sleep(nanoseconds: 250_000_000)
 
         let count = await patients.callCount
         let lastQuery = await patients.lastQuery


### PR DESCRIPTION
## Summary
Post-merge main CI for #9 ([commit `a6761c9`](https://github.com/CloudbrokerAz/mac-speech-to-text/commit/a6761c98f2b2cef453e35e526fea1c87423fc339)) [flaked](https://github.com/CloudbrokerAz/mac-speech-to-text/actions/runs/24924280991/job/72991447279) on `debounce_rapidKeystrokes_singleCall`:
```
✘ PatientPickerViewModelTests.swift:66: Expectation failed: (count → 0) == 1
✘ PatientPickerViewModelTests.swift:67: Expectation failed: (lastQuery → nil) == "Sample"
```

The test had a 30ms debounce + 150ms post-keystroke `Task.sleep`. That margin survives a developer Mac but the macos-15 GitHub-Actions runner under load can drift past 150ms before the debounce-task fires. The pre-PR code-reviewer subagent flagged this exact risk; this PR is the follow-up.

Tightened to 5ms debounce + 250ms wait (≈50× margin). No production change.

## Test plan
- [x] Local: `swift test --filter debounce_rapidKeystrokes_singleCall` passes (`0.267s`)
- [ ] CI: PR-scoped pre-commit, `swift test --parallel` against the documented skip list, codecov/patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)