### PR TITLE
refactor(models): OpaqueClinikoID newtype for patient/appointment/note IDs (#59)

### DIFF
--- a/Sources/Models/Appointment.swift
+++ b/Sources/Models/Appointment.swift
@@ -10,8 +10,9 @@ import Foundation
 /// memory only — no logging beyond structural fields, no on-disk cache.
 public struct Appointment: Decodable, Identifiable, Sendable, Equatable, Hashable {
     /// Cliniko numeric appointment ID. Stored as `Int` to match the wire
-    /// shape; the picker converts it to `String` at the `SessionStore`
-    /// boundary (`ClinicalSession.selectedAppointmentID`).
+    /// shape; the picker type-tags it into `OpaqueClinikoID` at the
+    /// `SessionStore` boundary
+    /// (`ClinicalSession.selectedAppointmentID`) — see #59.
     public let id: Int
 
     /// Scheduled start time. Required by Cliniko's schema.

--- a/Sources/Models/ClinicalSession.swift
+++ b/Sources/Models/ClinicalSession.swift
@@ -29,20 +29,22 @@ struct ClinicalSession: Sendable, Identifiable {
     /// purposes and the ReviewScreen drawer can hide re-added entries.
     var excludedReAdded: [String]
 
-    /// Cliniko patient ID selected for export. Opaque string; not
-    /// user-visible demographics.
-    var selectedPatientID: String?
+    /// Cliniko patient ID selected for export. Type-tagged as
+    /// `OpaqueClinikoID` (#59) so the type system refuses anything
+    /// other than a Cliniko-shaped opaque ID — no name, DOB, or
+    /// free-form string can land here.
+    var selectedPatientID: OpaqueClinikoID?
 
     /// Cliniko appointment ID selected for export.
-    var selectedAppointmentID: String?
+    var selectedAppointmentID: OpaqueClinikoID?
 
     init(
         id: UUID = UUID(),
         recordingSession: RecordingSession,
         draftNotes: StructuredNotes? = nil,
         excludedReAdded: [String] = [],
-        selectedPatientID: String? = nil,
-        selectedAppointmentID: String? = nil
+        selectedPatientID: OpaqueClinikoID? = nil,
+        selectedAppointmentID: OpaqueClinikoID? = nil
     ) {
         self.id = id
         self.recordingSession = recordingSession

--- a/Sources/Models/OpaqueClinikoID.swift
+++ b/Sources/Models/OpaqueClinikoID.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// A type-tagged Cliniko identifier — patient, appointment, or note.
+///
+/// Cliniko's wire shape for these resources is numeric (`Int`). The audit
+/// ledger and `SessionStore` need an opaque-but-typed handle that:
+///
+/// 1. **Refuses free-form strings** at every migrated callsite.
+///    `AuditRecord.init(patientID:)` accepts only `OpaqueClinikoID`, not
+///    `String` — so a contributor cannot accidentally widen the audit
+///    schema to carry a patient name without changing the type. The
+///    type *itself* is total over `String` (`init(rawValue:)` is
+///    public for `Codable` round-trip), but every migrated boundary
+///    speaks the typed form, which is the load-bearing win.
+/// 2. Encodes/decodes as a **bare** JSON string so the on-disk
+///    `audit.jsonl` schema stays unchanged from the `String`-typed
+///    predecessor (issue #59 acceptance: audit-row schema unchanged on
+///    disk). `RawRepresentable`'s synthesised Codable would emit a
+///    wrapping `{"rawValue":"..."}` object — the custom `init(from:)`
+///    / `encode(to:)` below flatten to a single-value container.
+///    Pinned at the byte level by
+///    `AuditStoreTests.line_pins_opaque_id_byte_shape`.
+/// 3. Round-trips through the `Int` ↔ `String` boundary in one place.
+///    Production code uses `init(_ int: Int)` at the Cliniko-response
+///    boundary (every `Patient.id` / `Appointment.id` / `created.id`
+///    site); `init(rawValue: String)` is reserved for Codable
+///    round-trip from `audit.jsonl` and for tests that want
+///    deterministic string literals.
+///
+/// **Issue #59.** Replaces the three bare-`String` ID fields on
+/// `AuditRecord` and the two on `ClinicalSession`. Wire-shape `Int`
+/// IDs on `Patient`, `Appointment`, and `TreatmentNotePayload` are
+/// deliberately preserved — those are what Cliniko's HTTP API speaks.
+///
+/// **`RawRepresentable` rationale.** Required by the issue spec for
+/// symmetry with the predecessor `String`-typed fields and so the
+/// `rawValue` accessor is callable at the few legitimate string
+/// boundaries (Codable, debug formatting). Do NOT drop the conformance
+/// without first removing the custom `Codable` methods below — the
+/// synthesised `RawRepresentable` Codable would re-emit the wrapping-
+/// object shape and silently break `audit.jsonl` back-compat.
+///
+/// **PHI posture.** An `OpaqueClinikoID` is the same opaque resource
+/// ID the Cliniko API itself logs in its CDN/load-balancer access
+/// logs — it is not a name, DOB, or contact field. But it is
+/// patient-correlatable: a `patient_id` in a leaked log is enough to
+/// re-identify the patient given access to the Cliniko tenant.
+/// Therefore: never use `OSLog`'s `privacy: .public` on an
+/// `OpaqueClinikoID`, never interpolate one into a
+/// `fatalError`/`assertionFailure` message. There is deliberately
+/// **no** `CustomStringConvertible` conformance — `\(id)` falls back
+/// to Swift's reflection-based form (`OpaqueClinikoID(rawValue:
+/// "1001")`) which is obviously-PHI-shaped, so an accidental log
+/// site reads as a leak rather than as an innocuous integer.
+public struct OpaqueClinikoID: RawRepresentable, Sendable, Hashable {
+    public let rawValue: String
+
+    /// Canonical construction at the Cliniko-response boundary. Use this
+    /// when you have a numeric `id` from a `Patient`, `Appointment`, or
+    /// `TreatmentNoteCreated` and want to type-tag it before passing
+    /// into `SessionStore` or `AuditRecord`.
+    public init(_ int: Int) {
+        self.rawValue = String(int)
+    }
+
+    /// String-form construction. **Reserved for `Codable` round-trip**
+    /// (decoding from `audit.jsonl` or test fixtures) and test wiring
+    /// that wants a deterministic literal. Production callsites must
+    /// use `init(_:Int)` at the Cliniko-response boundary —
+    /// `PatientPickerViewModel`, `TreatmentNoteExporter`, and the
+    /// `AuditRecord` construction in the exporter all do this. A
+    /// `String` value entering this initialiser at a non-Codable,
+    /// non-test callsite is a #59 regression.
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+}
+
+extension OpaqueClinikoID: Codable {
+    /// Decodes from a bare JSON string (e.g. `"1001"`). Preserves
+    /// audit-jsonl back-compat — a row encoded before #59 had
+    /// `"patient_id": "1001"`, so the post-#59 decoder reads that same
+    /// shape rather than expecting a wrapping `{"rawValue":"1001"}`
+    /// object.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.rawValue = try container.decode(String.self)
+    }
+
+    /// Encodes as a bare JSON string. Pinned by
+    /// `OpaqueClinikoIDTests.codable_encodesAsBareString` (type-level)
+    /// and `AuditStoreTests.line_pins_opaque_id_byte_shape`
+    /// (integration-level) so a future refactor that drops these
+    /// custom methods can't accidentally re-emit `RawRepresentable`'s
+    /// synthesised wrapping-object shape.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Sources/Models/Patient.swift
+++ b/Sources/Models/Patient.swift
@@ -14,8 +14,8 @@ import Foundation
 /// `.claude/references/phi-handling.md`.
 public struct Patient: Decodable, Identifiable, Sendable, Equatable, Hashable {
     /// Cliniko numeric patient ID. Stored as `Int` to match the wire shape;
-    /// the picker converts it to `String` at the `SessionStore` boundary
-    /// (`ClinicalSession.selectedPatientID` is opaque-string-typed).
+    /// the picker type-tags it into `OpaqueClinikoID` at the `SessionStore`
+    /// boundary (`ClinicalSession.selectedPatientID`) — see #59.
     public let id: Int
 
     /// Patient's first / given name. Required by Cliniko's schema, so the

--- a/Sources/Services/AuditStore.swift
+++ b/Sources/Services/AuditStore.swift
@@ -36,23 +36,29 @@ public protocol AuditStore: Sendable {
 /// names match the doc's example; deliberate snake_case via explicit
 /// `CodingKeys` (not `convertToSnakeCase`) so the encoder swap can't
 /// drift the on-disk shape.
+///
+/// ID fields are `OpaqueClinikoID` (issue #59) so the type system
+/// refuses non-Cliniko-shaped strings at compile time. The on-disk
+/// JSON shape is **unchanged** — `OpaqueClinikoID` encodes as a bare
+/// string, so a row written before #59 (`"patient_id": "1001"`) and a
+/// row written after look byte-identical.
 public struct AuditRecord: Codable, Sendable, Equatable {
     /// When the export landed, in UTC. Encoded as ISO8601 (see
     /// `LocalAuditStore.encoder`).
     public let timestamp: Date
 
-    /// Cliniko patient ID stored as an opaque string — `Patient.id` on
-    /// the wire is `Int`, but the UI layer (`ClinicalSession.selectedPatientID`)
-    /// already converts to `String` at its boundary, so we accept that
-    /// shape here for symmetry.
-    public let patientID: String
+    /// Cliniko patient ID. The wire shape is `Int`; the UI layer holds
+    /// it as `OpaqueClinikoID` (`ClinicalSession.selectedPatientID`),
+    /// and the exporter type-tags the Int into `OpaqueClinikoID(_:)`
+    /// at the audit-write boundary.
+    public let patientID: OpaqueClinikoID
 
     /// Optional Cliniko appointment ID. Practitioners may export against
     /// the patient only, in which case this is `nil`.
-    public let appointmentID: String?
+    public let appointmentID: OpaqueClinikoID?
 
     /// Cliniko `treatment_note.id` from the 201 response body.
-    public let noteID: String
+    public let noteID: OpaqueClinikoID
 
     /// HTTP status from Cliniko. The exporter only writes audit records
     /// on success, so this is always 2xx in practice — kept structural
@@ -68,9 +74,9 @@ public struct AuditRecord: Codable, Sendable, Equatable {
 
     public init(
         timestamp: Date,
-        patientID: String,
-        appointmentID: String?,
-        noteID: String,
+        patientID: OpaqueClinikoID,
+        appointmentID: OpaqueClinikoID?,
+        noteID: OpaqueClinikoID,
         clinikoStatus: Int,
         appVersion: String
     ) {

--- a/Sources/Services/Cliniko/TreatmentNoteExporter.swift
+++ b/Sources/Services/Cliniko/TreatmentNoteExporter.swift
@@ -167,13 +167,18 @@ actor TreatmentNoteExporter {
         // routes 2xx into the success path but discards the actual
         // status code. The audit row therefore records the documented
         // status. Threading the real HTTP status through `send<T>`
-        // is tracked as a follow-up — until then, this value is the
-        // contract.
+        // is tracked as a follow-up (issue #58) — until then, this
+        // value is the contract.
+        //
+        // Type-tag the Int IDs into `OpaqueClinikoID` at this audit
+        // boundary (#59). The wire-payload Ints flow into the
+        // numerical `TreatmentNotePayload`; the audit row carries the
+        // opaque-string form so the on-disk schema stays unchanged.
         let record = AuditRecord(
             timestamp: now(),
-            patientID: String(patientID),
-            appointmentID: appointmentID.map(String.init),
-            noteID: String(created.id),
+            patientID: OpaqueClinikoID(patientID),
+            appointmentID: appointmentID.map(OpaqueClinikoID.init),
+            noteID: OpaqueClinikoID(created.id),
             clinikoStatus: 201,
             appVersion: appVersion
         )

--- a/Sources/Services/SessionStore.swift
+++ b/Sources/Services/SessionStore.swift
@@ -104,15 +104,22 @@ final class SessionStore {
         touch()
     }
 
-    /// Set the Cliniko patient selection.
-    func setSelectedPatient(id: String?) {
+    /// Set the Cliniko patient selection. The `OpaqueClinikoID` type
+    /// tag (#59) means callers can't accidentally pass in a free-form
+    /// string — they must construct from a numeric `Patient.id` (the
+    /// Cliniko-response shape) or from a `rawValue` string with a
+    /// documented provenance (Codable round-trip, test wiring).
+    func setSelectedPatient(id: OpaqueClinikoID?) {
         guard active != nil else { return }
         active?.selectedPatientID = id
         touch()
     }
 
-    /// Set the Cliniko appointment selection.
-    func setSelectedAppointment(id: String?) {
+    /// Set the Cliniko appointment selection. Same `OpaqueClinikoID`
+    /// type-tag invariant as `setSelectedPatient(id:)` — the picker
+    /// constructs from the numeric `Appointment.id`; tests use
+    /// `init(rawValue:)` for deterministic literals.
+    func setSelectedAppointment(id: OpaqueClinikoID?) {
         guard active != nil else { return }
         active?.selectedAppointmentID = id
         touch()

--- a/Sources/Views/ClinicalNotes/PatientPickerViewModel.swift
+++ b/Sources/Views/ClinicalNotes/PatientPickerViewModel.swift
@@ -184,7 +184,7 @@ final class PatientPickerViewModel {
     /// selection without waiting on the appointment fetch.
     func selectPatient(_ patient: Patient) {
         selectedPatient = patient
-        sessionStore.setSelectedPatient(id: String(patient.id))
+        sessionStore.setSelectedPatient(id: OpaqueClinikoID(patient.id))
         sessionStore.setSelectedAppointment(id: nil)
         selectedAppointmentID = nil
         appointmentPhase = .loading
@@ -238,10 +238,11 @@ final class PatientPickerViewModel {
     }
 
     /// Select an appointment, or `nil` for "No appointment / general
-    /// note". Writes through to the session store.
+    /// note". Writes through to the session store, type-tagging the Int
+    /// into `OpaqueClinikoID` (#59) at the SessionStore boundary.
     func selectAppointment(id: Int?) {
         selectedAppointmentID = id
-        sessionStore.setSelectedAppointment(id: id.map(String.init))
+        sessionStore.setSelectedAppointment(id: id.map(OpaqueClinikoID.init))
     }
 
     /// Clear the entire selection state. Used by the host view when the

--- a/Tests/SpeechToTextTests/Models/ClinicalSessionTests.swift
+++ b/Tests/SpeechToTextTests/Models/ClinicalSessionTests.swift
@@ -42,32 +42,35 @@ struct ClinicalSessionTests {
             excluded: ["smalltalk"]
         )
         let id = UUID()
+        let patientID = OpaqueClinikoID(rawValue: "patient-1")
+        let appointmentID = OpaqueClinikoID(rawValue: "appt-1")
         let session = ClinicalSession(
             id: id,
             recordingSession: recording,
             draftNotes: notes,
             excludedReAdded: ["weather"],
-            selectedPatientID: "patient-1",
-            selectedAppointmentID: "appt-1"
+            selectedPatientID: patientID,
+            selectedAppointmentID: appointmentID
         )
 
         #expect(session.id == id)
         #expect(session.draftNotes == notes)
         #expect(session.excludedReAdded == ["weather"])
-        #expect(session.selectedPatientID == "patient-1")
-        #expect(session.selectedAppointmentID == "appt-1")
+        #expect(session.selectedPatientID == patientID)
+        #expect(session.selectedAppointmentID == appointmentID)
     }
 
     @Test("Mutating draftNotes leaves other fields untouched")
     func mutate_draftNotesIsIsolated() {
+        let patientID = OpaqueClinikoID(rawValue: "p")
         var session = ClinicalSession(
             recordingSession: RecordingSession(),
-            selectedPatientID: "p"
+            selectedPatientID: patientID
         )
         session.draftNotes = StructuredNotes(subjective: "x")
 
         #expect(session.draftNotes?.subjective == "x")
-        #expect(session.selectedPatientID == "p")
+        #expect(session.selectedPatientID == patientID)
     }
 }
 

--- a/Tests/SpeechToTextTests/Models/OpaqueClinikoIDTests.swift
+++ b/Tests/SpeechToTextTests/Models/OpaqueClinikoIDTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+/// Unit tests for `OpaqueClinikoID` (issue #59). The newtype's whole
+/// purpose is to:
+/// 1. Refuse free-form strings at compile time at the `AuditRecord` /
+///    `ClinicalSession` boundary.
+/// 2. Encode/decode as a **bare** JSON string so the on-disk
+///    `audit.jsonl` schema stays unchanged from the predecessor
+///    `String`-typed fields.
+/// 3. Round-trip the `Int ↔ String` boundary in one place.
+///
+/// (1) is enforced statically — a regression would surface as a build
+/// failure, not a test failure. The negative compile-failure case is
+/// documented as a comment block at the bottom of this suite. (2) and
+/// (3) are pinned by the tests below.
+@Suite("OpaqueClinikoID", .tags(.fast))
+struct OpaqueClinikoIDTests {
+
+    // MARK: - Construction
+
+    @Test("init(_:Int) preserves the numeric value as the canonical string form")
+    func intInit_preservesValue() {
+        let id = OpaqueClinikoID(1001)
+        #expect(id.rawValue == "1001")
+    }
+
+    @Test("init(rawValue:) preserves the string verbatim")
+    func rawValueInit_preservesString() {
+        // `init(rawValue:)` is total over `String`. Production
+        // callsites must not exercise it for non-numeric inputs — see
+        // the type-level doc-comment — but the type itself does not
+        // refuse them, so the test pins the round-trip property.
+        let id = OpaqueClinikoID(rawValue: "patient-99")
+        #expect(id.rawValue == "patient-99")
+    }
+
+    @Test("init(_:Int) and init(rawValue:) with the same digit-string produce equal IDs")
+    func dualInit_producesEqualIDs() {
+        let viaInt = OpaqueClinikoID(42)
+        let viaString = OpaqueClinikoID(rawValue: "42")
+        #expect(viaInt == viaString)
+        #expect(viaInt.hashValue == viaString.hashValue)
+    }
+
+    // MARK: - Wire shape (the `audit.jsonl` schema invariant)
+
+    @Test("Encodes as a bare JSON string, not as a wrapping object")
+    func codable_encodesAsBareString() throws {
+        let id = OpaqueClinikoID(1001)
+        let encoded = try JSONEncoder().encode(id)
+        let json = try #require(String(data: encoded, encoding: .utf8))
+
+        // Critical: must be `"1001"`, NOT `{"rawValue":"1001"}`. The
+        // pre-#59 audit ledger has bytes like
+        // `"patient_id":"1001"` and the post-#59 decoder still reads
+        // them — that's the `audit.jsonl` back-compat invariant the
+        // issue body calls out.
+        #expect(json == "\"1001\"")
+    }
+
+    @Test("Decodes a bare JSON string (audit-jsonl back-compat)")
+    func codable_decodesBareString() throws {
+        let json = try #require("\"42\"".data(using: .utf8))
+        let id = try JSONDecoder().decode(OpaqueClinikoID.self, from: json)
+        #expect(id.rawValue == "42")
+    }
+
+    @Test("Round-trips through Codable preserves rawValue exactly")
+    func codable_roundTrip_preservesRawValue() throws {
+        let original = OpaqueClinikoID(rawValue: "5678-edge")
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(OpaqueClinikoID.self, from: encoded)
+        #expect(decoded == original)
+        #expect(decoded.rawValue == "5678-edge")
+    }
+
+    @Test("Decodes inside a containing object with the field key")
+    func codable_decodesInsideObject() throws {
+        struct Wrapper: Codable, Equatable {
+            let id: OpaqueClinikoID
+        }
+        // Mirrors the audit.jsonl shape — an object whose `id`-named
+        // field is a bare string. Decoder must descend into the
+        // containing key without expecting a wrapping object.
+        let json = try #require(#"{"id":"9876543"}"#.data(using: .utf8))
+        let wrapper = try JSONDecoder().decode(Wrapper.self, from: json)
+        #expect(wrapper.id == OpaqueClinikoID(9876543))
+    }
+
+    @Test("Empty rawValue round-trips through Codable")
+    func codable_emptyRawValue_roundTrips() throws {
+        // Adversarial corner. The type does not refuse an empty
+        // rawValue at construction; the wire-shape test pins that this
+        // case round-trips as a bare empty JSON string (`""`) rather
+        // than failing or transforming. No production path should ever
+        // produce an empty ID, but if a tampered audit row carries one,
+        // the decoder must not silently transform it into something
+        // else (the read path is what surfaces the lie, not the
+        // decoder).
+        let original = OpaqueClinikoID(rawValue: "")
+        let encoded = try JSONEncoder().encode(original)
+        #expect(String(data: encoded, encoding: .utf8) == "\"\"")
+        let decoded = try JSONDecoder().decode(OpaqueClinikoID.self, from: encoded)
+        #expect(decoded == original)
+    }
+
+    @Test("Encodes inside a containing object as a bare-string field")
+    func codable_encodesInsideObject() throws {
+        struct Wrapper: Codable {
+            let id: OpaqueClinikoID
+        }
+        let encoded = try JSONEncoder().encode(Wrapper(id: OpaqueClinikoID(123)))
+        let parsed = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        let idValue = parsed?["id"]
+
+        // `JSONSerialization` will surface a JSON string as a Swift
+        // `String`; a wrapping `{"rawValue":"123"}` object would
+        // surface as `[String: Any]`. Pinning the String case is what
+        // proves the bare-string invariant downstream of #59.
+        #expect((idValue as? String) == "123")
+    }
+
+    // MARK: - Hashable
+
+    @Test("Hashable equality is rawValue-driven")
+    func hashable_rawValueDriven() {
+        let a = OpaqueClinikoID(1001)
+        let b = OpaqueClinikoID(rawValue: "1001")
+        let c = OpaqueClinikoID(rawValue: "1002")
+
+        #expect(a == b)
+        #expect(a != c)
+
+        var set: Set<OpaqueClinikoID> = []
+        set.insert(a)
+        set.insert(b) // duplicate rawValue → not added
+        set.insert(c)
+        #expect(set.count == 2)
+    }
+
+    // MARK: - Reflection / no CustomStringConvertible
+    //
+    // The type deliberately does NOT conform to `CustomStringConvertible`
+    // so that an accidental log site like `\(id)` falls back to Swift's
+    // reflection-based form (`OpaqueClinikoID(rawValue: "1001")`) which
+    // is obviously-PHI-shaped — the contributor reads the leak rather
+    // than letting `1001` slip into the log under the appearance of an
+    // innocuous integer. The PHI rule is documented on the type; this
+    // is the redundancy that lets it actually hold.
+
+    @Test("String(describing:) renders the reflection form, not a bare value")
+    func reflection_showsTypeContext() {
+        let id = OpaqueClinikoID(1001)
+        let described = String(describing: id)
+        // Belt-and-braces: assert the type name appears, not just the
+        // bare digits. The exact format is Swift-runtime-dependent
+        // (likely `OpaqueClinikoID(rawValue: "1001")`), so don't pin
+        // the byte sequence — pin the property that matters.
+        #expect(described.contains("OpaqueClinikoID"))
+    }
+
+    // MARK: - Type-system invariant
+    //
+    // Pinning the static refusal of free-form strings is the load-bearing
+    // contract of #59. The check is structural (compile-time), not
+    // runtime — Swift will reject these uses at build time:
+    //
+    //     // Won't compile — `AuditRecord.init(patientID:)` accepts only
+    //     // `OpaqueClinikoID`, not `String`:
+    //     // _ = AuditRecord(
+    //     //     timestamp: Date(),
+    //     //     patientID: "Mrs Smith",            // ❌ type error
+    //     //     appointmentID: nil,
+    //     //     noteID: "",                          // ❌ type error
+    //     //     clinikoStatus: 201,
+    //     //     appVersion: "0.0.0"
+    //     // )
+    //
+    //     // Won't compile — `SessionStore.setSelectedPatient(id:)`
+    //     // accepts only `OpaqueClinikoID?`:
+    //     // sessionStore.setSelectedPatient(id: "totally-not-a-cliniko-id")  // ❌
+    //
+    // The positive direction — that `OpaqueClinikoID` IS accepted — is
+    // exercised end-to-end by every other test in this suite. If a
+    // future change widens any of the migrated `init`s back to `String`,
+    // those callsites would silently re-enable the bug class #59 closes
+    // and the audit ledger's PHI-leak guard becomes structural-only
+    // (which is what the issue body warns against).
+}

--- a/Tests/SpeechToTextTests/Services/AuditStoreTests.swift
+++ b/Tests/SpeechToTextTests/Services/AuditStoreTests.swift
@@ -22,9 +22,9 @@ struct AuditStoreTests {
 
     private static func makeRecord(
         timestamp: Date = Date(timeIntervalSince1970: 1_777_320_000),
-        patientID: String = "1001",
-        appointmentID: String? = "5001",
-        noteID: String = "9876543",
+        patientID: OpaqueClinikoID = OpaqueClinikoID(rawValue: "1001"),
+        appointmentID: OpaqueClinikoID? = OpaqueClinikoID(rawValue: "5001"),
+        noteID: OpaqueClinikoID = OpaqueClinikoID(rawValue: "9876543"),
         clinikoStatus: Int = 201,
         appVersion: String = "0.3.0"
     ) -> AuditRecord {
@@ -70,11 +70,12 @@ struct AuditStoreTests {
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
         for index in 0..<5 {
-            try await store.record(Self.makeRecord(noteID: "note-\(index)"))
+            try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "note-\(index)")))
         }
         let loaded = try await store.loadAll()
 
-        #expect(loaded.map(\.noteID) == ["note-0", "note-1", "note-2", "note-3", "note-4"])
+        let expected = (0..<5).map { OpaqueClinikoID(rawValue: "note-\($0)") }
+        #expect(loaded.map(\.noteID) == expected)
     }
 
     @Test("loadAll on a fresh store returns an empty array")
@@ -96,9 +97,9 @@ struct AuditStoreTests {
         let store = LocalAuditStore(fileURL: url)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try await store.record(Self.makeRecord(noteID: "first"))
-        try await store.record(Self.makeRecord(noteID: "second"))
-        try await store.record(Self.makeRecord(noteID: "third"))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "first")))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "second")))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "third")))
 
         let raw = try Data(contentsOf: url)
         // Counting line-feed bytes — every record contributes a trailing
@@ -125,6 +126,50 @@ struct AuditStoreTests {
         // …and every required key is present (no field accidentally
         // omitted on the disk shape — required for replay parsing).
         #expect(Self.allowedKeys.isSubset(of: keys))
+    }
+
+    @Test("On-disk JSONL line carries OpaqueClinikoID values as bare strings (#59)")
+    func line_pins_opaque_id_byte_shape() async throws {
+        // Integration-level pin for the #59 wire-shape invariant:
+        // `OpaqueClinikoID` must encode as a bare JSON string, not as
+        // a wrapping `{"rawValue":"…"}` object. The type-level test
+        // (`OpaqueClinikoIDTests.codable_encodesAsBareString`) covers
+        // a single-value encode; this one covers the integration via
+        // `LocalAuditStore.makeEncoder()` so a future refactor that
+        // drops the custom `Codable` methods on the type-level
+        // doesn't pass the type-level test alone but break the
+        // disk-shape invariant the audit ledger depends on.
+        //
+        // The fixture rawValues here are the digit-shaped Cliniko IDs
+        // every production callsite uses (the picker writes
+        // `OpaqueClinikoID(Int)`); we don't pin the wrapping-object
+        // shape failure mode at this level because the type-level
+        // test already does.
+        let url = Self.tempAuditURL()
+        let store = LocalAuditStore(fileURL: url)
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+
+        try await store.record(Self.makeRecord(
+            patientID: OpaqueClinikoID(rawValue: "1001"),
+            appointmentID: OpaqueClinikoID(rawValue: "5001"),
+            noteID: OpaqueClinikoID(rawValue: "9876543")
+        ))
+
+        let raw = try Data(contentsOf: url)
+        let line = try #require(String(data: raw, encoding: .utf8))
+
+        // Bare-string fields, not wrapping objects.
+        #expect(line.contains("\"patient_id\":\"1001\""))
+        #expect(line.contains("\"appointment_id\":\"5001\""))
+        #expect(line.contains("\"note_id\":\"9876543\""))
+
+        // Negative pins — none of the wrapping-object byte sequences
+        // a regression to `RawRepresentable`'s synthesised `Codable`
+        // would emit.
+        #expect(!line.contains("\"patient_id\":{"))
+        #expect(!line.contains("\"appointment_id\":{"))
+        #expect(!line.contains("\"note_id\":{"))
+        #expect(!line.contains("\"rawValue\""))
     }
 
     @Test("Audit file is created with 0o600 permissions")
@@ -159,8 +204,8 @@ struct AuditStoreTests {
         let store = LocalAuditStore(fileURL: url)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try await store.record(Self.makeRecord(noteID: "good-1"))
-        try await store.record(Self.makeRecord(noteID: "good-2"))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "good-1")))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "good-2")))
         // Simulate a power-cut mid-write: append a partial line with no
         // trailing LF. Without tolerance, `loadAll` would throw on this
         // and the practitioner would lose visibility into every prior
@@ -172,7 +217,10 @@ struct AuditStoreTests {
 
         let loaded = try await store.loadAll()
 
-        #expect(loaded.map(\.noteID) == ["good-1", "good-2"])
+        #expect(loaded.map(\.noteID) == [
+            OpaqueClinikoID(rawValue: "good-1"),
+            OpaqueClinikoID(rawValue: "good-2")
+        ])
     }
 
     @Test("loadAll tolerates a corrupt middle line and surfaces the surrounding records")
@@ -181,18 +229,21 @@ struct AuditStoreTests {
         let store = LocalAuditStore(fileURL: url)
         defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
 
-        try await store.record(Self.makeRecord(noteID: "before"))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "before")))
         // Corrupt middle line — synthesised by writing junk bytes
         // between two LF separators directly to the file.
         let handle = try FileHandle(forWritingTo: url)
         try handle.seekToEnd()
         try handle.write(contentsOf: Data("not valid json\n".utf8))
         try handle.close()
-        try await store.record(Self.makeRecord(noteID: "after"))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "after")))
 
         let loaded = try await store.loadAll()
 
-        #expect(loaded.map(\.noteID) == ["before", "after"])
+        #expect(loaded.map(\.noteID) == [
+            OpaqueClinikoID(rawValue: "before"),
+            OpaqueClinikoID(rawValue: "after")
+        ])
     }
 
     // MARK: - InMemoryAuditStore parity
@@ -200,18 +251,21 @@ struct AuditStoreTests {
     @Test("InMemoryAuditStore round-trips records identically to LocalAuditStore")
     func inMemoryAuditStore_loadAll_returnsRecordedEntries() async throws {
         let store = InMemoryAuditStore()
-        try await store.record(Self.makeRecord(noteID: "a"))
-        try await store.record(Self.makeRecord(noteID: "b"))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "a")))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "b")))
 
         let loaded = try await store.loadAll()
 
-        #expect(loaded.map(\.noteID) == ["a", "b"])
+        #expect(loaded.map(\.noteID) == [
+            OpaqueClinikoID(rawValue: "a"),
+            OpaqueClinikoID(rawValue: "b")
+        ])
     }
 
     @Test("InMemoryAuditStore.reset clears recorded entries")
     func inMemoryAuditStore_reset_clearsEntries() async throws {
         let store = InMemoryAuditStore()
-        try await store.record(Self.makeRecord(noteID: "a"))
+        try await store.record(Self.makeRecord(noteID: OpaqueClinikoID(rawValue: "a")))
 
         await store.reset()
 

--- a/Tests/SpeechToTextTests/Services/Cliniko/TreatmentNoteExporterTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/TreatmentNoteExporterTests.swift
@@ -97,9 +97,12 @@ final class TreatmentNoteExporterTests: XCTestCase {
         let audit = try await auditStore.loadAll()
         XCTAssertEqual(audit.count, 1)
         let entry = try XCTUnwrap(audit.first)
-        XCTAssertEqual(entry.patientID, "1001")
-        XCTAssertEqual(entry.appointmentID, "5001")
-        XCTAssertEqual(entry.noteID, "9876543")
+        // ID fields are `OpaqueClinikoID` (#59); the exporter type-tags
+        // the wire-shape Int into the opaque form when building the
+        // audit row. Wire format on disk is unchanged (bare strings).
+        XCTAssertEqual(entry.patientID, OpaqueClinikoID(1001))
+        XCTAssertEqual(entry.appointmentID, OpaqueClinikoID(5001))
+        XCTAssertEqual(entry.noteID, OpaqueClinikoID(9876543))
         XCTAssertEqual(entry.clinikoStatus, 201)
         XCTAssertEqual(entry.appVersion, "0.3.0-test")
         XCTAssertEqual(entry.timestamp, Date(timeIntervalSince1970: 1_777_320_000))

--- a/Tests/SpeechToTextTests/Services/SessionStoreTests.swift
+++ b/Tests/SpeechToTextTests/Services/SessionStoreTests.swift
@@ -58,13 +58,15 @@ struct SessionStoreTests {
         let store = SessionStore()
         let notes = StructuredNotes(subjective: "subjective-placeholder")
         let id = UUID()
+        let patientID = OpaqueClinikoID(rawValue: "patient-1")
+        let appointmentID = OpaqueClinikoID(rawValue: "appt-1")
         let session = ClinicalSession(
             id: id,
             recordingSession: RecordingSession(),
             draftNotes: notes,
             excludedReAdded: ["snippet-placeholder"],
-            selectedPatientID: "patient-1",
-            selectedAppointmentID: "appt-1"
+            selectedPatientID: patientID,
+            selectedAppointmentID: appointmentID
         )
 
         store.start(session)
@@ -73,8 +75,8 @@ struct SessionStoreTests {
         #expect(active.id == id)
         #expect(active.draftNotes == notes)
         #expect(active.excludedReAdded == ["snippet-placeholder"])
-        #expect(active.selectedPatientID == "patient-1")
-        #expect(active.selectedAppointmentID == "appt-1")
+        #expect(active.selectedPatientID == patientID)
+        #expect(active.selectedAppointmentID == appointmentID)
     }
 
     // MARK: - replace
@@ -130,14 +132,14 @@ struct SessionStoreTests {
     @Test("setSelectedPatient is a no-op when active is nil")
     func setSelectedPatient_noopWhenInactive() {
         let store = SessionStore()
-        store.setSelectedPatient(id: "patient-1")
+        store.setSelectedPatient(id: OpaqueClinikoID(rawValue: "patient-1"))
         #expect(store.active == nil)
     }
 
     @Test("setSelectedAppointment is a no-op when active is nil")
     func setSelectedAppointment_noopWhenInactive() {
         let store = SessionStore()
-        store.setSelectedAppointment(id: "appt-1")
+        store.setSelectedAppointment(id: OpaqueClinikoID(rawValue: "appt-1"))
         #expect(store.active == nil)
     }
 
@@ -196,8 +198,9 @@ struct SessionStoreTests {
         let store = SessionStore()
         store.start(from: RecordingSession())
 
-        store.setSelectedPatient(id: "patient-1")
-        #expect(store.active?.selectedPatientID == "patient-1")
+        let patientID = OpaqueClinikoID(rawValue: "patient-1")
+        store.setSelectedPatient(id: patientID)
+        #expect(store.active?.selectedPatientID == patientID)
 
         store.setSelectedPatient(id: nil)
         #expect(store.active?.selectedPatientID == nil)
@@ -208,8 +211,9 @@ struct SessionStoreTests {
         let store = SessionStore()
         store.start(from: RecordingSession())
 
-        store.setSelectedAppointment(id: "appt-1")
-        #expect(store.active?.selectedAppointmentID == "appt-1")
+        let appointmentID = OpaqueClinikoID(rawValue: "appt-1")
+        store.setSelectedAppointment(id: appointmentID)
+        #expect(store.active?.selectedAppointmentID == appointmentID)
 
         store.setSelectedAppointment(id: nil)
         #expect(store.active?.selectedAppointmentID == nil)
@@ -298,8 +302,8 @@ struct SessionStoreTests {
         store.start(from: RecordingSession())
         store.setDraftNotes(StructuredNotes(subjective: "subjective-placeholder"))
         store.markExcludedReAdded("snippet-placeholder")
-        store.setSelectedPatient(id: "patient-1")
-        store.setSelectedAppointment(id: "appt-1")
+        store.setSelectedPatient(id: OpaqueClinikoID(rawValue: "patient-1"))
+        store.setSelectedAppointment(id: OpaqueClinikoID(rawValue: "appt-1"))
         store.touch()
         _ = store.checkIdleTimeout()
         store.clear()
@@ -328,8 +332,8 @@ struct SessionStoreTests {
             assessment: "assessment-placeholder",
             plan: "plan-placeholder"
         ))
-        store.setSelectedPatient(id: "patient-1")
-        store.setSelectedAppointment(id: "appt-1")
+        store.setSelectedPatient(id: OpaqueClinikoID(rawValue: "patient-1"))
+        store.setSelectedAppointment(id: OpaqueClinikoID(rawValue: "appt-1"))
 
         store.clear()
 

--- a/Tests/SpeechToTextTests/ViewModels/ReviewViewModelTests.swift
+++ b/Tests/SpeechToTextTests/ViewModels/ReviewViewModelTests.swift
@@ -294,7 +294,7 @@ struct ReviewViewModelTests {
         let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
         #expect(!viewModel.canExport)
 
-        store.setSelectedPatient(id: "42")
+        store.setSelectedPatient(id: OpaqueClinikoID(42))
         #expect(viewModel.canExport)
     }
 
@@ -326,7 +326,7 @@ struct ReviewViewModelTests {
     @Test("triggerExport with a patient posts .clinicalNotesExportRequested")
     func triggerExportWithPatientPosts() async {
         let store = makeSessionWith()
-        store.setSelectedPatient(id: "99")
+        store.setSelectedPatient(id: OpaqueClinikoID(99))
 
         let viewModel = ReviewViewModel(sessionStore: store, manipulations: stubManipulations())
 

--- a/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
+++ b/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
@@ -196,7 +196,7 @@ struct PatientPickerViewModelTests {
         let patient = Patient(id: 1234, firstName: "Sample", lastName: "Patient")
         vm.selectPatient(patient)
 
-        #expect(store.active?.selectedPatientID == "1234")
+        #expect(store.active?.selectedPatientID == OpaqueClinikoID(1234))
         #expect(vm.selectedPatient == patient)
         #expect(vm.appointmentPhase == .loading)
     }
@@ -216,7 +216,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.selectAppointment(id: 5678)
-        #expect(store.active?.selectedAppointmentID == "5678")
+        #expect(store.active?.selectedAppointmentID == OpaqueClinikoID(5678))
         #expect(vm.selectedAppointmentID == 5678)
 
         vm.selectAppointment(id: nil)


### PR DESCRIPTION
## Summary
- Introduces `OpaqueClinikoID` (`RawRepresentable, Codable, Sendable, Hashable`) at the audit ledger + `SessionStore` boundaries so the type system refuses free-form strings — `"Mrs. Smith"` can no longer sneak into `AuditRecord.patientID`.
- Custom `Codable` encodes/decodes as a **bare JSON string** (`singleValueContainer`), so `audit.jsonl` rows are byte-identical pre/post-#59. Pinned by both type-level and integration-level tests.
- Wire-shape `Int` IDs on `Patient`, `Appointment`, `TreatmentNotePayload` are deliberately preserved — those are what Cliniko's HTTP API speaks. The `TreatmentNoteExporter` is the boundary that type-tags into `OpaqueClinikoID` at the audit-write moment.

Closes #59. Unblocks #14 (export-flow UI) so the picker → SessionStore → exporter → audit handoff is type-checked end-to-end.

## Files migrated
- `AuditRecord.{patientID, noteID}` → `OpaqueClinikoID`; `.appointmentID` → `OpaqueClinikoID?`
- `ClinicalSession.{selectedPatientID, selectedAppointmentID}` → `OpaqueClinikoID?`
- `SessionStore.setSelectedPatient/Appointment(id:)` parameter types
- `PatientPickerViewModel` writethrough (`OpaqueClinikoID(patient.id)` instead of `String(patient.id)`)
- `TreatmentNoteExporter` audit-row construction
- Test fixtures across `ClinicalSessionTests`, `SessionStoreTests`, `AuditStoreTests`, `TreatmentNoteExporterTests`, `ReviewViewModelTests`, `PatientPickerViewModelTests`

## Pre-PR three-layer review (Opus)
Per `AGENTS.md` — `pr-review-toolkit:code-reviewer` + `type-design-analyzer` (mandatory for new type) + `silent-failure-hunter` (PHI surface) ran in parallel. Applied:
- **Dropped `intValue: Int?`** — dead code today; the soft-fail Optional encouraged `?? 0` swallow patterns at future callsites. #14 will define its own conversion at the right boundary.
- **Removed `CustomStringConvertible`** — `description = rawValue` made `\(id)` interpolation read as an innocuous integer in logs. Without it, `String(describing:)` falls back to the reflection form (`OpaqueClinikoID(rawValue: "1001")`) which is obviously PHI-shaped, so accidental log sites read as a leak.
- **Tightened `init(rawValue:)` doc-comment** — differentiates Codable / test use from production callsites; explains `RawRepresentable` rationale.
- **Added integration-level wire-shape test** (`AuditStoreTests.line_pins_opaque_id_byte_shape`) — pins the actual on-disk JSONL bytes (`"patient_id":"1001"`) so a future refactor that drops the custom `Codable` methods can't pass the type-level test alone but break the disk-shape invariant.
- **Doc symmetry** on `setSelectedAppointment`.

Deferred to follow-up: **phantom typing** (`OpaqueClinikoID<Patient>` vs `<Appointment>` vs `<TreatmentNote>`). Would prevent copy-paste bugs at the audit-row construction site, but expands beyond #59's "ONE struct" spec. Non-breaking source-wise to add later.

Other deferred concerns from review (all defensible to defer):
- **#58** (real HTTP status threaded through `ClinikoClient.send<T>`) — orthogonal; `TreatmentNoteExporter`'s `clinikoStatus: 201` lie is moot for the only audited endpoint today.
- **Boundary asymmetry** — `TreatmentNoteExporter.export(patientID: Int, ...)` still takes `Int`; #14's export-flow VM will hold `OpaqueClinikoID?` from `SessionStore` and convert at its own boundary. Conscious decision — flagged in the PR body so #14 can pick the right shape.

## Test plan
- [x] `swift test --parallel` — **252 tests passed in 24 suites**
- [x] `swiftlint lint --strict` — clean
- [x] `pre-commit run --files <changed>` — clean
- [x] On-disk wire-shape (audit.jsonl) byte-pinned via new integration test
- [x] PHI invariant — `AuditRecord` schema unchanged; ID fields are now `OpaqueClinikoID` (refusing `String` at the type level)
- [ ] CI on PR open (awaiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)