### PR TITLE
feat(ui): ClinicalNotesMode toggle + AppState SessionStore wiring (#11)

### DIFF
--- a/Sources/Models/UserSettings.swift
+++ b/Sources/Models/UserSettings.swift
@@ -66,7 +66,8 @@ struct UserSettings: Codable, Sendable {
             autoInsertText: true,
             copyToClipboard: true,
             accessibilityPromptDismissed: false,
-            clipboardOnlyMode: false
+            clipboardOnlyMode: false,
+            clinicalNotesModeEnabled: false
         ),
         hotkey: HotkeyConfiguration(
             enabled: true,
@@ -139,8 +140,15 @@ struct GeneralConfiguration: Codable, Sendable {
     var accessibilityPromptDismissed: Bool
     var clipboardOnlyMode: Bool
     var pasteBehavior: PasteBehavior
+    /// Clinical Notes Mode (#11). When `true`, the recording-completion modal
+    /// surfaces a "Generate Notes" action that drives the SOAP-note pipeline
+    /// (#5 + #13) instead of auto-dismissing after paste. Default `false` so
+    /// existing users see no behavioural change until they opt in.
+    var clinicalNotesModeEnabled: Bool
 
-    // Custom decoder to handle missing pasteBehavior in existing settings
+    // Custom decoder to handle missing pasteBehavior / clinicalNotesModeEnabled
+    // in existing settings. New optional fields use `decodeIfPresent` so saved
+    // settings from older builds still load.
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         launchAtLogin = try container.decode(Bool.self, forKey: .launchAtLogin)
@@ -149,6 +157,7 @@ struct GeneralConfiguration: Codable, Sendable {
         accessibilityPromptDismissed = try container.decode(Bool.self, forKey: .accessibilityPromptDismissed)
         clipboardOnlyMode = try container.decode(Bool.self, forKey: .clipboardOnlyMode)
         pasteBehavior = try container.decodeIfPresent(PasteBehavior.self, forKey: .pasteBehavior) ?? .pasteOnly
+        clinicalNotesModeEnabled = try container.decodeIfPresent(Bool.self, forKey: .clinicalNotesModeEnabled) ?? false
     }
 
     init(
@@ -157,7 +166,8 @@ struct GeneralConfiguration: Codable, Sendable {
         copyToClipboard: Bool = true,
         accessibilityPromptDismissed: Bool = false,
         clipboardOnlyMode: Bool = false,
-        pasteBehavior: PasteBehavior = .pasteOnly
+        pasteBehavior: PasteBehavior = .pasteOnly,
+        clinicalNotesModeEnabled: Bool = false
     ) {
         self.launchAtLogin = launchAtLogin
         self.autoInsertText = autoInsertText
@@ -165,6 +175,7 @@ struct GeneralConfiguration: Codable, Sendable {
         self.accessibilityPromptDismissed = accessibilityPromptDismissed
         self.clipboardOnlyMode = clipboardOnlyMode
         self.pasteBehavior = pasteBehavior
+        self.clinicalNotesModeEnabled = clinicalNotesModeEnabled
     }
 }
 

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -24,6 +24,21 @@ class AppState {
     @ObservationIgnored let settingsService: SettingsService
     @ObservationIgnored let statisticsService: StatisticsService
 
+    /// In-memory clinical session lifecycle (#2). Always instantiated; cheap
+    /// and idle when Clinical Notes Mode (#11) is off. The active
+    /// `ClinicalSession` only ever exists between the end of a recording and
+    /// either successful Cliniko export, idle timeout, or app quit. PHI lives
+    /// here exclusively — see `.claude/references/phi-handling.md`.
+    ///
+    /// `clinicalNotesProcessor` (the `actor ClinicalNotesProcessor` from #5)
+    /// injection is deferred until the concrete `MLXGemmaProvider` lands —
+    /// only the `LLMProvider` protocol + `MockLLMProvider` shipped in #3, so
+    /// there is no production-shaped LLM to construct a default processor
+    /// against. Wiring is a one-line addition once that provider exists; the
+    /// store on its own is a no-op when the toggle is off and provides no
+    /// PHI surface area.
+    @ObservationIgnored let sessionStore: SessionStore
+
     /// Task for loading statistics - tracked for proper lifecycle management
     @ObservationIgnored private var loadingTask: Task<Void, Never>?
     /// nonisolated copy for deinit access (deinit cannot access MainActor-isolated state)
@@ -39,6 +54,7 @@ class AppState {
         self.permissionService = PermissionService()
         self.settingsService = SettingsService()
         self.statisticsService = StatisticsService()
+        self.sessionStore = SessionStore()
 
         // Load settings
         self.settings = settingsService.load()

--- a/Sources/Views/LiquidGlassRecordingModal.swift
+++ b/Sources/Views/LiquidGlassRecordingModal.swift
@@ -429,32 +429,78 @@ struct LiquidGlassRecordingModal: View {
                 EmptyView()
 
             } else if !viewModel.transcribedText.isEmpty {
-                // Success indicator
-                HStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 18))
-                        .foregroundStyle(
-                            LinearGradient(
-                                colors: [Color.liquidPrismaticGreen, Color.liquidPrismaticCyan],
-                                startPoint: .topLeading,
-                                endPoint: .bottomTrailing
+                if viewModel.isClinicalNotesEnabled {
+                    // Clinical Notes Mode (#11): show "Generate Notes" + "Done"
+                    // instead of auto-dismissing. Tap surfaces the transcript
+                    // to whoever listens for `.clinicalNotesGenerateRequested`
+                    // (ReviewScreen presenter wires up in #13).
+                    Button {
+                        handleGenerateNotes()
+                    } label: {
+                        Text("Generate Notes")
+                            .font(.system(size: 14, weight: .semibold, design: .rounded))
+                            .foregroundStyle(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                            .background(
+                                LinearGradient(
+                                    colors: [Color.liquidPrismaticGreen, Color.liquidPrismaticCyan],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
                             )
-                        )
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .shadow(color: Color.liquidPrismaticGreen.opacity(0.4), radius: 8, y: 4)
+                    }
+                    .buttonStyle(.plain)
+                    .keyboardShortcut(.return)
+                    .accessibilityIdentifier("generateNotesButton")
 
-                    Text(viewModel.lastTranscriptionCopiedToClipboard ? "Copied!" : "Inserted!")
-                        .font(.system(size: 14, weight: .semibold, design: .rounded))
-                        .foregroundStyle(
-                            LinearGradient(
-                                colors: [Color.liquidPrismaticGreen, Color.liquidPrismaticCyan],
-                                startPoint: .leading,
-                                endPoint: .trailing
-                            )
-                        )
-                }
-                .onAppear {
-                    Task {
-                        try? await Task.sleep(nanoseconds: 900_000_000)
+                    Button {
                         handleDismiss()
+                    } label: {
+                        Text("Done")
+                            .font(.system(size: 14, weight: .medium, design: .rounded))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 10)
+                            .background(.ultraThinMaterial)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .stroke(Color.white.opacity(0.1), lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityIdentifier("doneAfterTranscriptionButton")
+                } else {
+                    // Default: success indicator + auto-dismiss after 0.9s
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 18))
+                            .foregroundStyle(
+                                LinearGradient(
+                                    colors: [Color.liquidPrismaticGreen, Color.liquidPrismaticCyan],
+                                    startPoint: .topLeading,
+                                    endPoint: .bottomTrailing
+                                )
+                            )
+
+                        Text(viewModel.lastTranscriptionCopiedToClipboard ? "Copied!" : "Inserted!")
+                            .font(.system(size: 14, weight: .semibold, design: .rounded))
+                            .foregroundStyle(
+                                LinearGradient(
+                                    colors: [Color.liquidPrismaticGreen, Color.liquidPrismaticCyan],
+                                    startPoint: .leading,
+                                    endPoint: .trailing
+                                )
+                            )
+                    }
+                    .onAppear {
+                        Task {
+                            try? await Task.sleep(nanoseconds: 900_000_000)
+                            handleDismiss()
+                        }
                     }
                 }
 
@@ -606,6 +652,43 @@ struct LiquidGlassRecordingModal: View {
         }
 
         dismissTaskId = UUID()
+    }
+
+    /// Hand the just-finished transcript to the Clinical Notes pipeline
+    /// (#13's ReviewScreen presenter listens). Posting via `NotificationCenter`
+    /// keeps the modal decoupled from `AppState` and lets #13 land its
+    /// presenter in one place without further changes here.
+    ///
+    /// Until the ReviewScreen presenter lands in #13, this post has no
+    /// observers and the modal dismisses with the transcript only present on
+    /// `RecordingViewModel.transcribedText` (cleared on next start). When #13
+    /// opens the review screen it must also defensively re-check Cliniko
+    /// credential presence before allowing export — the toggle's disabled
+    /// state can desynchronise from on-disk credential state if a settings
+    /// save fails on the credential-removal auto-disable path. #14's export
+    /// flow is the consumer-side enforcement point for that invariant.
+    private func handleGenerateNotes() {
+        let transcript = viewModel.transcribedText
+        guard !transcript.isEmpty else {
+            // Defence-in-depth: parent `if !viewModel.transcribedText.isEmpty`
+            // already gates rendering of this branch. If we reach here, the
+            // invariant is broken and a developer should notice.
+            AppLogger.viewModel.warning(
+                "handleGenerateNotes called with empty transcript — unexpected"
+            )
+            return
+        }
+        // Log the post so the listener gap (until #13 lands) is at least
+        // visible in sysdiagnose. Length only — never the transcript body.
+        AppLogger.viewModel.info(
+            "clinicalNotesGenerateRequested posted length=\(transcript.count, privacy: .public)"
+        )
+        NotificationCenter.default.post(
+            name: .clinicalNotesGenerateRequested,
+            object: nil,
+            userInfo: ["transcript": transcript]
+        )
+        handleDismiss()
     }
 }
 

--- a/Sources/Views/MainView/MainView.swift
+++ b/Sources/Views/MainView/MainView.swift
@@ -302,7 +302,10 @@ struct MainView: View {
             }
         case .clinicalNotes:
             if let clinicalNotesVM = clinicalNotesViewModel {
-                ClinicalNotesSection(viewModel: clinicalNotesVM)
+                ClinicalNotesSection(
+                    viewModel: clinicalNotesVM,
+                    settingsService: settingsService
+                )
             } else {
                 ClinicalNotesSectionPlaceholder()
             }

--- a/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
@@ -1,24 +1,52 @@
 // ClinicalNotesSection.swift
 // macOS Local Speech-to-Text Application
 //
-// Cliniko credentials + Clinical Notes Mode settings (issue #7).
-// The Clinical Notes Mode toggle itself ships in #11; this section currently
-// owns only the Cliniko-export credentials surface.
+// Clinical Notes Mode toggle (#11) + Cliniko credentials (#7). The toggle is
+// gated on the credentials being present — see `viewModel.hasStoredCredentials`
+// (AC4 of #7). Disabling the toggle is one click; un-storing credentials also
+// implicitly disables the experience.
 
 import SwiftUI
 
-/// Settings section for Cliniko credentials. The doctor pastes their Cliniko
-/// API key, picks the regional shard, optionally tests the connection, and
-/// can clear credentials. Per `.claude/references/cliniko-api.md` the key is
-/// stored in Keychain via `ClinikoCredentialStore`; the shard goes to
-/// `UserDefaults`.
+/// Settings section for Clinical Notes Mode + Cliniko credentials. The doctor
+/// flips Clinical Notes Mode on, pastes their Cliniko API key, picks the
+/// regional shard, optionally tests the connection, and can clear credentials.
+/// Per `.claude/references/cliniko-api.md` the key is stored in Keychain via
+/// `ClinikoCredentialStore`; the shard goes to `UserDefaults`.
 struct ClinicalNotesSection: View {
     @Bindable var viewModel: ClinicalNotesSectionViewModel
+
+    // MARK: - Dependencies
+
+    let settingsService: SettingsService
+
+    // MARK: - State
+
+    @State private var settings: UserSettings
+    @State private var saveError: String?
+    @State private var errorDismissalTask: Task<Void, Never>?
+
+    // MARK: - Initialisation
+
+    init(
+        viewModel: ClinicalNotesSectionViewModel,
+        settingsService: SettingsService = SettingsService()
+    ) {
+        self.viewModel = viewModel
+        self.settingsService = settingsService
+        self._settings = State(initialValue: settingsService.load())
+    }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
+                if let error = saveError {
+                    saveErrorBanner(message: error)
+                }
+
                 sectionHeader
+
+                clinicalNotesModeRow
 
                 connectionStatusCard
 
@@ -39,11 +67,28 @@ struct ClinicalNotesSection: View {
                 privacyFooter
             }
             .padding(20)
+            .animation(.easeInOut(duration: 0.3), value: saveError)
         }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("clinicalNotesSection")
         .task {
             await viewModel.refreshState()
+            // Reload settings on appear so a toggle change made elsewhere is
+            // reflected the next time the user lands here.
+            settings = settingsService.load()
+        }
+        .onDisappear {
+            errorDismissalTask?.cancel()
+            errorDismissalTask = nil
+        }
+        .onChange(of: viewModel.credentialState) { _, newValue in
+            // If the doctor removes credentials, force the toggle off so
+            // Clinical Notes Mode can never appear "on" without a tenant to
+            // export to. Persist immediately so a quit before a save still
+            // disables the mode.
+            guard newValue == .absent, settings.general.clinicalNotesModeEnabled else { return }
+            settings.general.clinicalNotesModeEnabled = false
+            saveSettings()
         }
     }
 
@@ -61,6 +106,77 @@ struct ClinicalNotesSection: View {
                 .foregroundStyle(.secondary)
         }
         .accessibilityIdentifier("clinicalNotesSection.header")
+    }
+
+    // MARK: - Clinical Notes Mode Toggle
+
+    /// The mode toggle is gated on `hasStoredCredentials`: we do not let the
+    /// doctor enable Clinical Notes Mode without a Cliniko tenant configured,
+    /// because the post-recording "Generate Notes" flow ends in a Cliniko
+    /// POST. The card explains this when the toggle is disabled, so the user
+    /// is not left guessing why the switch won't move.
+    private var clinicalNotesModeRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Toggle(isOn: clinicalNotesModeBinding) {
+                HStack(spacing: 12) {
+                    Image(systemName: "stethoscope")
+                        .font(.system(size: 16))
+                        .foregroundStyle(Color.iconPrimaryAdaptive)
+                        .frame(width: 24)
+                        .accessibilityHidden(true)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Clinical Notes Mode")
+                            .font(.body)
+                            .foregroundStyle(.primary)
+
+                        Text("Generate structured SOAP notes after each recording")
+                            .font(.caption)
+                            .foregroundStyle(Color.textTertiaryAdaptive)
+                    }
+                }
+            }
+            .toggleStyle(.switch)
+            .disabled(!viewModel.hasStoredCredentials)
+            .padding(.vertical, 4)
+            .accessibilityIdentifier("clinicalNotesModeToggle")
+            .accessibilityLabel("Clinical Notes Mode. Generate structured SOAP notes after each recording.")
+
+            if !viewModel.hasStoredCredentials {
+                Text("Add your Cliniko credentials below to enable Clinical Notes Mode.")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .accessibilityIdentifier("clinicalNotesModeToggle.disabledHint")
+            }
+        }
+    }
+
+    private var clinicalNotesModeBinding: Binding<Bool> {
+        Binding(
+            get: { settings.general.clinicalNotesModeEnabled },
+            set: { newValue in
+                settings.general.clinicalNotesModeEnabled = newValue
+                saveSettings()
+            }
+        )
+    }
+
+    // MARK: - Save error banner
+
+    private func saveErrorBanner(message: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.white)
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.white)
+            Spacer()
+        }
+        .padding(12)
+        .background(Color.red.opacity(0.9))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .transition(.move(edge: .top).combined(with: .opacity))
+        .accessibilityIdentifier("clinicalNotesSection.saveErrorBanner")
     }
 
     // MARK: - Connection Status Card
@@ -209,6 +325,39 @@ struct ClinicalNotesSection: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .accessibilityElement(children: .combine)
         .accessibilityIdentifier("clinicalNotesSection.statusBanner")
+    }
+
+    // MARK: - Persistence
+
+    private func saveSettings() {
+        do {
+            try settingsService.save(settings)
+            saveError = nil
+        } catch {
+            // Log the structural error class so a developer reading
+            // sysdiagnose can distinguish encoder failure from UserDefaults
+            // write failure. Never log `error.localizedDescription` directly
+            // — settings are PHI-adjacent (no PHI in the schema today, but
+            // the field set evolves). See `.claude/references/phi-handling.md`.
+            AppLogger.service.error(
+                "ClinicalNotesSection: settings save failed kind=\(String(describing: type(of: error)), privacy: .public)"
+            )
+            // Reload to drop the optimistic mutation so the UI reflects what
+            // is actually persisted. Then surface a transient banner.
+            settings = settingsService.load()
+            showSaveError("Could not save the Clinical Notes Mode setting. Please try again.")
+        }
+    }
+
+    private func showSaveError(_ message: String) {
+        saveError = message
+        errorDismissalTask?.cancel()
+        errorDismissalTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(3))
+            if !Task.isCancelled {
+                saveError = nil
+            }
+        }
     }
 
     // MARK: - Privacy Footer
@@ -577,6 +726,9 @@ final class ClinicalNotesSectionViewModel {
 // MARK: - Previews
 
 #Preview("Clinical Notes Section") {
-    ClinicalNotesSection(viewModel: ClinicalNotesSectionViewModel())
-        .frame(width: 640, height: 700)
+    ClinicalNotesSection(
+        viewModel: ClinicalNotesSectionViewModel(),
+        settingsService: SettingsService()
+    )
+    .frame(width: 640, height: 700)
 }

--- a/Sources/Views/MenuBarViewModel.swift
+++ b/Sources/Views/MenuBarViewModel.swift
@@ -80,4 +80,10 @@ extension Notification.Name {
     static let switchLanguage = Notification.Name("switchLanguage")
     /// Posted when voice trigger monitoring state changes (userInfo contains "state": VoiceTriggerState)
     static let voiceTriggerStateChanged = Notification.Name("voiceTriggerStateChanged")
+    /// Posted when the practitioner taps "Generate Notes" in the recording
+    /// modal with Clinical Notes Mode (#11) enabled. `userInfo["transcript"]`
+    /// carries the just-finished transcript as `String`. The ReviewScreen
+    /// presenter (#13) listens for this; until that lands, the AppDelegate
+    /// listener is a no-op and the notification is purely a hand-off seam.
+    static let clinicalNotesGenerateRequested = Notification.Name("clinicalNotesGenerateRequested")
 }

--- a/Sources/Views/RecordingViewModel.swift
+++ b/Sources/Views/RecordingViewModel.swift
@@ -62,6 +62,14 @@ final class RecordingViewModel {
     /// Whether the last transcription was copied to clipboard (not inserted)
     var lastTranscriptionCopiedToClipboard: Bool = false
 
+    /// Whether Clinical Notes Mode (#11) is enabled in Settings. Read on
+    /// demand from `SettingsService` so a toggle change made in the
+    /// Main window during a recording is honoured by the next read; the
+    /// modal evaluates this only after transcription completes.
+    var isClinicalNotesEnabled: Bool {
+        settingsService.load().general.clinicalNotesModeEnabled
+    }
+
     // MARK: - Dependencies
     // All services are @ObservationIgnored to prevent @Observable from tracking them
     // This is critical for fluidAudioService which is an actor existential type -

--- a/Tests/SpeechToTextTests/App/AppStateTests.swift
+++ b/Tests/SpeechToTextTests/App/AppStateTests.swift
@@ -398,6 +398,17 @@ final class AppStateTests: XCTestCase {
         XCTAssertNotNil(appState.permissionService)
         XCTAssertNotNil(appState.settingsService)
         XCTAssertNotNil(appState.statisticsService)
+        XCTAssertNotNil(appState.sessionStore)
+    }
+
+    // MARK: - #11 Clinical Notes Mode wiring
+
+    /// `SessionStore` is always instantiated so the post-recording flow can
+    /// drop a `ClinicalSession` into it without conditional construction. It
+    /// must start empty — Clinical Notes Mode is opt-in.
+    func test_initialization_sessionStoreStartsEmpty() {
+        let appState = AppState()
+        XCTAssertNil(appState.sessionStore.active)
     }
 
     // MARK: - Concurrent Access Tests

--- a/Tests/SpeechToTextTests/Models/ClinicalNotesModeSettingsTests.swift
+++ b/Tests/SpeechToTextTests/Models/ClinicalNotesModeSettingsTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+/// Coverage for the `clinicalNotesModeEnabled` flag added in #11. The flag
+/// lives on `GeneralConfiguration` and is persisted as part of the JSON
+/// `UserSettings` blob in `UserDefaults`. Two contracts:
+///
+/// 1. **Default false.** Existing builds upgrading to a flag-aware build must
+///    see the recording flow unchanged until they explicitly opt in.
+/// 2. **Decode migration.** A `UserSettings` blob saved by a pre-#11 build
+///    (no `clinicalNotesModeEnabled` key) must decode cleanly with the flag
+///    defaulting to `false` — `decodeIfPresent` handles this; the test pins
+///    the contract so a future refactor doesn't accidentally make the field
+///    required.
+@Suite("UserSettings: Clinical Notes Mode flag (#11)", .tags(.fast))
+struct ClinicalNotesModeSettingsTests {
+
+    @Test("Default value is false")
+    func defaultValue_isFalse() {
+        let general = UserSettings.default.general
+        #expect(general.clinicalNotesModeEnabled == false)
+    }
+
+    @Test("Memberwise init defaults clinicalNotesModeEnabled to false")
+    func memberwiseInit_defaultsToFalse() {
+        let general = GeneralConfiguration()
+        #expect(general.clinicalNotesModeEnabled == false)
+    }
+
+    @Test("Memberwise init honours explicit true")
+    func memberwiseInit_acceptsExplicitTrue() {
+        let general = GeneralConfiguration(clinicalNotesModeEnabled: true)
+        #expect(general.clinicalNotesModeEnabled == true)
+    }
+
+    @Test("Decoding pre-#11 settings JSON defaults the flag to false")
+    func decode_legacyJSON_defaultsFlagToFalse() throws {
+        // Synthetic pre-#11 payload — every persisted GeneralConfiguration
+        // field present except `clinicalNotesModeEnabled`. `decodeIfPresent`
+        // must fill it in.
+        let legacyJSON = #"""
+        {
+            "launchAtLogin": false,
+            "autoInsertText": true,
+            "copyToClipboard": true,
+            "accessibilityPromptDismissed": false,
+            "clipboardOnlyMode": false,
+            "pasteBehavior": "paste"
+        }
+        """#
+
+        let data = try #require(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(GeneralConfiguration.self, from: data)
+        #expect(decoded.clinicalNotesModeEnabled == false)
+    }
+
+    @Test("Round-tripping the flag preserves it")
+    func encodeDecode_preservesFlag() throws {
+        let original = GeneralConfiguration(clinicalNotesModeEnabled: true)
+
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(original)
+
+        let decoder = JSONDecoder()
+        let roundTripped = try decoder.decode(GeneralConfiguration.self, from: data)
+
+        #expect(roundTripped.clinicalNotesModeEnabled == true)
+    }
+
+    @Test("Pre-#11 JSON containing a missing pasteBehavior also fills the new flag")
+    func decode_legacyJSON_withoutPasteBehavior_defaultsBothFields() throws {
+        // Even older payload predating #11 *and* the pasteBehavior addition.
+        // Both `decodeIfPresent` paths must hold simultaneously.
+        let legacyJSON = #"""
+        {
+            "launchAtLogin": true,
+            "autoInsertText": false,
+            "copyToClipboard": false,
+            "accessibilityPromptDismissed": true,
+            "clipboardOnlyMode": true
+        }
+        """#
+
+        let data = try #require(legacyJSON.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(GeneralConfiguration.self, from: data)
+        #expect(decoded.pasteBehavior == .pasteOnly)
+        #expect(decoded.clinicalNotesModeEnabled == false)
+    }
+}

--- a/Tests/SpeechToTextTests/Models/UserSettingsTests.swift
+++ b/Tests/SpeechToTextTests/Models/UserSettingsTests.swift
@@ -35,6 +35,9 @@ final class UserSettingsTests: XCTestCase {
         XCTAssertTrue(general.copyToClipboard)
         XCTAssertFalse(general.accessibilityPromptDismissed)
         XCTAssertFalse(general.clipboardOnlyMode)
+        // #11: Clinical Notes Mode is opt-in. Existing users see the recording
+        // flow unchanged on update — must remain false by default.
+        XCTAssertFalse(general.clinicalNotesModeEnabled)
     }
 
     func test_defaultSettings_language_hasCorrectDefaults() {

--- a/Tests/SpeechToTextTests/Views/ClinicalNotesSectionRenderTests.swift
+++ b/Tests/SpeechToTextTests/Views/ClinicalNotesSectionRenderTests.swift
@@ -20,6 +20,15 @@ final class ClinicalNotesSectionRenderTests: XCTestCase {
         return defaults
     }
 
+    private func makeSettingsService() -> SettingsService {
+        let suiteName = "ClinicalNotesSectionRenderTests-Settings-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("UserDefaults(suiteName:) returned nil")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return SettingsService(userDefaults: defaults)
+    }
+
     private func makeViewModel() -> ClinicalNotesSectionViewModel {
         let store = ClinikoCredentialStore(
             secureStore: InMemorySecureStore(),
@@ -32,13 +41,19 @@ final class ClinicalNotesSectionRenderTests: XCTestCase {
 
     func test_clinicalNotesSection_instantiatesWithoutCrash() {
         let viewModel = makeViewModel()
-        let view = ClinicalNotesSection(viewModel: viewModel)
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
         XCTAssertNotNil(view)
     }
 
     func test_clinicalNotesSection_canBeInspected() throws {
         let viewModel = makeViewModel()
-        let view = ClinicalNotesSection(viewModel: viewModel)
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
         // ViewInspector forces SwiftUI's body to be evaluated; if any
         // @Observable + actor existential issue exists in the VM, this is
         // where it surfaces (EXC_BAD_ACCESS). Just touching the body counts.
@@ -49,7 +64,10 @@ final class ClinicalNotesSectionRenderTests: XCTestCase {
         let viewModel = makeViewModel()
         // Default state — no credentials saved.
         XCTAssertFalse(viewModel.hasStoredCredentials)
-        let view = ClinicalNotesSection(viewModel: viewModel)
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
         XCTAssertNoThrow(try view.inspect().findAll(ViewType.SecureField.self))
     }
 
@@ -64,7 +82,26 @@ final class ClinicalNotesSectionRenderTests: XCTestCase {
         let viewModel = ClinicalNotesSectionViewModel(credentialStore: store, authProbe: probe)
         await viewModel.refreshState()
 
-        let view = ClinicalNotesSection(viewModel: viewModel)
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
         XCTAssertNoThrow(try view.inspect().findAll(ViewType.SecureField.self))
+    }
+
+    // MARK: - #11 Clinical Notes Mode toggle
+
+    /// The toggle is rendered above the credentials block. Confirm it's reachable
+    /// via the accessibility identifier — that's the contract UI tests + future
+    /// snapshot tests will pivot on.
+    func test_clinicalNotesModeToggle_isPresent() throws {
+        let viewModel = makeViewModel()
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModeToggle")
+        )
     }
 }

--- a/Tests/SpeechToTextTests/Views/RecordingViewModelClinicalNotesTests.swift
+++ b/Tests/SpeechToTextTests/Views/RecordingViewModelClinicalNotesTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+/// `RecordingViewModel.isClinicalNotesEnabled` is the read seam the recording
+/// modal uses to decide between the existing auto-dismiss success indicator
+/// and the new "Generate Notes" button row added in #11. It must reflect the
+/// most-recently saved value of `settings.general.clinicalNotesModeEnabled`.
+///
+/// Read-on-demand (not cached at init) is the contract: the doctor may flip
+/// the toggle in the Main window between starting a recording and finishing
+/// it; the modal evaluates this only after transcription completes, so a
+/// fresh read is correct. The test pins that contract.
+@MainActor
+@Suite("RecordingViewModel: isClinicalNotesEnabled (#11)", .tags(.fast))
+struct RecordingViewModelClinicalNotesTests {
+
+    private func makeSettingsService() -> SettingsService {
+        let suiteName = "RecordingViewModelClinicalNotesTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("UserDefaults(suiteName:) returned nil")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return SettingsService(userDefaults: defaults)
+    }
+
+    @Test("Defaults to false on a fresh settings store")
+    func defaultsFalse() {
+        let settingsService = makeSettingsService()
+        let viewModel = RecordingViewModel(settingsService: settingsService)
+        #expect(viewModel.isClinicalNotesEnabled == false)
+    }
+
+    @Test("Reflects a saved-true value")
+    func reflectsSavedTrue() throws {
+        let settingsService = makeSettingsService()
+        var settings = settingsService.load()
+        settings.general.clinicalNotesModeEnabled = true
+        try settingsService.save(settings)
+
+        let viewModel = RecordingViewModel(settingsService: settingsService)
+        #expect(viewModel.isClinicalNotesEnabled == true)
+    }
+
+    @Test("Reads on demand — a save after init is honoured")
+    func readsOnDemand() throws {
+        let settingsService = makeSettingsService()
+        let viewModel = RecordingViewModel(settingsService: settingsService)
+        #expect(viewModel.isClinicalNotesEnabled == false)
+
+        var settings = settingsService.load()
+        settings.general.clinicalNotesModeEnabled = true
+        try settingsService.save(settings)
+
+        // Same view model — must see the new value because the property is
+        // a computed read of `settingsService.load()`, not a stored copy.
+        #expect(viewModel.isClinicalNotesEnabled == true)
+    }
+}


### PR DESCRIPTION
## Summary

Implements [#11](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/11) — Clinical Notes Mode toggle in the Clinical Notes settings section, `SessionStore` wiring into `AppState`, and a "Generate Notes" button in the production recording modal that surfaces only when the toggle is on.

- Adds `clinicalNotesModeEnabled: Bool` to `GeneralConfiguration` with a `decodeIfPresent` migration so settings saved by older builds load with the flag defaulting to `false`.
- New "Clinical Notes Mode" toggle row above the existing Cliniko credentials block in `ClinicalNotesSection`. Disabled until credentials are stored (mirrors AC4 from #7); auto-flips off and persists when credentials are removed.
- `AppState` gains `@ObservationIgnored let sessionStore: SessionStore` (always-instantiated, cheap, idle until used).
- `LiquidGlassRecordingModal` (the production modal — verified against `AppDelegate.showRecordingModal` line 866; the legacy `RecordingModal.swift` is no longer presented) swaps the auto-dismissing "Inserted!" success indicator for a "Generate Notes" + "Done" row when the toggle is on. Tap "Generate Notes" posts `Notification.Name.clinicalNotesGenerateRequested` with `userInfo["transcript"]`. The toggle-off branch is byte-for-byte the prior implementation.
- New `RecordingViewModel.isClinicalNotesEnabled` computed property reads `settingsService.load().general.clinicalNotesModeEnabled` on demand so a toggle change made between recording-start and recording-stop is honoured.

## Deferred to a follow-up PR

`AppState.clinicalNotesProcessor` injection. The processor needs an `LLMProvider`, and the concrete `MLXGemmaProvider` doesn't exist yet — only the protocol + `MockLLMProvider` shipped in #3. Wiring `ClinicalNotesProcessor` into `AppState` today would require a stub provider that's ripped out the moment the real one lands. Documented in the `AppState` doc comment alongside `sessionStore`. Not user-visible.

## Listener gap acknowledged

`Notification.Name.clinicalNotesGenerateRequested` has no observer until #13 lands its ReviewScreen presenter. Until then, tapping "Generate Notes" dismisses the modal and the transcript is held only on `RecordingViewModel.transcribedText` (cleared on next start). The post is logged (length only — never the transcript body — per `phi-handling.md`) so the gap is at least visible in sysdiagnose. The PR's modal doc-comment also calls out a known residual hazard for #13/#14: if a settings save fails on the credential-removal auto-disable path, the toggle's persisted state can desynchronise from credential presence. The defensive enforcement point for that invariant is the **export consumer side** (#13 / #14) rather than the modal — a Cliniko POST without credentials must error gracefully regardless of how the user got there.

## Pre-PR review

- Spawned `pr-review-toolkit:code-reviewer` (Opus) over the diff. Verdict: **cleared to push, no blockers.**
- Spawned `pr-review-toolkit:silent-failure-hunter` (Opus) in parallel. Three blockers raised; two addressed (added `AppLogger` calls in `saveSettings` catch path + `handleGenerateNotes` empty-transcript guard + post-notification site, all PHI-safe — kind/length only). The third (`isClinicalNotesEnabled` defensive credential check) deferred to consumer side; documented as known hazard for #13/#14 in the modal doc-comment.

## Test plan

- [x] `swift test --parallel` skipping hardware-dependent classes — 202/202 pass locally.
- [x] `swiftlint lint --strict` — 0 violations across 112 files.
- [x] `pre-commit run --files <changed>` — all hooks pass.
- [ ] CI (GitHub Actions) — awaiting on PR open.
- [ ] Pre-push remote-Mac UI suite — to be run before merge.

New tests:
- `ClinicalNotesModeSettingsTests.swift` (Swift Testing) — default false, memberwise init, decode migration with synthetic legacy JSON, round-trip preservation, double-missing-field migration.
- `RecordingViewModelClinicalNotesTests.swift` (Swift Testing) — `isClinicalNotesEnabled` defaults false, reflects saved value, reads on demand (a save after init is honoured by the same VM).
- Extended `UserSettingsTests` — `XCTAssertFalse(general.clinicalNotesModeEnabled)`.
- Extended `AppStateTests` — `sessionStore` exists, starts with `active == nil`.
- Extended `ClinicalNotesSectionRenderTests` — toggle is reachable by accessibility identifier; all 4 existing tests updated for the new init signature.

All Swift Testing tests tagged `.fast` and use isolated `UserDefaults(suiteName:)` so global state stays clean.

## AC mapping

- [x] Toggle persists across launches — single JSON `UserSettings` blob via `SettingsService.save`.
- [x] With toggle OFF: existing recording flow unchanged — verified by reading the `else` branch in `LiquidGlassRecordingModal.actionSection` byte-for-byte against the prior implementation.
- [x] With toggle ON: Generate Notes button appears after recording completes — accessibility ID `generateNotesButton`. Tap posts `.clinicalNotesGenerateRequested` for #13's ReviewScreen presenter.
- [x] All existing tests still pass.

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)