### PR TITLE
feat(ui): ReviewScreen — two-column SOAP editor + manipulations + excluded drawer (#13)

### DIFF
--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -39,6 +39,16 @@ class AppState {
     /// PHI surface area.
     @ObservationIgnored let sessionStore: SessionStore
 
+    /// Static manipulations taxonomy bundled with the app (#6). Loaded
+    /// once at launch and handed to `ReviewWindowController` so the
+    /// review surface (#13) renders the checklist without re-parsing the
+    /// JSON on every present. Empty repository on load failure — the
+    /// `swift-tools-version: 5.9` `.copy(...)` in `Package.swift` makes
+    /// the JSON's presence in the test bundle a build-system invariant,
+    /// so any failure is a structural bug we want to surface (logged) but
+    /// never want to crash production over.
+    @ObservationIgnored let manipulations: ManipulationsRepository
+
     /// Task for loading statistics - tracked for proper lifecycle management
     @ObservationIgnored private var loadingTask: Task<Void, Never>?
     /// nonisolated copy for deinit access (deinit cannot access MainActor-isolated state)
@@ -47,6 +57,13 @@ class AppState {
     @ObservationIgnored private var voiceTriggerStateObserver: NSObjectProtocol?
     /// nonisolated copy for deinit access
     @ObservationIgnored private nonisolated(unsafe) var deinitVoiceTriggerStateObserver: NSObjectProtocol?
+    /// Observer for `.clinicalNotesGenerateRequested` (posted by the
+    /// recording modal once the doctor has acknowledged the safety
+    /// disclaimer). Hops the transcript off the notification boundary
+    /// into `SessionStore` and presents `ReviewWindowController`.
+    @ObservationIgnored private var clinicalNotesGenerateObserver: NSObjectProtocol?
+    /// nonisolated copy for deinit access
+    @ObservationIgnored private nonisolated(unsafe) var deinitClinicalNotesGenerateObserver: NSObjectProtocol?
 
     init() {
         // Initialize services
@@ -55,6 +72,15 @@ class AppState {
         self.settingsService = SettingsService()
         self.statisticsService = StatisticsService()
         self.sessionStore = SessionStore()
+        self.manipulations = Self.loadManipulationsTaxonomy()
+
+        // Configure ReviewWindowController once with the SessionStore +
+        // taxonomy so `present()` is a no-arg call from the notification
+        // observer below. Mirrors the MainWindowController.shared idiom.
+        ReviewWindowController.shared.configure(
+            sessionStore: self.sessionStore,
+            manipulations: self.manipulations
+        )
 
         // Load settings
         self.settings = settingsService.load()
@@ -90,12 +116,111 @@ class AppState {
         }
         voiceTriggerStateObserver = observer
         deinitVoiceTriggerStateObserver = observer
+
+        // Observe the Generate-Notes hand-off from the recording modal.
+        // The notification carries `userInfo["transcript"]` (per #11/#12);
+        // we hop it into `SessionStore` immediately so PHI does not
+        // continue to ride the NotificationCenter boundary, then present
+        // the review window. This closes the leak gap noted on #11's
+        // hand-off comment to #13.
+        let clinicalObserver = NotificationCenter.default.addObserver(
+            forName: .clinicalNotesGenerateRequested,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            // Mirror the recording-modal poster's empty-guard
+            // (LiquidGlassRecordingModal.postGenerateNotesAndDismiss)
+            // as defence-in-depth. A future poster that bypasses the
+            // modal's guard must not produce a degenerate session here.
+            // Logs are structural-only (length / state); no PHI.
+            guard let transcript = notification.userInfo?["transcript"] as? String else {
+                AppLogger.app.error(
+                    "AppState: clinicalNotesGenerateRequested userInfo missing transcript"
+                )
+                return
+            }
+            guard !transcript.isEmpty else {
+                AppLogger.app.warning(
+                    "AppState: clinicalNotesGenerateRequested empty transcript — ignoring"
+                )
+                return
+            }
+            // The notification can be delivered from either MainActor or
+            // a background queue depending on the poster; hop explicitly
+            // before mutating MainActor-isolated state (concurrency.md §2).
+            Task { @MainActor [weak self] in
+                self?.handleClinicalNotesGenerateRequested(transcript: transcript)
+            }
+        }
+        clinicalNotesGenerateObserver = clinicalObserver
+        deinitClinicalNotesGenerateObserver = clinicalObserver
     }
 
     deinit {
         deinitLoadingTask?.cancel()
         if let observer = deinitVoiceTriggerStateObserver {
             NotificationCenter.default.removeObserver(observer)
+        }
+        if let observer = deinitClinicalNotesGenerateObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Clinical Notes (#13)
+
+    /// Handle the Generate-Notes hand-off. Builds a minimal
+    /// `RecordingSession` carrying the transcript, hops PHI into
+    /// `SessionStore`, seeds an empty `StructuredNotes` so the editor is
+    /// immediately interactive in the no-LLM path (production wiring of
+    /// `ClinicalNotesProcessor` lands in the same PR series as
+    /// `MLXGemmaProvider` per the comment on `sessionStore` above and
+    /// the `#18` blocker), then presents the review window.
+    ///
+    /// PHI: only the transcript length and "session started" structural
+    /// markers cross the log boundary. See
+    /// `.claude/references/phi-handling.md`.
+    private func handleClinicalNotesGenerateRequested(transcript: String) {
+        AppLogger.app.info(
+            "AppState: clinicalNotes hand-off length=\(transcript.count, privacy: .public)"
+        )
+        let language = settings.language.defaultLanguage
+        var recording = RecordingSession(
+            language: language,
+            state: .completed
+        )
+        recording.transcribedText = transcript
+
+        sessionStore.start(from: recording)
+        // Seed an empty draft so the SOAP editor is interactive without
+        // waiting on the LLM (the practitioner can compose from the raw
+        // transcript via the "View raw transcript" sheet). Once the LLM
+        // wiring lands, this seed will be replaced with the
+        // `ClinicalNotesProcessor.Outcome` payload before the window
+        // presents.
+        sessionStore.setDraftNotes(StructuredNotes())
+
+        ReviewWindowController.shared.present()
+    }
+
+    // MARK: - Manipulations loader
+
+    /// Load the bundled manipulations taxonomy. Surfaces decode / lookup
+    /// failures as a structural log + empty repository — the JSON's
+    /// presence is a `Package.swift` build-system invariant (#6), so a
+    /// runtime failure means a build went wrong rather than something
+    /// the user can fix. ReviewScreen renders an empty checklist in
+    /// that pathological case so the rest of the app still functions.
+    private static func loadManipulationsTaxonomy() -> ManipulationsRepository {
+        do {
+            return try ManipulationsRepository.loadFromBundle()
+        } catch {
+            // Structural log: the case description, no PHI anywhere.
+            AppLogger.app.error(
+                "AppState: failed to load manipulations taxonomy kind=\(String(describing: type(of: error)), privacy: .public)"
+            )
+            assertionFailure("AppState: manipulations taxonomy missing — see Package.swift .copy(...)")
+            return ManipulationsRepository(all: [])
         }
     }
 

--- a/Sources/Views/ClinicalNotes/ExcludedContentDrawer.swift
+++ b/Sources/Views/ClinicalNotes/ExcludedContentDrawer.swift
@@ -74,7 +74,10 @@ struct ExcludedContentDrawer: View {
         } else {
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 4) {
-                    ForEach(Array(entries.enumerated()), id: \.element) { _, entry in
+                    // Index-based ID so duplicate snippet strings don't
+                    // collide in `ForEach`'s identity tracking — content
+                    // alone is not unique.
+                    ForEach(Array(entries.enumerated()), id: \.offset) { _, entry in
                         excludedRow(entry)
                     }
                 }

--- a/Sources/Views/ClinicalNotes/ExcludedContentDrawer.swift
+++ b/Sources/Views/ClinicalNotes/ExcludedContentDrawer.swift
@@ -1,0 +1,130 @@
+// ExcludedContentDrawer.swift
+// macOS Local Speech-to-Text Application
+//
+// Collapsible drawer showing excluded snippets the LLM dropped from the
+// SOAP note. Each entry has a `↺` re-add button that hands the entry
+// back to `ReviewViewModel.reAddExcludedEntry(_:)` — the VM resolves
+// the destination field (default Subjective; last-focused-within-5s if
+// applicable) and updates `SessionStore`.
+//
+// PHI: every excluded snippet is patient data. View stays purely
+// presentational. Logging happens in the VM and is structural-only.
+
+import SwiftUI
+
+struct ExcludedContentDrawer: View {
+    @Bindable var viewModel: ReviewViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+
+            if viewModel.isExcludedDrawerOpen {
+                drawerBody
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .background(.ultraThinMaterial.opacity(0.4),
+                    in: RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .animation(
+            .spring(response: 0.5, dampingFraction: 0.7),
+            value: viewModel.isExcludedDrawerOpen
+        )
+        .accessibilityIdentifier("reviewScreen.excludedDrawer")
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        Button {
+            viewModel.toggleExcludedDrawer()
+        } label: {
+            HStack(spacing: 8) {
+                Text("Excluded")
+                    .font(.system(size: 11, weight: .semibold, design: .rounded))
+                    .tracking(0.6)
+                    .foregroundStyle(Color.iconPrimaryAdaptive)
+
+                Text("(\(viewModel.excludedRemainingCount))")
+                    .font(.system(size: 11, design: .rounded))
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Image(systemName: viewModel.isExcludedDrawerOpen ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(.isHeader)
+        .accessibilityIdentifier("reviewScreen.excludedDrawer.toggle")
+    }
+
+    // MARK: - Body
+
+    @ViewBuilder
+    private var drawerBody: some View {
+        let entries = viewModel.excludedEntries
+        if entries.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 4) {
+                    ForEach(Array(entries.enumerated()), id: \.element) { _, entry in
+                        excludedRow(entry)
+                    }
+                }
+                .padding(.horizontal, 6)
+                .padding(.bottom, 6)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        Text("Nothing excluded.")
+            .font(.system(size: 12))
+            .foregroundStyle(.tertiary)
+            .padding(.horizontal, 10)
+            .padding(.bottom, 8)
+            .accessibilityIdentifier("reviewScreen.excludedDrawer.empty")
+    }
+
+    private func excludedRow(_ entry: String) -> some View {
+        HStack(alignment: .top, spacing: 8) {
+            Text(quoted(entry))
+                .font(.system(size: 12))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button {
+                viewModel.reAddExcludedEntry(entry)
+            } label: {
+                Image(systemName: "arrow.uturn.left.circle")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.amberBright)
+            }
+            .buttonStyle(.plain)
+            .help("Re-add to \(viewModel.reAddTargetField().displayName)")
+            .accessibilityLabel("Re-add to \(viewModel.reAddTargetField().displayName)")
+            .accessibilityIdentifier("reviewScreen.excludedDrawer.row.readd")
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 6)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.clear)
+        )
+    }
+
+    /// Render the entry inside guillemet quotes for visual separation
+    /// from the surrounding chrome. Truncation handled by `lineLimit`.
+    private func quoted(_ entry: String) -> String {
+        "\u{201C}\(entry)\u{201D}"
+    }
+}

--- a/Sources/Views/ClinicalNotes/ManipulationsChecklist.swift
+++ b/Sources/Views/ClinicalNotes/ManipulationsChecklist.swift
@@ -1,0 +1,97 @@
+// ManipulationsChecklist.swift
+// macOS Local Speech-to-Text Application
+//
+// Right-pane manipulations checklist for `ReviewScreen` (#13). Renders
+// the static `ManipulationsRepository` taxonomy as a stable-ordered
+// list of toggles bound to `ReviewViewModel`.
+//
+// PHI: this view sees no PHI — manipulations are static taxonomy. The
+// selection state on `StructuredNotes.selectedManipulationIDs` is also
+// non-PHI metadata. The view stays purely presentational; logging is
+// owned by the VM.
+
+import SwiftUI
+
+/// Manipulations checklist. Stable-ordered per
+/// `ManipulationsRepository.all` — that ordering is a UI contract per
+/// the repository docs.
+struct ManipulationsChecklist: View {
+    @Bindable var viewModel: ReviewViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Manipulations")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .tracking(0.6)
+                .foregroundStyle(Color.iconPrimaryAdaptive)
+                .accessibilityAddTraits(.isHeader)
+
+            if viewModel.manipulationsList.isEmpty {
+                emptyTaxonomyBanner
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 4) {
+                        ForEach(viewModel.manipulationsList) { manipulation in
+                            manipulationRow(manipulation)
+                        }
+                    }
+                }
+            }
+        }
+        .accessibilityIdentifier("reviewScreen.manipulations")
+    }
+
+    /// Surface a structural-only banner when the taxonomy failed to
+    /// load from the bundle — the bundle resource is a `Package.swift`
+    /// build invariant (#6), so an empty taxonomy means a build went
+    /// wrong rather than something the practitioner can fix. Don't
+    /// silently render a blank checklist.
+    private var emptyTaxonomyBanner: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 12))
+                .foregroundStyle(Color.amberBright)
+            Text("Manipulations taxonomy not loaded — contact support before exporting.")
+                .font(.system(size: 12))
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(8)
+        .accessibilityIdentifier("reviewScreen.manipulations.emptyTaxonomyBanner")
+    }
+
+    private func manipulationRow(_ manipulation: Manipulation) -> some View {
+        let selected = viewModel.isManipulationSelected(id: manipulation.id)
+        return Button {
+            viewModel.toggleManipulation(id: manipulation.id)
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: selected ? "checkmark.square.fill" : "square")
+                    .font(.system(size: 14))
+                    .foregroundStyle(selected ? Color.amberPrimary : Color.iconSecondaryAdaptive)
+                    .frame(width: 18)
+
+                Text(manipulation.displayName)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(rowBackground(selected: selected))
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("reviewScreen.manipulations.row.\(manipulation.id)")
+        .accessibilityAddTraits(selected ? [.isSelected] : [])
+    }
+
+    private func rowBackground(selected: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(selected ? Color.amberLight.opacity(0.35) : Color.clear)
+    }
+}

--- a/Sources/Views/ClinicalNotes/RawTranscriptSheet.swift
+++ b/Sources/Views/ClinicalNotes/RawTranscriptSheet.swift
@@ -1,0 +1,67 @@
+// RawTranscriptSheet.swift
+// macOS Local Speech-to-Text Application
+//
+// Read-only sheet that surfaces the unmodified consultation transcript.
+// Triggered from `ReviewScreen` via "View raw transcript" — used both
+// as a sanity-check for the practitioner during edit, and as the
+// primary surface in the LLM-fallback path where `draftNotes` is empty.
+//
+// PHI: every visible character is patient data. The view is purely
+// presentational and contains no logging or external send paths.
+
+import SwiftUI
+
+struct RawTranscriptSheet: View {
+    let transcript: String
+    let onDismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+
+            Divider()
+
+            ScrollView {
+                Text(displayedText)
+                    .font(.system(size: 13))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(20)
+                    .textSelection(.enabled)
+                    .accessibilityIdentifier("reviewScreen.rawTranscript.body")
+            }
+            .frame(minHeight: 320)
+        }
+        .frame(minWidth: 520, minHeight: 420)
+        .background(.background)
+        .accessibilityIdentifier("reviewScreen.rawTranscript")
+    }
+
+    private var header: some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Raw transcript")
+                    .font(.system(size: 14, weight: .semibold, design: .rounded))
+                    .accessibilityAddTraits(.isHeader)
+                Text("Read-only — close this sheet to keep editing the SOAP note.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Button("Close", action: onDismiss)
+                .keyboardShortcut(.escape)
+                .accessibilityIdentifier("reviewScreen.rawTranscript.close")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+    }
+
+    /// Show a placeholder if the transcript is empty so the practitioner
+    /// is not staring at a blank pane.
+    private var displayedText: String {
+        transcript.isEmpty
+            ? "(No transcript captured for this session.)"
+            : transcript
+    }
+}

--- a/Sources/Views/ClinicalNotes/ReviewScreen.swift
+++ b/Sources/Views/ClinicalNotes/ReviewScreen.swift
@@ -1,0 +1,323 @@
+// ReviewScreen.swift
+// macOS Local Speech-to-Text Application
+//
+// Primary review + edit surface for a generated clinical note (#13).
+// Layout is locked per the EPIC #1 wireframe: frosted header (patient +
+// draft warning), two-column body (SOAP editor on the left, manipulations
+// checklist + excluded drawer on the right), action bar (View raw
+// transcript / Cancel / Export to Cliniko).
+//
+// Adheres to Warm Minimalism: `.ultraThinMaterial`, amber accents from
+// `Color+Theme.swift`, spring `(0.5, 0.7)` animations, minimal chrome.
+//
+// PHI: every SOAP field, manipulation choice, excluded snippet, and
+// transcript line is patient data. View stays purely presentational —
+// all logging is owned by `ReviewViewModel`. See
+// `.claude/references/phi-handling.md`.
+
+import SwiftUI
+
+/// Root SwiftUI surface for `ReviewWindow`. Built from a pre-instantiated
+/// `ReviewViewModel` (the actor-existential mitigation pattern documented
+/// in `.claude/references/concurrency.md` §1).
+struct ReviewScreen: View {
+
+    @Bindable var viewModel: ReviewViewModel
+
+    /// Shared focus state across the four SOAP editors. Powers ⌘1–⌘4
+    /// keyboard navigation (each of those shortcuts writes the matching
+    /// field into this state via the hidden command-buttons block).
+    @FocusState private var focusedField: SOAPField?
+
+    var body: some View {
+        ZStack {
+            background
+
+            VStack(spacing: 0) {
+                header
+
+                bodyPanel
+                    .padding(.horizontal, 20)
+                    .padding(.vertical, 16)
+
+                actionBar
+            }
+
+            // Hidden buttons that expose the keyboard shortcuts. Buttons
+            // are the only `View` form that registers a shortcut without
+            // also taking visible space — and being inside the visible
+            // hierarchy is required for the shortcut to fire (off-screen
+            // buttons are ignored). `frame(0,0)` + `hidden()` is the
+            // documented pattern.
+            shortcutSink
+        }
+        .frame(minWidth: 880, minHeight: 560)
+        .sheet(isPresented: $viewModel.isRawTranscriptSheetOpen) {
+            RawTranscriptSheet(
+                transcript: viewModel.transcript,
+                onDismiss: { viewModel.dismissRawTranscript() }
+            )
+        }
+        .onAppear {
+            // Ensure the practitioner can immediately start editing the
+            // most-used field without an extra click.
+            focusedField = .subjective
+            viewModel.noteFieldFocused(.subjective)
+        }
+        .accessibilityIdentifier("reviewScreen")
+    }
+
+    // MARK: - Background
+
+    private var background: some View {
+        // Subtle adaptive background so the panes have a parent surface
+        // distinct from the SwiftUI window's translucent backdrop.
+        Color.secondaryBackgroundAdaptive
+            .ignoresSafeArea()
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Clinical Notes Review")
+                    .font(.system(size: 16, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.primary)
+                    .accessibilityAddTraits(.isHeader)
+
+                Text(headerSubtitle)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            draftBadge
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Color.subtleBorderAdaptive)
+                .frame(height: 1)
+        }
+        .accessibilityIdentifier("reviewScreen.header")
+    }
+
+    private var headerSubtitle: String {
+        viewModel.hasDraft
+            ? "Review and edit the AI-drafted note before exporting."
+            : "No draft yet — compose the note from the raw transcript."
+    }
+
+    private var draftBadge: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Color.amberBright)
+            Text("Draft")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .foregroundStyle(.primary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+        .background(
+            Capsule().fill(Color.amberLight.opacity(0.4))
+        )
+        .accessibilityIdentifier("reviewScreen.draftBadge")
+    }
+
+    // MARK: - Body
+
+    private var bodyPanel: some View {
+        HStack(alignment: .top, spacing: 16) {
+            soapColumn
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            sidebarColumn
+                .frame(width: 280)
+        }
+    }
+
+    // MARK: SOAP column
+
+    private var soapColumn: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                ForEach(SOAPField.allCases, id: \.self) { field in
+                    SOAPSectionEditor(
+                        field: field,
+                        text: viewModel.binding(for: field),
+                        focusBinding: $focusedField,
+                        onFocus: { viewModel.noteFieldFocused(field) }
+                    )
+                }
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.cardBackgroundAdaptive)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.subtleBorderAdaptive, lineWidth: 1)
+            )
+            .shadow(color: Color.cardShadowAdaptive, radius: 6, x: 0, y: 2)
+        }
+        .accessibilityIdentifier("reviewScreen.soapColumn")
+    }
+
+    // MARK: Sidebar column
+
+    private var sidebarColumn: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ManipulationsChecklist(viewModel: viewModel)
+                .padding(12)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(Color.cardBackgroundAdaptive)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(Color.subtleBorderAdaptive, lineWidth: 1)
+                )
+
+            ExcludedContentDrawer(viewModel: viewModel)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(Color.subtleBorderAdaptive, lineWidth: 1)
+                )
+        }
+        .accessibilityIdentifier("reviewScreen.sidebarColumn")
+    }
+
+    // MARK: - Action bar
+
+    private var actionBar: some View {
+        HStack(spacing: 12) {
+            Button {
+                viewModel.presentRawTranscript()
+            } label: {
+                Label("View raw transcript", systemImage: "doc.text.magnifyingglass")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .buttonStyle(.bordered)
+            .disabled(!viewModel.hasTranscript)
+            .accessibilityIdentifier("reviewScreen.actions.viewRawTranscript")
+
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Color.errorRed)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("reviewScreen.errorBanner")
+            }
+
+            Spacer()
+
+            Button("Cancel") {
+                viewModel.cancelReview()
+            }
+            .keyboardShortcut(.cancelAction)
+            .accessibilityIdentifier("reviewScreen.actions.cancel")
+
+            Button {
+                viewModel.triggerExport()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.up.forward.app.fill")
+                    Text("Export to Cliniko")
+                }
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
+                .padding(.horizontal, 4)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(Color.amberPrimary)
+            .disabled(!viewModel.canExport)
+            .accessibilityIdentifier("reviewScreen.actions.export")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.subtleBorderAdaptive)
+                .frame(height: 1)
+        }
+        .accessibilityIdentifier("reviewScreen.actionBar")
+    }
+
+    // MARK: - Keyboard shortcut sink
+
+    /// Hidden command buttons that own the ⌘1–⌘4 + ⌘E shortcuts. Each
+    /// shortcut focuses the matching SOAP editor (or triggers Export).
+    /// Kept as a separate group so the visible chrome above stays
+    /// shortcut-free.
+    private var shortcutSink: some View {
+        Group {
+            ForEach(SOAPField.allCases, id: \.self) { field in
+                Button("Focus \(field.displayName)") {
+                    // SOAPSectionEditor's `onChange(of: focusBinding.wrappedValue)`
+                    // will invoke `viewModel.noteFieldFocused(field)` when this
+                    // assignment lands, so we deliberately do not double-fire it.
+                    focusedField = field
+                }
+                .keyboardShortcut(shortcutKey(for: field), modifiers: [.command])
+                .frame(width: 0, height: 0)
+                .opacity(0)
+                .accessibilityHidden(true)
+            }
+
+            Button("Export") {
+                viewModel.triggerExport()
+            }
+            .keyboardShortcut("e", modifiers: [.command])
+            .frame(width: 0, height: 0)
+            .opacity(0)
+            .disabled(!viewModel.canExport)
+            .accessibilityHidden(true)
+        }
+    }
+
+    private func shortcutKey(for field: SOAPField) -> KeyEquivalent {
+        switch field {
+        case .subjective: return "1"
+        case .objective: return "2"
+        case .assessment: return "3"
+        case .plan: return "4"
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Review Screen") {
+    let store = SessionStore()
+    var session = RecordingSession(language: "en", state: .completed)
+    session.transcribedText = "Patient reports R-neck pain x 3/52, worse with rotation. Cervical screening normal. Plan diversified HVLA C5-C6 + Activator T2-T4."
+    store.start(from: session)
+    var notes = StructuredNotes()
+    notes.subjective = "Pt reports R-neck pain x 3/52."
+    notes.objective = "C5/C6 restriction, hypertonic R upper trap."
+    notes.assessment = "Mechanical cervical dysfunction."
+    notes.plan = "HVLA C5-C6, Activator T2-T4. Re-eval next visit."
+    notes.excluded = ["Weather chat at start of consult.", "Patient mentioned kids and dog.", "Brief parking discussion."]
+    notes.selectedManipulationIDs = ["diversified_hvla", "activator"]
+    store.setDraftNotes(notes)
+
+    let manipulations = ManipulationsRepository(all: [
+        Manipulation(id: "diversified_hvla", displayName: "Diversified HVLA", clinikoCode: nil),
+        Manipulation(id: "gonstead", displayName: "Gonstead", clinikoCode: nil),
+        Manipulation(id: "activator", displayName: "Activator", clinikoCode: nil),
+        Manipulation(id: "thompson", displayName: "Thompson", clinikoCode: nil),
+        Manipulation(id: "sot", displayName: "SOT", clinikoCode: nil)
+    ])
+
+    return ReviewScreen(viewModel: ReviewViewModel(
+        sessionStore: store,
+        manipulations: manipulations
+    ))
+    .frame(width: 1100, height: 720)
+}

--- a/Sources/Views/ClinicalNotes/ReviewViewModel.swift
+++ b/Sources/Views/ClinicalNotes/ReviewViewModel.swift
@@ -1,0 +1,406 @@
+// ReviewViewModel.swift
+// macOS Local Speech-to-Text Application
+//
+// View model behind the ReviewScreen (#13). Owns:
+//   - SessionStore-backed bindings for the four SOAP fields,
+//   - manipulation-checklist selection state,
+//   - excluded-content re-add routing (default Subjective; last-focused
+//     SOAP field if focused within the last `reAddTargetWindow` seconds),
+//   - the raw-transcript sheet and excluded drawer toggle states,
+//   - cancel + export gestures (the latter posts a notification handed
+//     off to #14's export flow).
+//
+// PHI: every SOAP field, manipulation selection, and excluded snippet
+// reaches through this view model. Logging is structural-only —
+// counts and structural state, never bodies. See
+// `.claude/references/phi-handling.md`.
+
+import Foundation
+import Observation
+import OSLog
+import SwiftUI
+
+/// One of the four SOAP fields. Single source of truth for: keyboard-focus
+/// routing (⌘1–⌘4), re-add destination resolution, presentation labels,
+/// accessibility identifiers, and the read/write `WritableKeyPath` into
+/// `StructuredNotes`. Adding a fifth section means: add the case, add a
+/// branch to `notesKeyPath`, and the compiler will surface every other
+/// site that needs updating.
+///
+/// `Int` raw value reserved for ordered iteration via `allCases` — not a
+/// stable serialisation contract (PHI types in this project are
+/// session-only and never persisted).
+enum SOAPField: Int, CaseIterable, Sendable, Hashable {
+    case subjective
+    case objective
+    case assessment
+    case plan
+
+    /// User-facing section label.
+    var displayName: String {
+        switch self {
+        case .subjective: return "Subjective"
+        case .objective: return "Objective"
+        case .assessment: return "Assessment"
+        case .plan: return "Plan"
+        }
+    }
+
+    /// Stable accessibility identifier suffix. Also used as a structural
+    /// log key (`OSLog` `privacy: .public`) — both the test framework
+    /// and the log alphabet are stable contracts on this string.
+    var accessibilityID: String {
+        switch self {
+        case .subjective: return "subjective"
+        case .objective: return "objective"
+        case .assessment: return "assessment"
+        case .plan: return "plan"
+        }
+    }
+
+    /// Writable projection into `StructuredNotes` for the matching SOAP
+    /// string. Lets `value(for:)` and `setValue(_:for:)` collapse to a
+    /// single line each, and centralises the SOAPField↔StructuredNotes
+    /// mapping in one switch — adding a section can only happen by
+    /// adding both an enum case and a key path on the same line.
+    var notesKeyPath: WritableKeyPath<StructuredNotes, String> {
+        switch self {
+        case .subjective: return \.subjective
+        case .objective: return \.objective
+        case .assessment: return \.assessment
+        case .plan: return \.plan
+        }
+    }
+}
+
+/// `@Observable @MainActor` view model for `ReviewScreen` (#13).
+///
+/// Service references are `@ObservationIgnored` — `SessionStore` is a
+/// `@MainActor`-isolated `@Observable` class today, but storing any
+/// non-value reference on another `@Observable` triggers the actor-
+/// existential scan documented in `.claude/references/concurrency.md` §1
+/// (the same crash pattern that bit `RecordingViewModel`). The annotation
+/// is correct prophylactic hygiene.
+///
+/// Lifetime: this VM is constructed by `ReviewWindowController` once per
+/// window presentation and torn down when the window closes. It does not
+/// outlive a clinical session.
+@Observable
+@MainActor
+final class ReviewViewModel {
+
+    // MARK: - Observed state
+
+    /// Last SOAP field the practitioner focused **and when**, used for
+    /// re-add routing. The pair is a single optional so the two halves
+    /// cannot drift apart — illegal-state-by-design.
+    private(set) var lastFocus: FocusSnapshot?
+
+    /// Whether the excluded-content drawer is expanded. Defaults to
+    /// expanded so the practitioner sees the available re-add affordances
+    /// without an extra interaction on first render.
+    /// Public-mutable so SwiftUI two-way bindings (`@Bindable`) work; do
+    /// not mutate from non-view code.
+    var isExcludedDrawerOpen: Bool = true
+
+    /// Whether the read-only raw-transcript sheet is visible.
+    /// Public-mutable so SwiftUI two-way bindings (`@Bindable`) work; do
+    /// not mutate from non-view code.
+    var isRawTranscriptSheetOpen: Bool = false
+
+    /// Last surfaced error banner, if any. Cleared on retry / dismiss.
+    /// Public-mutable so SwiftUI two-way bindings (`@Bindable`) work; do
+    /// not mutate from non-view code.
+    var errorMessage: String?
+
+    // MARK: - Dependencies
+
+    @ObservationIgnored let sessionStore: SessionStore
+    @ObservationIgnored private let manipulationsRepo: ManipulationsRepository
+
+    @ObservationIgnored private let now: @Sendable () -> Date
+    @ObservationIgnored private let reAddTargetWindow: TimeInterval
+    @ObservationIgnored private let logger = Logger(
+        subsystem: "com.speechtotext",
+        category: "ReviewViewModel"
+    )
+
+    /// Tuple of the most recent focused field + its timestamp. See
+    /// `lastFocus` above.
+    struct FocusSnapshot: Sendable, Equatable {
+        let field: SOAPField
+        let at: Date
+    }
+
+    // MARK: - Init
+
+    /// - Parameters:
+    ///   - sessionStore: source of truth for `draftNotes` + selection state.
+    ///   - manipulations: static taxonomy rendered as the right-pane checklist.
+    ///   - reAddTargetWindow: how recently a SOAP field must have been
+    ///     focused for a re-added excluded entry to land there instead of
+    ///     the default `.subjective`. Default 5 s per the issue spec.
+    ///   - now: clock for the focus window. Tests pass a fixed clock.
+    init(
+        sessionStore: SessionStore,
+        manipulations: ManipulationsRepository,
+        reAddTargetWindow: TimeInterval = 5.0,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.sessionStore = sessionStore
+        self.manipulationsRepo = manipulations
+        self.reAddTargetWindow = reAddTargetWindow
+        self.now = now
+    }
+
+    // MARK: - Manipulations accessor
+
+    /// Stable-ordered taxonomy rendered by the right-pane checklist.
+    /// Hides the underlying `ManipulationsRepository` from view code so
+    /// the VM is the only thing that knows about the repository.
+    var manipulationsList: [Manipulation] {
+        manipulationsRepo.all
+    }
+
+    // MARK: - Read accessors
+
+    /// The unmodified transcript captured by FluidAudio. Rendered
+    /// read-only by `RawTranscriptSheet` and used as the empty-draft
+    /// fallback prompt copy.
+    var transcript: String {
+        sessionStore.active?.recordingSession.transcribedText ?? ""
+    }
+
+    /// Whether the active session has a non-empty transcript. Used to
+    /// gate "View raw transcript".
+    var hasTranscript: Bool {
+        !transcript.isEmpty
+    }
+
+    /// Excluded snippets that the practitioner has not yet re-added.
+    /// Re-added entries hide from the drawer per the wireframe. Order
+    /// preserved from the LLM output.
+    var excludedEntries: [String] {
+        guard let active = sessionStore.active,
+              let notes = active.draftNotes else { return [] }
+        let readded = Set(active.excludedReAdded)
+        return notes.excluded.filter { !readded.contains($0) }
+    }
+
+    /// Number of excluded entries still available to re-add. Drives the
+    /// "Excluded (n)" drawer header.
+    var excludedRemainingCount: Int { excludedEntries.count }
+
+    /// Whether the export action is enabled. The patient picker (#9) is
+    /// hosted from the export-flow sheet (#14); ⌘E is gated until a
+    /// patient is selected upstream.
+    var canExport: Bool {
+        sessionStore.active?.selectedPatientID != nil
+    }
+
+    /// Whether `draftNotes` is `nil` — the LLM either hasn't filled it
+    /// in yet or fell back via `ClinicalNotesProcessor.Outcome
+    /// .rawTranscriptFallback`. The screen renders a "draft from raw
+    /// transcript" affordance in that state.
+    var hasDraft: Bool {
+        sessionStore.active?.draftNotes != nil
+    }
+
+    // MARK: - SOAP field accessors
+
+    /// Current value for `field`. Empty string when no draft exists yet
+    /// (or no active session, which is unreachable from a presented
+    /// `ReviewWindow` but defended against here for the idle-timeout
+    /// edge case — see `setValue(_:for:)`).
+    func value(for field: SOAPField) -> String {
+        guard let notes = sessionStore.active?.draftNotes else { return "" }
+        return notes[keyPath: field.notesKeyPath]
+    }
+
+    /// Write a new value into `field`. Lazily seeds an empty
+    /// `StructuredNotes` if the LLM hasn't populated one yet — keeps
+    /// the UI editable in the raw-transcript-fallback path.
+    ///
+    /// Surfaces a session-loss banner when no active session exists.
+    /// In the normal flow this is unreachable (the window only opens
+    /// after `AppState.handleClinicalNotesGenerateRequested` has called
+    /// `sessionStore.start(from:)`), but the
+    /// `SessionStore.checkIdleTimeout()` path can drop `active` while a
+    /// review is on screen — in which case every keystroke would
+    /// otherwise vanish silently. The banner is the visible signal that
+    /// the doctor's recent edits aren't landing.
+    func setValue(_ value: String, for field: SOAPField) {
+        guard let active = sessionStore.active else {
+            // PHI-safe: only the field id and an "expired" sentinel.
+            logger.error(
+                "ReviewViewModel.setValue dropped — no active session field=\(field.accessibilityID, privacy: .public)"
+            )
+            errorMessage = "Session expired — please cancel and re-record."
+            return
+        }
+        var notes = active.draftNotes ?? StructuredNotes()
+        notes[keyPath: field.notesKeyPath] = value
+        sessionStore.setDraftNotes(notes)
+    }
+
+    /// Two-way `Binding<String>` for SwiftUI text editors. Writes hop
+    /// through `setValue(_:for:)` so every keystroke is reflected in
+    /// `SessionStore.draftNotes` (AC item: "All text edits are reflected
+    /// in `SessionStore.draftNotes` in real time").
+    ///
+    /// Strong `[self]` capture is intentional: the VM's lifetime is
+    /// bounded by `ReviewWindow.viewModel` (which is `let`), so when the
+    /// window tears down the bindings die with it. Using `[weak self]`
+    /// would force every binding read to handle `nil` defensively for
+    /// no real benefit.
+    func binding(for field: SOAPField) -> Binding<String> {
+        Binding<String>(
+            get: { [self] in self.value(for: field) },
+            set: { [self] newValue in self.setValue(newValue, for: field) }
+        )
+    }
+
+    // MARK: - Manipulation checklist
+
+    /// Whether the given manipulation id is currently selected on the draft.
+    func isManipulationSelected(id: String) -> Bool {
+        sessionStore.active?.draftNotes?.selectedManipulationIDs.contains(id) ?? false
+    }
+
+    /// Toggle a manipulation's selection. Surfaces a session-expired
+    /// banner without an active session (see `setValue` for the
+    /// idle-timeout rationale). Lazily seeds an empty `StructuredNotes`
+    /// if necessary so the checklist works in the
+    /// raw-transcript-fallback path.
+    func toggleManipulation(id: String) {
+        guard let active = sessionStore.active else {
+            logger.error(
+                "ReviewViewModel.toggleManipulation dropped — no active session"
+            )
+            errorMessage = "Session expired — please cancel and re-record."
+            return
+        }
+        var notes = active.draftNotes ?? StructuredNotes()
+        if let existingIndex = notes.selectedManipulationIDs.firstIndex(of: id) {
+            notes.selectedManipulationIDs.remove(at: existingIndex)
+        } else {
+            notes.selectedManipulationIDs.append(id)
+        }
+        sessionStore.setDraftNotes(notes)
+    }
+
+    // MARK: - Focus tracking
+
+    /// Called by SOAPSectionEditor when its TextEditor takes focus. The
+    /// timestamp is what `reAddTargetField` consults to decide whether
+    /// the practitioner's "current" field should win over the default.
+    func noteFieldFocused(_ field: SOAPField) {
+        lastFocus = FocusSnapshot(field: field, at: now())
+        sessionStore.touch()
+    }
+
+    /// Resolves the destination for a re-added excluded entry.
+    ///
+    /// - Returns: the SOAP field focused within `reAddTargetWindow`
+    ///   seconds of `now()`, or `.subjective` as the documented default.
+    func reAddTargetField() -> SOAPField {
+        guard let snapshot = lastFocus,
+              now().timeIntervalSince(snapshot.at) <= reAddTargetWindow else {
+            return .subjective
+        }
+        return snapshot.field
+    }
+
+    // MARK: - Re-add an excluded entry
+
+    /// Move `entry` from the excluded drawer into a SOAP field. The entry
+    /// is appended (with a blank-line separator if the destination is
+    /// already non-empty) and recorded in `SessionStore.excludedReAdded`
+    /// so the drawer hides it on the next render.
+    ///
+    /// PHI: structural log only — count of entries before and after, no
+    /// content.
+    func reAddExcludedEntry(_ entry: String) {
+        guard sessionStore.active != nil else {
+            logger.error(
+                "ReviewViewModel.reAddExcludedEntry dropped — no active session"
+            )
+            errorMessage = "Session expired — please cancel and re-record."
+            return
+        }
+        let target = reAddTargetField()
+        let existing = value(for: target)
+        let combined: String
+        if existing.isEmpty {
+            combined = entry
+        } else {
+            combined = "\(existing)\n\n\(entry)"
+        }
+        setValue(combined, for: target)
+        sessionStore.markExcludedReAdded(entry)
+        logger.info(
+            // PHI-safe: only the target field name + remaining-excluded count.
+            "ReviewViewModel: re-added excluded entry target=\(target.accessibilityID, privacy: .public) remaining=\(self.excludedRemainingCount, privacy: .public)"
+        )
+    }
+
+    // MARK: - Drawer / sheet toggles
+
+    func toggleExcludedDrawer() {
+        isExcludedDrawerOpen.toggle()
+    }
+
+    func presentRawTranscript() {
+        guard hasTranscript else { return }
+        isRawTranscriptSheetOpen = true
+    }
+
+    func dismissRawTranscript() {
+        isRawTranscriptSheetOpen = false
+    }
+
+    // MARK: - Lifecycle gestures
+
+    /// Cancel review. Drops the active session — PHI cleared from the
+    /// store — and posts the dismiss notification so
+    /// `ReviewWindowController` closes the window. The notification
+    /// carries `self` as the `object` so observers can filter against
+    /// concurrent test fixtures or future multiple-VM scenarios.
+    func cancelReview() {
+        logger.info("ReviewViewModel: cancelReview")
+        sessionStore.clear()
+        NotificationCenter.default.post(name: .reviewScreenDidDismiss, object: self)
+    }
+
+    /// Trigger the export flow (#14). Posts a notification with no PHI in
+    /// `userInfo` — the export-flow VM reads patient + appointment +
+    /// `draftNotes` directly from `SessionStore`, which is the single
+    /// source of truth. The notification carries `self` as the `object`
+    /// so observers can filter against concurrent fixtures.
+    func triggerExport() {
+        guard canExport else {
+            logger.info("ReviewViewModel: triggerExport blocked — no patient selected")
+            errorMessage = "Select a patient before exporting."
+            return
+        }
+        logger.info("ReviewViewModel: triggerExport")
+        NotificationCenter.default.post(
+            name: .clinicalNotesExportRequested,
+            object: self
+        )
+    }
+}
+
+// MARK: - Notification names
+
+extension Notification.Name {
+    /// Posted by `ReviewViewModel.cancelReview()` and on window-close so
+    /// `ReviewWindowController` can drop its strong reference. Mirrors
+    /// the `mainWindowDidClose` pattern in `MainWindow.swift`.
+    static let reviewScreenDidDismiss = Notification.Name("reviewScreenDidDismiss")
+
+    /// Posted by `ReviewViewModel.triggerExport()`. Picked up by the
+    /// export-flow presenter that lands in #14. Carries no PHI in
+    /// `userInfo` — `SessionStore` is the source of truth.
+    static let clinicalNotesExportRequested = Notification.Name("clinicalNotesExportRequested")
+}

--- a/Sources/Views/ClinicalNotes/ReviewViewModel.swift
+++ b/Sources/Views/ClinicalNotes/ReviewViewModel.swift
@@ -180,11 +180,31 @@ final class ReviewViewModel {
     /// Excluded snippets that the practitioner has not yet re-added.
     /// Re-added entries hide from the drawer per the wireframe. Order
     /// preserved from the LLM output.
+    ///
+    /// Duplicate handling is count-based: if the LLM emits the same
+    /// snippet twice and the practitioner re-adds it once, one
+    /// remaining copy stays in the drawer. This relies on
+    /// `SessionStore.excludedReAdded` faithfully appending each re-add;
+    /// the dedup guard inside `markExcludedReAdded` collapses repeated
+    /// re-adds of the same string into a single audit entry, so the
+    /// "re-add one of two duplicates" scenario above effectively
+    /// re-adds the first match and leaves any remaining copies in the
+    /// drawer until the audit guard is relaxed in a follow-up.
     var excludedEntries: [String] {
         guard let active = sessionStore.active,
               let notes = active.draftNotes else { return [] }
-        let readded = Set(active.excludedReAdded)
-        return notes.excluded.filter { !readded.contains($0) }
+        var remainingReAdds = active.excludedReAdded.reduce(into: [String: Int]()) { acc, snippet in
+            acc[snippet, default: 0] += 1
+        }
+        var result: [String] = []
+        for entry in notes.excluded {
+            if let count = remainingReAdds[entry], count > 0 {
+                remainingReAdds[entry] = count - 1
+            } else {
+                result.append(entry)
+            }
+        }
+        return result
     }
 
     /// Number of excluded entries still available to re-add. Drives the
@@ -318,6 +338,11 @@ final class ReviewViewModel {
     /// already non-empty) and recorded in `SessionStore.excludedReAdded`
     /// so the drawer hides it on the next render.
     ///
+    /// Trailing whitespace on the existing field is normalised before
+    /// the separator is added so re-adding twice doesn't pile up
+    /// triple-newlines (matters for fields the practitioner has
+    /// already edited).
+    ///
     /// PHI: structural log only — count of entries before and after, no
     /// content.
     func reAddExcludedEntry(_ entry: String) {
@@ -329,12 +354,12 @@ final class ReviewViewModel {
             return
         }
         let target = reAddTargetField()
-        let existing = value(for: target)
+        let trimmedExisting = trimmedTrailingWhitespace(value(for: target))
         let combined: String
-        if existing.isEmpty {
+        if trimmedExisting.isEmpty {
             combined = entry
         } else {
-            combined = "\(existing)\n\n\(entry)"
+            combined = "\(trimmedExisting)\n\n\(entry)"
         }
         setValue(combined, for: target)
         sessionStore.markExcludedReAdded(entry)
@@ -342,6 +367,23 @@ final class ReviewViewModel {
             // PHI-safe: only the target field name + remaining-excluded count.
             "ReviewViewModel: re-added excluded entry target=\(target.accessibilityID, privacy: .public) remaining=\(self.excludedRemainingCount, privacy: .public)"
         )
+    }
+
+    /// Strip trailing whitespace and newlines without touching leading
+    /// or interior whitespace (which the practitioner may have edited
+    /// intentionally). Stays purely structural — no PHI escapes this
+    /// function.
+    private nonisolated func trimmedTrailingWhitespace(_ text: String) -> String {
+        var end = text.endIndex
+        while end > text.startIndex {
+            let prior = text.index(before: end)
+            if text[prior].isWhitespace || text[prior].isNewline {
+                end = prior
+            } else {
+                break
+            }
+        }
+        return String(text[text.startIndex..<end])
     }
 
     // MARK: - Drawer / sheet toggles

--- a/Sources/Views/ClinicalNotes/ReviewWindow.swift
+++ b/Sources/Views/ClinicalNotes/ReviewWindow.swift
@@ -1,0 +1,255 @@
+// ReviewWindow.swift
+// macOS Local Speech-to-Text Application
+//
+// `NSWindow` host for `ReviewScreen` (#13). Mirrors the
+// `MainWindow` / `MainWindowController` pattern: a singleton controller
+// owned by `AppDelegate`-equivalent host code, with the view model
+// constructed externally and passed into the SwiftUI root (the
+// actor-existential mitigation pattern from
+// `.claude/references/concurrency.md` §1).
+//
+// `AppState` configures the controller once on launch (`configure(...)`)
+// with its own `SessionStore` + a bundle-loaded `ManipulationsRepository`,
+// so callers can `present()` without further plumbing.
+
+import AppKit
+import Foundation
+import OSLog
+import SwiftUI
+
+// MARK: - ReviewWindow
+
+@MainActor
+final class ReviewWindow: NSObject, NSWindowDelegate {
+    // MARK: - Properties
+
+    private var window: NSWindow?
+    private let viewModel: ReviewViewModel
+
+    private static let initialWidth: CGFloat = 1100
+    private static let initialHeight: CGFloat = 720
+    private static let minimumWidth: CGFloat = 880
+    private static let minimumHeight: CGFloat = 560
+    private static let windowTitle = "Clinical Notes Review"
+
+    // MARK: - Init
+
+    init(viewModel: ReviewViewModel) {
+        self.viewModel = viewModel
+        super.init()
+    }
+
+    // MARK: - Public
+
+    /// Present the window and bring it to front.
+    func show() {
+        if window == nil {
+            window = makeWindow()
+        }
+        guard let window else { return }
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(nil)
+    }
+
+    /// Close + release the underlying NSWindow. Idempotent.
+    func close() {
+        window?.delegate = nil
+        window?.close()
+        window = nil
+    }
+
+    var isVisible: Bool {
+        window?.isVisible ?? false
+    }
+
+    // MARK: - NSWindowDelegate
+
+    func windowWillClose(_ notification: Notification) {
+        // PHI chokepoint. Whatever path closed the window (Cancel, ⎋,
+        // title-bar X, or a future export-flow auto-close), the session
+        // does not survive the visible surface. `SessionStore.clear()`
+        // is idempotent — `cancelReview` and the export-flow may have
+        // already cleared, in which case this is a no-op. This satisfies
+        // the AGENTS.md "PHI in-memory only, plus the HTTPS body at the
+        // moment of POST to Cliniko" rule for the title-bar X path that
+        // bypasses every in-app gesture.
+        viewModel.sessionStore.clear()
+
+        // Drop the delegate before clearing the reference (mirrors
+        // MainWindow.swift HIGH-9 fix). Then notify the controller so it
+        // can drop its strong ref and any further `.reviewScreenDidDismiss`
+        // listeners (export-flow / AppState) get the close signal.
+        window?.delegate = nil
+        window = nil
+        NotificationCenter.default.post(name: .reviewScreenDidDismiss, object: nil)
+    }
+
+    // MARK: - Private
+
+    private func makeWindow() -> NSWindow {
+        let newWindow = NSWindow(
+            contentRect: NSRect(
+                x: 0,
+                y: 0,
+                width: Self.initialWidth,
+                height: Self.initialHeight
+            ),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+
+        newWindow.delegate = self
+        newWindow.title = Self.windowTitle
+        newWindow.identifier = NSUserInterfaceItemIdentifier("reviewWindow")
+        newWindow.titlebarAppearsTransparent = false
+        newWindow.titleVisibility = .visible
+        // PHI: window state restoration is OFF so transcript / draft note
+        // content cannot survive in NSWindow restoration archives. See
+        // AGENTS.md "PHI in-memory only" rule.
+        newWindow.isRestorable = false
+        newWindow.minSize = NSSize(width: Self.minimumWidth, height: Self.minimumHeight)
+        // `.normal` (vs. the recording modal's `.floating`): this is a
+        // long-form editor, not a transient capture overlay.
+        newWindow.level = .normal
+        newWindow.animationBehavior = .documentWindow
+
+        let rootView = ReviewScreen(viewModel: viewModel)
+        newWindow.contentView = NSHostingView(rootView: rootView)
+        newWindow.center()
+
+        return newWindow
+    }
+}
+
+// MARK: - ReviewWindowController
+
+/// Singleton controller for `ReviewWindow`. Configured once by
+/// `AppState.init` with a `SessionStore` + `ManipulationsRepository`;
+/// `.clinicalNotesGenerateRequested` triggers `present()`.
+@MainActor
+final class ReviewWindowController {
+    // MARK: - Singleton
+
+    static let shared = ReviewWindowController()
+
+    // MARK: - Properties
+
+    private var window: ReviewWindow?
+    private var sessionStore: SessionStore?
+    private var manipulations: ManipulationsRepository?
+    private var dismissObserver: NSObjectProtocol?
+
+    private let logger = Logger(
+        subsystem: "com.speechtotext",
+        category: "ReviewWindowController"
+    )
+
+    // MARK: - Init
+
+    private init() {
+        // Listen for dismiss so we drop the strong ref to the window when
+        // it closes (whether via Cancel, ⎋, or the title-bar close button).
+        // Mirrors the `mainWindowDidClose` pattern in `MainWindow.swift`.
+        dismissObserver = NotificationCenter.default.addObserver(
+            forName: .reviewScreenDidDismiss,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            // Notification handlers are not MainActor-isolated even with a
+            // .main queue; hop explicitly so MainActor-isolated state is
+            // safe to mutate per `.claude/references/concurrency.md` §2.
+            Task { @MainActor [weak self] in
+                self?.handleDismissNotification()
+            }
+        }
+    }
+
+    deinit {
+        // Singleton: this `deinit` is unreachable in production. The
+        // observer is registered for the process lifetime by design,
+        // matching `MainWindowController.shared`. Cleanup runs only in
+        // tests that recreate the singleton via reflection or in
+        // hypothetical future de-singleton-isation.
+        if let observer = dismissObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    // MARK: - Configuration
+
+    /// Wire the controller with its dependencies. Called once by
+    /// `AppState.init`; subsequent calls overwrite (so tests / reset
+    /// flows can reconfigure cleanly).
+    func configure(
+        sessionStore: SessionStore,
+        manipulations: ManipulationsRepository
+    ) {
+        self.sessionStore = sessionStore
+        self.manipulations = manipulations
+    }
+
+    /// Whether `configure(...)` has been called. Tests use this to
+    /// guard against double-presentation in shared-state scenarios.
+    var isConfigured: Bool {
+        sessionStore != nil && manipulations != nil
+    }
+
+    // MARK: - Presentation
+
+    /// Open the review window. Constructs the `ReviewViewModel` outside
+    /// the SwiftUI root to mirror the actor-existential mitigation
+    /// pattern in `LiquidGlassRecordingModal` / `RecordingViewModel`.
+    func present() {
+        guard let sessionStore, let manipulations else {
+            // Configure-before-present is an AppState-init contract.
+            // Surface as a structural log + assertion so misconfiguration
+            // surfaces in DEBUG / tests without crashing release.
+            logger.error("ReviewWindowController.present called before configure")
+            assertionFailure("ReviewWindowController.present called before configure")
+            return
+        }
+
+        // Idempotent: an existing window just gets brought forward.
+        if let existing = window {
+            existing.show()
+            return
+        }
+
+        let viewModel = ReviewViewModel(
+            sessionStore: sessionStore,
+            manipulations: manipulations
+        )
+        let newWindow = ReviewWindow(viewModel: viewModel)
+        newWindow.show()
+        window = newWindow
+        logger.info("ReviewWindowController: presented review window")
+    }
+
+    /// Programmatically close the window. Triggers the same dismiss
+    /// notification path as the user-initiated close.
+    func close() {
+        window?.close()
+        window = nil
+    }
+
+    var isPresented: Bool {
+        window?.isVisible ?? false
+    }
+
+    // MARK: - Private
+
+    private func handleDismissNotification() {
+        // Two paths converge here:
+        //   1. User-driven cancel via `ReviewViewModel.cancelReview` —
+        //      window is still alive, we must close it. `close()` fires
+        //      AppKit's `windowWillClose`, which posts a second dismiss
+        //      notification; the second pass through this handler hits
+        //      the already-nil branch (no-op).
+        //   2. Title-bar X / programmatic close — `windowWillClose` has
+        //      already nilled `self.window`, so `close()` is a no-op.
+        // Both ReviewWindow.close and NSWindow.close are idempotent.
+        window?.close()
+        window = nil
+    }
+}

--- a/Sources/Views/ClinicalNotes/SOAPSectionEditor.swift
+++ b/Sources/Views/ClinicalNotes/SOAPSectionEditor.swift
@@ -1,0 +1,112 @@
+// SOAPSectionEditor.swift
+// macOS Local Speech-to-Text Application
+//
+// Single SOAP section editor used by `ReviewScreen` (#13). Renders a
+// section header, an editable `TextEditor` bound to `ReviewViewModel`,
+// and propagates focus back to the VM so re-add routing can find the
+// last-touched field.
+//
+// PHI: the bound text is patient data. The view is purely
+// presentational — no logging, no telemetry. See
+// `.claude/references/phi-handling.md`.
+
+import SwiftUI
+
+/// One editable SOAP section. The host (`ReviewScreen`) owns the
+/// `@FocusState` and binds it through; this keeps a single SwiftUI
+/// focus chain across all four sections so ⌘1–⌘4 can route focus
+/// without each editor maintaining its own state.
+struct SOAPSectionEditor: View {
+
+    let field: SOAPField
+
+    /// Binding into the practitioner-edited string. Reads / writes hop
+    /// through `SessionStore` via `ReviewViewModel.binding(for:)`.
+    @Binding var text: String
+
+    /// Shared focus chain across the four SOAP fields.
+    var focusBinding: FocusState<SOAPField?>.Binding
+
+    /// Invoked when this editor takes focus. The VM uses the timestamp to
+    /// route re-added excluded entries to the most recently focused
+    /// field.
+    let onFocus: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            sectionHeader
+
+            TextEditor(text: $text)
+                .font(.system(size: 13))
+                .focused(focusBinding, equals: field)
+                .onChange(of: focusBinding.wrappedValue) { _, newValue in
+                    if newValue == field { onFocus() }
+                }
+                .padding(8)
+                .frame(minHeight: 96)
+                .background(.background.opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .stroke(borderColor, lineWidth: 1)
+                )
+                .accessibilityIdentifier("reviewScreen.soap.\(field.accessibilityID).editor")
+        }
+        .accessibilityIdentifier("reviewScreen.soap.\(field.accessibilityID)")
+    }
+
+    private var sectionHeader: some View {
+        HStack(spacing: 8) {
+            Text(field.displayName.uppercased())
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .tracking(0.6)
+                .foregroundStyle(Color.iconPrimaryAdaptive)
+
+            Spacer()
+
+            // Subtle keyboard-shortcut hint, mirrors the SettingsView /
+            // recording modal idiom — small, secondary, never the focus.
+            Text(shortcutHint)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var shortcutHint: String {
+        switch field {
+        case .subjective: return "⌘1"
+        case .objective: return "⌘2"
+        case .assessment: return "⌘3"
+        case .plan: return "⌘4"
+        }
+    }
+
+    private var borderColor: Color {
+        focusBinding.wrappedValue == field
+            ? Color.amberPrimary.opacity(0.5)
+            : Color.subtleBorderAdaptive
+    }
+}
+
+// MARK: - Preview
+
+#Preview("SOAPSectionEditor") {
+    PreviewHost()
+        .padding()
+        .frame(width: 480, height: 240)
+}
+
+private struct PreviewHost: View {
+    @State private var text = "Patient reports R-neck pain x 3/52, worse with cervical rotation."
+    @FocusState private var focused: SOAPField?
+
+    var body: some View {
+        SOAPSectionEditor(
+            field: .subjective,
+            text: $text,
+            focusBinding: $focused,
+            onFocus: {}
+        )
+    }
+}

--- a/Tests/SpeechToTextTests/ViewModels/ReviewViewModelTests.swift
+++ b/Tests/SpeechToTextTests/ViewModels/ReviewViewModelTests.swift
@@ -252,6 +252,40 @@ struct ReviewViewModelTests {
         #expect(viewModel.excludedEntries == ["A", "C"])
     }
 
+    @Test("excludedEntries handles duplicates by count, leaving extra copies in the drawer")
+    func excludedEntriesHandlesDuplicatesByCount() {
+        // SessionStore.markExcludedReAdded dedups same-string re-adds
+        // (audit-trail invariant), so even if the same snippet appears
+        // twice in `notes.excluded`, only one re-add is tracked. The
+        // count-based filter therefore hides one copy and keeps the
+        // other in the drawer — order preserved from the LLM output.
+        let store = makeSessionWith()
+        var notes = StructuredNotes()
+        notes.excluded = ["dup", "dup", "single"]
+        store.setDraftNotes(notes)
+        store.markExcludedReAdded("dup")
+
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+        #expect(viewModel.excludedEntries == ["dup", "single"])
+    }
+
+    @Test("reAddExcludedEntry trims trailing whitespace before adding the separator")
+    func reAddTrimsTrailingWhitespace() {
+        let store = makeSessionWith()
+        var notes = StructuredNotes()
+        // Existing has trailing whitespace + newline (e.g. from a prior
+        // re-add that the practitioner partially deleted).
+        notes.subjective = "Pre-existing.   \n\n"
+        notes.excluded = ["New snippet."]
+        store.setDraftNotes(notes)
+
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.reAddExcludedEntry("New snippet.")
+
+        #expect(store.active?.draftNotes?.subjective == "Pre-existing.\n\nNew snippet.")
+    }
+
     // MARK: - canExport / triggerExport
 
     @Test("canExport requires a selected patient")

--- a/Tests/SpeechToTextTests/ViewModels/ReviewViewModelTests.swift
+++ b/Tests/SpeechToTextTests/ViewModels/ReviewViewModelTests.swift
@@ -1,0 +1,362 @@
+// ReviewViewModelTests.swift
+// macOS Local Speech-to-Text Application
+//
+// Swift Testing `.fast` suite for `ReviewViewModel` (#13). Covers:
+//   - SOAP-field bindings write through to `SessionStore.draftNotes`,
+//   - manipulation toggle adds/removes entries from
+//     `selectedManipulationIDs`,
+//   - excluded re-add routes to default (Subjective) when no recent
+//     focus, and to the last-focused field when within the focus window,
+//   - `excludedEntries` filters out re-added entries,
+//   - cancel clears the session and posts `.reviewScreenDidDismiss`,
+//   - export posts `.clinicalNotesExportRequested` only when a patient
+//     is selected.
+//
+// PHI: tests use synthetic strings only. No real transcripts, no
+// Cliniko, no LLM, no Keychain. See `.claude/references/testing-conventions.md`.
+
+import Foundation
+import Testing
+@testable import SpeechToText
+
+@Suite("ReviewViewModel", .tags(.fast))
+@MainActor
+struct ReviewViewModelTests {
+
+    // MARK: - Helpers
+
+    private func stubManipulations() -> ManipulationsRepository {
+        ManipulationsRepository(all: [
+            Manipulation(id: "diversified_hvla", displayName: "Diversified HVLA", clinikoCode: nil),
+            Manipulation(id: "activator", displayName: "Activator", clinikoCode: nil),
+            Manipulation(id: "thompson", displayName: "Thompson", clinikoCode: nil)
+        ])
+    }
+
+    private func makeSessionWith(
+        transcript: String = "Synthetic transcript.",
+        notes: StructuredNotes? = StructuredNotes()
+    ) -> SessionStore {
+        let store = SessionStore()
+        var recording = RecordingSession(language: "en", state: .completed)
+        recording.transcribedText = transcript
+        store.start(from: recording)
+        if let notes {
+            store.setDraftNotes(notes)
+        }
+        return store
+    }
+
+    // MARK: - SOAP bindings
+
+    @Test("setValue writes through to SessionStore.draftNotes for each field")
+    func setValueWritesThroughToSessionStore() {
+        let store = makeSessionWith()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.setValue("Subj", for: .subjective)
+        viewModel.setValue("Obj", for: .objective)
+        viewModel.setValue("Asm", for: .assessment)
+        viewModel.setValue("Pln", for: .plan)
+
+        let draft = store.active?.draftNotes
+        #expect(draft?.subjective == "Subj")
+        #expect(draft?.objective == "Obj")
+        #expect(draft?.assessment == "Asm")
+        #expect(draft?.plan == "Pln")
+    }
+
+    @Test("binding(for:) round-trips through SessionStore on every set")
+    func bindingRoundTripsThroughSessionStore() {
+        let store = makeSessionWith()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        let binding = viewModel.binding(for: .subjective)
+        binding.wrappedValue = "First"
+        #expect(store.active?.draftNotes?.subjective == "First")
+
+        binding.wrappedValue = "Second"
+        #expect(store.active?.draftNotes?.subjective == "Second")
+    }
+
+    @Test("setValue without active session does not write but surfaces a banner")
+    func setValueNoOpWithoutActiveSession() {
+        let store = SessionStore() // no active
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.setValue("Subj", for: .subjective)
+
+        #expect(store.active == nil)
+        // S2 mitigation: every silent-guard hit surfaces a banner so the
+        // doctor sees that their keystroke is not landing (idle-timeout
+        // path between recording end and review-window close).
+        #expect(viewModel.errorMessage != nil)
+    }
+
+    @Test("toggleManipulation without active session surfaces a banner")
+    func toggleManipulationSurfacesBannerWithoutSession() {
+        let store = SessionStore()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.toggleManipulation(id: "activator")
+
+        #expect(viewModel.errorMessage != nil)
+    }
+
+    @Test("reAddExcludedEntry without active session surfaces a banner")
+    func reAddSurfacesBannerWithoutSession() {
+        let store = SessionStore()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.reAddExcludedEntry("Anything")
+
+        #expect(viewModel.errorMessage != nil)
+    }
+
+    @Test("setValue lazily seeds StructuredNotes when draft is nil")
+    func setValueSeedsDraftWhenNil() {
+        let store = makeSessionWith(notes: nil) // active session, no draft
+        #expect(store.active?.draftNotes == nil)
+
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+        viewModel.setValue("Hello", for: .objective)
+
+        #expect(store.active?.draftNotes?.objective == "Hello")
+        #expect(store.active?.draftNotes?.subjective == "")
+    }
+
+    // MARK: - Manipulation toggle
+
+    @Test("toggleManipulation adds and then removes an id from selectedManipulationIDs")
+    func toggleManipulationAddsAndRemoves() {
+        let store = makeSessionWith()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.toggleManipulation(id: "activator")
+        #expect(viewModel.isManipulationSelected(id: "activator"))
+        #expect(store.active?.draftNotes?.selectedManipulationIDs == ["activator"])
+
+        viewModel.toggleManipulation(id: "activator")
+        #expect(!viewModel.isManipulationSelected(id: "activator"))
+        #expect(store.active?.draftNotes?.selectedManipulationIDs == [])
+    }
+
+    @Test("toggleManipulation seeds an empty draft when needed")
+    func toggleManipulationSeedsDraft() {
+        let store = makeSessionWith(notes: nil)
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.toggleManipulation(id: "diversified_hvla")
+        #expect(store.active?.draftNotes?.selectedManipulationIDs == ["diversified_hvla"])
+    }
+
+    // MARK: - Excluded re-add routing
+
+    @Test("reAddExcludedEntry routes to Subjective by default and removes from drawer")
+    func reAddDefaultsToSubjective() {
+        let store = makeSessionWith()
+        var notes = StructuredNotes()
+        notes.subjective = "Pre-existing."
+        notes.excluded = ["Weather chat.", "Parking talk."]
+        store.setDraftNotes(notes)
+
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.reAddExcludedEntry("Weather chat.")
+
+        // Routed to Subjective, separator preserved.
+        let updated = try? #require(store.active?.draftNotes)
+        #expect(updated?.subjective == "Pre-existing.\n\nWeather chat.")
+
+        // Drawer hides re-added entries.
+        #expect(viewModel.excludedEntries == ["Parking talk."])
+    }
+
+    @Test("reAddExcludedEntry honours the last-focused field within the window")
+    func reAddRoutesToRecentlyFocusedField() {
+        let store = makeSessionWith()
+        var notes = StructuredNotes()
+        notes.objective = "Existing objective."
+        notes.excluded = ["Tangential remark."]
+        store.setDraftNotes(notes)
+
+        var clock = Date(timeIntervalSince1970: 1_000_000)
+        let viewModel = ReviewViewModel(
+            sessionStore: store,
+            manipulations: stubManipulations(),
+            reAddTargetWindow: 5.0,
+            now: { clock }
+        )
+
+        // Practitioner focused Objective at t=0.
+        viewModel.noteFieldFocused(.objective)
+
+        // Re-adds 2 seconds later — within the 5s window — so target = .objective.
+        clock = Date(timeIntervalSince1970: 1_000_002)
+        viewModel.reAddExcludedEntry("Tangential remark.")
+
+        #expect(store.active?.draftNotes?.objective == "Existing objective.\n\nTangential remark.")
+        #expect(store.active?.draftNotes?.subjective == "")
+    }
+
+    @Test("reAddExcludedEntry falls back to Subjective once the focus window expires")
+    func reAddFallsBackOnceFocusWindowExpires() {
+        let store = makeSessionWith()
+        var notes = StructuredNotes()
+        notes.excluded = ["Late re-add."]
+        store.setDraftNotes(notes)
+
+        var clock = Date(timeIntervalSince1970: 2_000_000)
+        let viewModel = ReviewViewModel(
+            sessionStore: store,
+            manipulations: stubManipulations(),
+            reAddTargetWindow: 5.0,
+            now: { clock }
+        )
+
+        viewModel.noteFieldFocused(.plan)
+        // 6 s later — outside the 5 s window.
+        clock = Date(timeIntervalSince1970: 2_000_006)
+
+        viewModel.reAddExcludedEntry("Late re-add.")
+
+        #expect(store.active?.draftNotes?.plan == "")
+        #expect(store.active?.draftNotes?.subjective == "Late re-add.")
+    }
+
+    @Test("reAddExcludedEntry handles empty target field without leading newlines")
+    func reAddDoesNotAddSeparatorToEmptyField() {
+        let store = makeSessionWith()
+        var notes = StructuredNotes()
+        notes.excluded = ["Solo entry."]
+        store.setDraftNotes(notes)
+
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        viewModel.reAddExcludedEntry("Solo entry.")
+
+        #expect(store.active?.draftNotes?.subjective == "Solo entry.")
+    }
+
+    // MARK: - excludedEntries filter
+
+    @Test("excludedEntries filters out entries already in excludedReAdded")
+    func excludedEntriesFiltersReAdded() {
+        let store = makeSessionWith()
+        var notes = StructuredNotes()
+        notes.excluded = ["A", "B", "C"]
+        store.setDraftNotes(notes)
+        store.markExcludedReAdded("B")
+
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+        #expect(viewModel.excludedEntries == ["A", "C"])
+    }
+
+    // MARK: - canExport / triggerExport
+
+    @Test("canExport requires a selected patient")
+    func canExportRequiresPatient() {
+        let store = makeSessionWith()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+        #expect(!viewModel.canExport)
+
+        store.setSelectedPatient(id: "42")
+        #expect(viewModel.canExport)
+    }
+
+    @Test("triggerExport without a patient sets a structural error message and does not post")
+    func triggerExportWithoutPatientSetsErrorMessage() async {
+        let store = makeSessionWith()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        var receivedExport = false
+        // Filter on the VM so a concurrent parallel test posting the same
+        // notification with a different VM does not spuriously trip this
+        // observer (Tests run with `--parallel` and share NotificationCenter.default).
+        let observer = NotificationCenter.default.addObserver(
+            forName: .clinicalNotesExportRequested,
+            object: viewModel,
+            queue: .main
+        ) { _ in receivedExport = true }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        viewModel.triggerExport()
+
+        // Drain main queue once so the .main-queue observer (if any) fires.
+        await Task.yield()
+
+        #expect(viewModel.errorMessage != nil)
+        #expect(receivedExport == false)
+    }
+
+    @Test("triggerExport with a patient posts .clinicalNotesExportRequested")
+    func triggerExportWithPatientPosts() async {
+        let store = makeSessionWith()
+        store.setSelectedPatient(id: "99")
+
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        var receivedExport = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .clinicalNotesExportRequested,
+            object: viewModel,
+            queue: .main
+        ) { _ in receivedExport = true }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        viewModel.triggerExport()
+
+        await Task.yield()
+        await Task.yield()
+        #expect(receivedExport)
+    }
+
+    // MARK: - cancelReview
+
+    @Test("cancelReview clears SessionStore and posts .reviewScreenDidDismiss")
+    func cancelReviewClearsAndDismisses() async {
+        let store = makeSessionWith()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+
+        var receivedDismiss = false
+        let observer = NotificationCenter.default.addObserver(
+            forName: .reviewScreenDidDismiss,
+            object: viewModel,
+            queue: .main
+        ) { _ in receivedDismiss = true }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        viewModel.cancelReview()
+
+        await Task.yield()
+        await Task.yield()
+        #expect(store.active == nil)
+        #expect(receivedDismiss)
+    }
+
+    // MARK: - Sheet / drawer toggles
+
+    @Test("presentRawTranscript opens only when a transcript is present")
+    func presentRawTranscriptGuardsEmpty() {
+        let storeWithText = makeSessionWith(transcript: "Hello.")
+        let viewModelWithText = ReviewViewModel(sessionStore: storeWithText, manipulations: stubManipulations())
+        viewModelWithText.presentRawTranscript()
+        #expect(viewModelWithText.isRawTranscriptSheetOpen)
+
+        let storeNoSession = SessionStore()
+        let viewModelNoSession = ReviewViewModel(sessionStore: storeNoSession, manipulations: stubManipulations())
+        viewModelNoSession.presentRawTranscript()
+        #expect(!viewModelNoSession.isRawTranscriptSheetOpen)
+    }
+
+    @Test("toggleExcludedDrawer flips state")
+    func toggleExcludedDrawer() {
+        let store = makeSessionWith()
+        let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
+        #expect(viewModel.isExcludedDrawerOpen)
+        viewModel.toggleExcludedDrawer()
+        #expect(!viewModel.isExcludedDrawerOpen)
+        viewModel.toggleExcludedDrawer()
+        #expect(viewModel.isExcludedDrawerOpen)
+    }
+}

--- a/Tests/SpeechToTextTests/Views/ReviewScreenRenderTests.swift
+++ b/Tests/SpeechToTextTests/Views/ReviewScreenRenderTests.swift
@@ -1,0 +1,164 @@
+// ReviewScreenRenderTests.swift
+// macOS Local Speech-to-Text Application
+//
+// ViewInspector + crash-detection tests for `ReviewScreen` (#13) and its
+// sub-views: SOAPSectionEditor, ManipulationsChecklist,
+// ExcludedContentDrawer, RawTranscriptSheet.
+//
+// Catches the @Observable + actor-existential crash pattern documented in
+// `.claude/references/concurrency.md` §1, plus body-evaluation crashes
+// that only surface at runtime. Each test instantiates a fresh
+// `ReviewViewModel` with a real `SessionStore` + a tiny stub
+// `ManipulationsRepository` — no network, no Keychain, no LLM.
+
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import SpeechToText
+
+extension ReviewScreen: Inspectable {}
+extension SOAPSectionEditor: Inspectable {}
+extension ManipulationsChecklist: Inspectable {}
+extension ExcludedContentDrawer: Inspectable {}
+extension RawTranscriptSheet: Inspectable {}
+
+@MainActor
+final class ReviewScreenRenderTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeStubManipulations() -> ManipulationsRepository {
+        ManipulationsRepository(all: [
+            Manipulation(id: "diversified_hvla", displayName: "Diversified HVLA", clinikoCode: nil),
+            Manipulation(id: "activator", displayName: "Activator", clinikoCode: nil),
+            Manipulation(id: "thompson", displayName: "Thompson", clinikoCode: nil)
+        ])
+    }
+
+    private func makeViewModel(populated: Bool = false) -> ReviewViewModel {
+        let store = SessionStore()
+        if populated {
+            var recording = RecordingSession(language: "en", state: .completed)
+            recording.transcribedText = "Patient reports R-neck pain x 3/52."
+            store.start(from: recording)
+            var notes = StructuredNotes()
+            notes.subjective = "Pt reports R-neck pain x 3/52."
+            notes.excluded = ["Weather chat at start.", "Brief parking discussion."]
+            store.setDraftNotes(notes)
+        }
+        return ReviewViewModel(
+            sessionStore: store,
+            manipulations: makeStubManipulations()
+        )
+    }
+
+    // MARK: - ReviewScreen: instantiation
+
+    func test_reviewScreen_instantiatesWithoutCrash() {
+        let viewModel = makeViewModel()
+        let screen = ReviewScreen(viewModel: viewModel)
+        XCTAssertNotNil(screen)
+    }
+
+    func test_reviewScreen_bodyAccessDoesNotCrash() {
+        let viewModel = makeViewModel()
+        let screen = ReviewScreen(viewModel: viewModel)
+        let body = screen.body
+        XCTAssertNotNil(body)
+    }
+
+    /// Mirror of `RecordingModalRenderTests.test_recordingModal_externalViewModelCreation_noCrash`
+    /// — VM constructed BEFORE view, then handed in. Verifies the
+    /// actor-existential mitigation pattern from `.claude/references/concurrency.md` §1.
+    func test_reviewScreen_externalViewModelCreation_noCrash() {
+        let viewModel = makeViewModel()
+        XCTAssertTrue(viewModel.isExcludedDrawerOpen) // drawer defaults open
+        let screen = ReviewScreen(viewModel: viewModel)
+        let body = screen.body
+        XCTAssertNotNil(body)
+    }
+
+    /// Populated session — exercises the `excludedEntries` / draft-notes
+    /// rendering paths that an empty session would skip.
+    func test_reviewScreen_populated_bodyAccessDoesNotCrash() {
+        let viewModel = makeViewModel(populated: true)
+        let screen = ReviewScreen(viewModel: viewModel)
+        let body = screen.body
+        XCTAssertNotNil(body)
+    }
+
+    func test_reviewScreen_exposesAccessibilityIdentifier() throws {
+        let viewModel = makeViewModel(populated: true)
+        let screen = ReviewScreen(viewModel: viewModel)
+        let inspected = try screen.inspect()
+        XCTAssertNoThrow(try inspected.find(viewWithAccessibilityIdentifier: "reviewScreen"))
+    }
+
+    // MARK: - SOAPSectionEditor
+
+    func test_soapSectionEditor_instantiatesWithoutCrash() {
+        struct Host: View {
+            @State var text = "Pt reports R-neck pain."
+            @FocusState var focused: SOAPField?
+
+            var body: some View {
+                SOAPSectionEditor(
+                    field: .subjective,
+                    text: $text,
+                    focusBinding: $focused,
+                    onFocus: {}
+                )
+            }
+        }
+
+        let host = Host()
+        XCTAssertNotNil(host.body)
+    }
+
+    // MARK: - ManipulationsChecklist
+
+    func test_manipulationsChecklist_instantiatesWithoutCrash() {
+        let viewModel = makeViewModel(populated: true)
+        let view = ManipulationsChecklist(viewModel: viewModel)
+        XCTAssertNotNil(view.body)
+    }
+
+    func test_manipulationsChecklist_emptyTaxonomy_doesNotCrash() {
+        // Defensive: AppState falls back to an empty repository on
+        // bundle-load failure (`assertionFailure` in DEBUG, empty in
+        // RELEASE). The checklist must render without crashing.
+        let store = SessionStore()
+        let viewModel = ReviewViewModel(
+            sessionStore: store,
+            manipulations: ManipulationsRepository(all: [])
+        )
+        let view = ManipulationsChecklist(viewModel: viewModel)
+        XCTAssertNotNil(view.body)
+    }
+
+    // MARK: - ExcludedContentDrawer
+
+    func test_excludedContentDrawer_instantiatesWithoutCrash() {
+        let viewModel = makeViewModel(populated: true)
+        let view = ExcludedContentDrawer(viewModel: viewModel)
+        XCTAssertNotNil(view.body)
+    }
+
+    func test_excludedContentDrawer_empty_doesNotCrash() {
+        let viewModel = makeViewModel() // no draft → no excluded entries
+        let view = ExcludedContentDrawer(viewModel: viewModel)
+        XCTAssertNotNil(view.body)
+    }
+
+    // MARK: - RawTranscriptSheet
+
+    func test_rawTranscriptSheet_instantiatesWithoutCrash() {
+        let view = RawTranscriptSheet(transcript: "Hello world.", onDismiss: {})
+        XCTAssertNotNil(view.body)
+    }
+
+    func test_rawTranscriptSheet_emptyTranscript_doesNotCrash() {
+        let view = RawTranscriptSheet(transcript: "", onDismiss: {})
+        XCTAssertNotNil(view.body)
+    }
+}


### PR DESCRIPTION
Closes #13.

## Summary

- New views under `Sources/Views/ClinicalNotes/`: `ReviewScreen` (frosted header + two columns + action bar), `SOAPSectionEditor` (shared `@FocusState<SOAPField?>`), `ManipulationsChecklist` (with empty-taxonomy banner), `ExcludedContentDrawer` (default Subjective; last-focused-within-5s wins), `RawTranscriptSheet`, `ReviewViewModel` (`@Observable @MainActor`, `@ObservationIgnored` services per `concurrency.md` §1).
- New `ReviewWindow` + `ReviewWindowController.shared` mirroring `MainWindow`. `windowWillClose` is the PHI chokepoint — `SessionStore.clear()` runs for every close path (Cancel / ⎋ / title-bar X) so PHI cannot survive the visible surface, satisfying the AGENTS.md "PHI in-memory only" rule.
- `AppState.init` wires both halves: configures the controller once with `SessionStore` + a bundle-loaded `ManipulationsRepository`, and registers a `.clinicalNotesGenerateRequested` observer that hops the transcript off the NotificationCenter boundary into `SessionStore` immediately (closes the leak gap noted on #11/#12). Empty-transcript + missing-userInfo guards mirror the recording modal's poster-side guards as defence-in-depth.
- `SOAPField.notesKeyPath: WritableKeyPath<StructuredNotes, String>` collapses the SOAP↔StructuredNotes mapping into a single switch — adding a fifth section is a one-line change with compiler-enforced fan-out.
- LLM processor wiring stays deferred until `MLXGemmaProvider` lands per the existing comment on `AppState.sessionStore` and the `#18` blocker. The screen renders interactively with an empty seed in the meantime.

## Tests
- `Tests/SpeechToTextTests/ViewModels/ReviewViewModelTests.swift` — 20 Swift Testing `.fast` tests: SOAP binding round-trip, manipulation toggle, re-add routing (default + recently-focused + outside-window + empty-separator), excluded filter, `canExport` / `triggerExport`, `cancelReview`, drawer / sheet toggles, **session-loss banner surfacing** (idle-timeout mitigation per silent-failure review). Uses `object: self` filtering for stability under `--parallel`.
- `Tests/SpeechToTextTests/Views/ReviewScreenRenderTests.swift` — 12 XCTest + ViewInspector crash-detection tests across `ReviewScreen` + every sub-view, including empty-taxonomy + empty-transcript + populated-session paths.

## Pre-PR review (Opus, three-layer)
- `pr-review-toolkit:code-reviewer`, `silent-failure-hunter`, `type-design-analyzer` all spawned in parallel. Both blockers folded in:
  - Cancel button now actually closes the NSWindow (`handleDismissNotification` calls `window?.close()`).
  - Title-bar X clears PHI (`windowWillClose` calls `sessionStore.clear()`).
- Type-design wins applied: `notesKeyPath` projection, single `FocusSnapshot` tuple optional (illegal-state-free), `manipulationsList` accessor hides the repo.
- Silent-failure mitigations: every guard surfaces a session-loss banner so idle-timeout draft-loss never disappears silently. Empty-taxonomy banner so a build bug surfaces visibly.
- One follow-up flagged for #14: today's `triggerExport` gate at the action bar means the no-patient `errorMessage` branch is unreachable from the visible UI; #14's export-flow should own the picker affordance and either remove the gate or auto-clear the banner on `canExport` change.

## Acceptance (issue #13)
- [x] Crash-detection test (ViewInspector): instantiates with mock `SessionStore` + `ManipulationsRepository` without crashing.
- [x] Text edits reflected in `SessionStore.draftNotes` in real time (binding-round-trip test).
- [x] Re-adding an excluded entry removes it from the drawer + appends to the target section (default Subjective; last-focused field if focused within 5 s).
- [x] Keyboard navigation: ⌘1–⌘4 focuses S/O/A/P; ⌘E triggers Export (when enabled).

Snapshot tests deferred to #24 as planned.

Awaiting CI + Gemini Code Assist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)