### PR TITLE
test(services,ui): close #15 + #16 — service test polish, SafetyDisclaimerView coverage, Keychain deleteAll fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
       #   WakeWordServiceTests              reads real WAV fixtures from models
       #   GeneralSectionPersistenceTests    shared UserDefaults race under --parallel;
       #                                     tracked for fix, runs pre-push serially.
+      #   KeychainSecureStoreTests          real macOS Keychain — Swift Testing suite
+      #                                     tagged .requiresHardware; will migrate to
+      #                                     --skip-tag requiresHardware once #31 lands.
       - name: Run unit tests (with coverage)
         shell: bash
         run: |
@@ -164,7 +167,8 @@ jobs:
             --skip TextInsertionServiceTests \
             --skip VoiceTriggerMonitoringServiceTests \
             --skip WakeWordServiceTests \
-            --skip GeneralSectionPersistenceTests 2>&1 | tee test.log
+            --skip GeneralSectionPersistenceTests \
+            --skip KeychainSecureStoreTests 2>&1 | tee test.log
 
       # Coverage export is a *required* part of this job — the whole point is
       # PR-visible coverage. A missing profdata / xctest bundle / binary

--- a/Sources/Services/KeychainSecureStore.swift
+++ b/Sources/Services/KeychainSecureStore.swift
@@ -154,10 +154,33 @@ public actor KeychainSecureStore: SecureStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service
         ]
-        let status = SecItemDelete(query as CFDictionary)
-        guard status == errSecSuccess || status == errSecItemNotFound else {
-            logger.error("deleteAll failed service=\(self.service, privacy: .public) status=\(status)")
-            throw Failure.osStatus(status, .deleteAll)
+        // `SecItemDelete` on macOS removes only one matching item per call
+        // even though the documentation says it "deletes all matching items"
+        // — a long-standing legacy-keychain quirk. Loop until the keychain
+        // reports `errSecItemNotFound` so a service namespace holding multiple
+        // credentials is fully wiped on `deleteAll`. Caught by
+        // `KeychainSecureStoreTests.deleteAll_removesAllItems` (the prior
+        // single-call implementation left every item except the first).
+        //
+        // The loop is bounded as a defensive guard: an ACL bug, a daemon
+        // edge case, or a concurrent process re-inserting items under the
+        // same `service` could otherwise wedge the actor's executor and
+        // silently fail every queued call behind it. 10_000 is far above
+        // any plausible item count for one Cliniko-credential namespace.
+        let maxIterations = 10_000
+        for _ in 0..<maxIterations {
+            let status = SecItemDelete(query as CFDictionary)
+            switch status {
+            case errSecSuccess:
+                continue
+            case errSecItemNotFound:
+                return
+            default:
+                logger.error("deleteAll failed service=\(self.service, privacy: .public) status=\(status)")
+                throw Failure.osStatus(status, .deleteAll)
+            }
         }
+        logger.error("deleteAll exceeded \(maxIterations) iterations service=\(self.service, privacy: .public)")
+        throw Failure.osStatus(errSecInternalError, .deleteAll)
     }
 }

--- a/Tests/SpeechToTextTests/Services/ClinicalNotesProcessorTests.swift
+++ b/Tests/SpeechToTextTests/Services/ClinicalNotesProcessorTests.swift
@@ -285,6 +285,74 @@ struct ClinicalNotesProcessorTests {
         #expect(notes.excluded == ["weekend small talk", "coffee banter"])
     }
 
+    // MARK: - Sendable / concurrency contract (#15 polish)
+
+    /// Documents the public-surface contract that `ClinicalNotesProcessor`
+    /// (an `actor`) and its `Outcome` payload satisfy `Sendable`. The
+    /// processor is shipped across actor boundaries by the recording
+    /// modal — its `Task` hops the outcome back to the `@MainActor`
+    /// review view model — so both types must round-trip across
+    /// isolation cleanly.
+    ///
+    /// Caveat: this project is on Swift 5.9 language mode (per
+    /// `Package.swift`), so a hypothetical future demotion to `class`
+    /// without an explicit `Sendable` conformance would emit a
+    /// *warning* at the call site rather than a hard compile error.
+    /// SwiftLint's strict mode escalates the warning to an error in CI.
+    /// Consider this test executable documentation rather than a
+    /// load-bearing barrier.
+    @Test("ClinicalNotesProcessor and Outcome conform to Sendable")
+    func sendableConformancePin() {
+        func requireSendable<T: Sendable>(_: T.Type) {}
+        requireSendable(ClinicalNotesProcessor.self)
+        requireSendable(ClinicalNotesProcessor.Outcome.self)
+    }
+
+    /// Smoke test that N concurrent `process(transcript:)` calls all
+    /// reach `.success` and the provider observed every call. Pins
+    /// the high-level "actor handles concurrent traffic without
+    /// dropping or duplicating work" invariant; the actor's
+    /// per-call serialization is enforced by the type system, not
+    /// by this test.
+    ///
+    /// Failure surface is per-task: the `failures` array reports
+    /// each non-`.success` outcome with its index and the structural
+    /// fallback reason, so a regression that fails 1 of N tasks
+    /// doesn't read as a generic "expected true, got false".
+    @Test("Concurrent process(transcript:) calls each reach .success and are accounted for")
+    func concurrentProcessCalls_eachReachSuccess() async {
+        let provider = MockLLMProvider(response: Self.validJSON)
+        let proc = Self.processor(provider: provider)
+        let parallelism = 16
+
+        let outcomes: [ClinicalNotesProcessor.Outcome] = await withTaskGroup(
+            of: ClinicalNotesProcessor.Outcome.self,
+            returning: [ClinicalNotesProcessor.Outcome].self
+        ) { group in
+            for _ in 0..<parallelism {
+                group.addTask { await proc.process(transcript: "t") }
+            }
+            var collected: [ClinicalNotesProcessor.Outcome] = []
+            for await outcome in group {
+                collected.append(outcome)
+            }
+            return collected
+        }
+
+        #expect(outcomes.count == parallelism)
+
+        let failures = outcomes.enumerated().compactMap { index, outcome -> String? in
+            if case .success = outcome { return nil }
+            return "task[\(index)] = \(outcome)"
+        }
+        #expect(
+            failures.isEmpty,
+            "Concurrent process calls produced non-success outcomes: \(failures)"
+        )
+
+        #expect(await provider.callCount() == parallelism)
+    }
+
     // MARK: - Helpers
 
     /// Render a minimal SOAP JSON response with the given manipulations

--- a/Tests/SpeechToTextTests/Services/KeychainSecureStoreTests.swift
+++ b/Tests/SpeechToTextTests/Services/KeychainSecureStoreTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+// Round-trip tests against the **real** macOS Keychain (#15 polish).
+//
+// Tagged `.requiresHardware` because they touch the user-level keychain
+// — CI skips them via `--skip-tag requiresHardware` per
+// `.claude/references/testing-conventions.md`. They run on the
+// developer's Mac and on pre-push remote-Mac runs (`scripts/remote-test.sh`).
+//
+// The wrapper-level behaviour of `ClinikoCredentialStore` is already
+// covered against `InMemorySecureStore` in `Cliniko/ClinikoCredentialStoreTests`;
+// the goal of this file is to pin the **real `KeychainSecureStore`** —
+// `SecItemAdd` / `SecItemUpdate` / `SecItemCopyMatching` /
+// `SecItemDelete` wiring + the `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
+// guarantee — against an actual keychain.
+//
+// Every test uses a UUID-suffixed service so cross-run isolation is
+// guaranteed and no production key is touched. Happy-path tests call
+// `deleteAll()` at the end to keep the user's keychain tidy.
+//
+// ### Coverage left intentionally untested
+//
+// `Failure.unexpectedItemType` (in `KeychainSecureStore.get`) cannot be
+// triggered without first inserting a non-`Data` item via lower-level
+// Keychain APIs (e.g. `SecItemAdd` with `kSecValueRef` instead of
+// `kSecValueData`). That is itself a Keychain-manipulation hazard not
+// justified for a single error branch — the mapping is reviewed by
+// inspection at `Sources/Services/KeychainSecureStore.swift:122-129`.
+//
+// `Failure.osStatus` mapping is similarly only reachable via
+// fault-injection at the `SecItem*` layer; SecureStore-level error
+// surfacing is already covered through the `ThrowingSecureStore` stub
+// in `ClinikoCredentialStoreTests`.
+
+@Suite("KeychainSecureStore (real Keychain)", .tags(.requiresHardware))
+struct KeychainSecureStoreTests {
+
+    /// UUID-suffixed service per test guarantees no cross-run / cross-test
+    /// collision. Service names are unique, so any leftover items from a
+    /// crashed test run are harmless (and orphaned to that UUID forever).
+    private static func uniqueService() -> String {
+        "com.speechtotext.tests.\(UUID().uuidString)"
+    }
+
+    // MARK: - Round-trip
+
+    @Test("set followed by get returns the stored Data verbatim")
+    func setGet_returnsStoredData() async throws {
+        let store = KeychainSecureStore(service: Self.uniqueService())
+        let payload = Data("secret-token-\(UUID().uuidString)".utf8)
+        let key = "test-key"
+
+        try await store.set(payload, forKey: key)
+        let retrieved = try await store.get(forKey: key)
+        #expect(retrieved == payload)
+        // Cleanup runs *after* the behavioural assertion so a transient
+        // keychain failure in cleanup doesn't mask the test's actual
+        // verdict. Best-effort via `try?` — the UUID-suffixed service
+        // makes any leftover row orphaned to this run only.
+        try? await store.deleteAll()
+    }
+
+    @Test("set on an existing key overwrites via the SecItemUpdate path")
+    func set_overwritesExistingValue() async throws {
+        let store = KeychainSecureStore(service: Self.uniqueService())
+        let key = "k"
+
+        try await store.set(Data("first".utf8), forKey: key)
+        try await store.set(Data("second".utf8), forKey: key)
+        let retrieved = try await store.get(forKey: key)
+        #expect(retrieved == Data("second".utf8))
+        try? await store.deleteAll()
+    }
+
+    // MARK: - Missing-key contract
+
+    /// The SecureStore contract is "missing returns `nil`, anything
+    /// else throws". Pin that an unset key returns `nil` and does not
+    /// surface as a thrown `Failure.osStatus(errSecItemNotFound, .get)`.
+    @Test("get returns nil for a key that has never been set")
+    func get_missingKey_returnsNil() async throws {
+        let store = KeychainSecureStore(service: Self.uniqueService())
+        let retrieved = try await store.get(forKey: "never-set")
+        #expect(retrieved == nil)
+    }
+
+    // MARK: - Delete
+
+    @Test("delete removes the item; subsequent get returns nil")
+    func delete_removesItem() async throws {
+        let store = KeychainSecureStore(service: Self.uniqueService())
+        let key = "k"
+
+        try await store.set(Data("payload".utf8), forKey: key)
+        try await store.delete(forKey: key)
+        let retrieved = try await store.get(forKey: key)
+        #expect(retrieved == nil)
+        try? await store.deleteAll()
+    }
+
+    /// `errSecItemNotFound` from `SecItemDelete` must be treated as
+    /// success — a `.delete` call after the item has already been
+    /// removed (or before it was ever set) is a legitimate idempotent
+    /// no-op.
+    @Test("delete is idempotent for a missing key (does not throw)")
+    func delete_missingKey_doesNotThrow() async throws {
+        let store = KeychainSecureStore(service: Self.uniqueService())
+        try await store.delete(forKey: "never-existed")
+    }
+
+    // MARK: - deleteAll
+
+    @Test("deleteAll removes every item under the service namespace")
+    func deleteAll_removesAllItems() async throws {
+        let store = KeychainSecureStore(service: Self.uniqueService())
+
+        try await store.set(Data("a".utf8), forKey: "k1")
+        try await store.set(Data("b".utf8), forKey: "k2")
+        try await store.deleteAll()
+
+        let r1 = try await store.get(forKey: "k1")
+        let r2 = try await store.get(forKey: "k2")
+        #expect(r1 == nil)
+        #expect(r2 == nil)
+    }
+
+    @Test("deleteAll on an empty namespace is idempotent")
+    func deleteAll_emptyNamespace_doesNotThrow() async throws {
+        let store = KeychainSecureStore(service: Self.uniqueService())
+        try await store.deleteAll()
+    }
+
+    // MARK: - Service-namespace isolation
+
+    /// Two stores with distinct services must not see each other's
+    /// items, even for the same key. Pins the `kSecAttrService`
+    /// scoping — a regression here would let one feature's credentials
+    /// leak into another's namespace.
+    @Test("Stores with different services do not see each other's items")
+    func differentServices_areIsolated() async throws {
+        let storeA = KeychainSecureStore(service: Self.uniqueService())
+        let storeB = KeychainSecureStore(service: Self.uniqueService())
+        let key = "shared-key-name"
+
+        try await storeA.set(Data("from-A".utf8), forKey: key)
+        let bSeesA = try await storeB.get(forKey: key)
+        #expect(bSeesA == nil)
+        try? await storeA.deleteAll()
+    }
+}

--- a/Tests/SpeechToTextTests/Views/SafetyDisclaimerViewRenderTests.swift
+++ b/Tests/SpeechToTextTests/Views/SafetyDisclaimerViewRenderTests.swift
@@ -76,4 +76,90 @@ final class SafetyDisclaimerViewRenderTests: XCTestCase {
     // serves as the modal-side single-shot, and the ack itself is
     // idempotent (`RecordingViewModel.acknowledgeSafetyDisclaimer` is
     // safe to call repeatedly — re-saving the same `true` value).
+
+    // MARK: - Render contract pins (#16)
+
+    /// AC item 1 (#12): the headline is the load-bearing safety
+    /// statement and was reviewed for clinical wording. Pin the exact
+    /// copy so an accidental softening (e.g. dropping "not a
+    /// diagnostic tool") is caught at test time, not in the field.
+    func test_safetyDisclaimer_titleCopyIsPinned() throws {
+        let view = SafetyDisclaimerView(onAcknowledge: {})
+        let inspected = try view.inspect()
+        let textValues = inspected
+            .findAll(ViewType.Text.self)
+            .compactMap { try? $0.string() }
+        XCTAssertTrue(
+            textValues.contains("This is a drafting assistant, not a diagnostic tool"),
+            "Disclaimer title copy must match the reviewed wording exactly. Found texts: \(textValues)"
+        )
+    }
+
+    /// AC item 1 (#12): the body must include the doctor-responsibility
+    /// clause. Substring assertion — leaves room for minor wording
+    /// tweaks while pinning the accountability statement.
+    func test_safetyDisclaimer_copyContainsResponsibilityClause() throws {
+        let view = SafetyDisclaimerView(onAcknowledge: {})
+        let inspected = try view.inspect()
+        let joined = inspected
+            .findAll(ViewType.Text.self)
+            .compactMap { try? $0.string() }
+            .joined(separator: " ")
+        XCTAssertTrue(
+            joined.contains("responsible for reviewing, editing, and clinically validating"),
+            "Disclaimer body must include the doctor-responsibility clause. Joined text was: \(joined)"
+        )
+    }
+
+    /// Pin the acknowledge button's label text. The button is the only
+    /// dismissal affordance (AC item 2: no escape, no tap-to-dismiss),
+    /// so the label is the doctor's contract — "I understand,
+    /// continue" is the reviewed wording.
+    func test_safetyDisclaimer_acknowledgeButton_labelTextIsPinned() throws {
+        let view = SafetyDisclaimerView(onAcknowledge: {})
+        let inspected = try view.inspect()
+        let button = try inspected
+            .find(viewWithAccessibilityIdentifier: "safetyDisclaimerView.acknowledgeButton")
+            .find(ViewType.Button.self)
+        let labelText = try button.labelView().find(ViewType.Text.self).string()
+        XCTAssertEqual(
+            labelText,
+            "I understand, continue",
+            "Acknowledge button label must match the reviewed wording exactly"
+        )
+    }
+
+    /// Pin `hasAcknowledged: Bool = false` as the initial state — the
+    /// acknowledge button must be enabled on first render so the
+    /// doctor can dismiss the modal. Catches an accidental flip of
+    /// the single-shot guard's initial value (which would deadlock
+    /// the modal on first render).
+    func test_safetyDisclaimer_acknowledgeButton_isInitiallyEnabled() throws {
+        let view = SafetyDisclaimerView(onAcknowledge: {})
+        let inspected = try view.inspect()
+        let button = try inspected
+            .find(viewWithAccessibilityIdentifier: "safetyDisclaimerView.acknowledgeButton")
+            .find(ViewType.Button.self)
+        XCTAssertFalse(
+            button.isDisabled(),
+            "Acknowledge button must be enabled on first render"
+        )
+    }
+
+    /// Pin the modal-overlay structural shape: the disclaimer's root
+    /// is a `ZStack` that lays the scrim behind the disclaimer card.
+    /// Mirrors the `RecordingModalRenderTests.test_recordingModal_viewHierarchy`
+    /// pattern. A refactor that swapped the structural container
+    /// (e.g. to a `VStack`) would change the layering and let
+    /// interaction leak through to the underlying recording modal.
+    ///
+    /// Uses the root `zStack()` accessor rather than `find(ZStack.self)`
+    /// so the test fails on a real refactor instead of accidentally
+    /// matching a SwiftUI-internal `ZStack` reachable via `Background`
+    /// / `Overlay` traversal.
+    func test_safetyDisclaimer_renderHierarchyRootIsZStack() throws {
+        let view = SafetyDisclaimerView(onAcknowledge: {})
+        let inspected = try view.inspect()
+        XCTAssertNoThrow(try inspected.zStack())
+    }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -49,6 +49,11 @@ ignore:
   - "Sources/Services/TextInsertionService.swift"
   - "Sources/Services/VoiceTriggerMonitoringService.swift"
   - "Sources/Services/WakeWordService.swift"
+  # Real-Keychain wrapper — `KeychainSecureStoreTests` is Swift Testing
+  # `.requiresHardware`-tagged and skipped in CI. The SecureStore
+  # contract callers consume is fully covered through
+  # `ClinikoCredentialStore` against `InMemorySecureStore`.
+  - "Sources/Services/KeychainSecureStore.swift"
   # App-lifecycle code: NSApplicationDelegate callbacks, NSApp wiring,
   # menu-bar / notification observer setup. Exercising these in a unit
   # test would require mocking NSApplication, NSStatusBar, etc — not


### PR DESCRIPTION
## Summary

- **Closes #15** — adds the two remaining unit-test polish gaps surfaced by the recon pass: a `Sendable` compile-time pin + per-task-attributed concurrent-call smoke test on `ClinicalNotesProcessor`, and a new `KeychainSecureStoreTests` suite (Swift Testing, `.requiresHardware`-tagged) round-tripping the real macOS Keychain via UUID-suffixed services.
- **Closes #16** — extends `SafetyDisclaimerViewRenderTests` from 4 to 9 ViewInspector render tests pinning #12 AC items: title copy, doctor-responsibility clause, the acknowledge button's label text + initial-enabled state, and the root-`ZStack` overlay structure.
- **Production fix** — the new Keychain test caught a real bug: `KeychainSecureStore.deleteAll()` previously called `SecItemDelete` once and macOS only removes one matching item per call (legacy-keychain quirk). Rewrote to loop until `errSecItemNotFound` with a 10_000-iteration safety bound to guard against ACL bugs / concurrent re-insertion wedging the actor's executor.
- CI skip-list entry added for `KeychainSecureStoreTests` until `--skip-tag requiresHardware` lands (#31).

## Pre-PR review pipeline (Layer 1)

Ran `pr-review-toolkit:code-reviewer` and `pr-review-toolkit:silent-failure-hunter` (both `model: opus`) in parallel. Both flagged the unbounded `deleteAll()` loop (BLOCKER / MAJOR) — folded in before push. Also folded:
- per-task failure attribution in the concurrent-process test (was `allSatisfy → bool`, now reports each non-success outcome with its index),
- cleanup ordering in the Keychain happy-path tests (assertion now runs before `try? await store.deleteAll()` cleanup so a transient cleanup failure can't mask the verdict),
- root-`zStack()` accessor instead of `find(ZStack.self)` (the latter could match a SwiftUI-internal ZStack via Background/Overlay traversal),
- softened the Sendable-pin docstring (Swift 5.9 mode emits a warning, not a hard error, on a hypothetical demoted type).

PHI-leak lens: clean. None of the new tests construct, log, or assert against transcript content / patient data / Cliniko response bodies.

## Test plan

- [x] `swift test --parallel` — 295 Swift Testing tests in 27 suites pass; 9 SafetyDisclaimer XCTest render tests pass; pre-existing WakeWord failures unchanged (CI skip-list).
- [x] `swift test --parallel --skip KeychainSecureStoreTests` — confirms hardware-tagged suite is properly excluded from the CI path.
- [x] `pre-commit run --files <changed>` — SwiftLint, secrets, YAML/JSON syntax, all pass.
- [x] `swiftlint lint --strict` — clean.
- [ ] Awaiting CI on this PR.
- [ ] Awaiting Gemini Code Assist (Layer 2).

## Out of scope (deliberately deferred)

- The `unexpectedItemType` mapping in `KeychainSecureStore.get` is reviewed by inspection — exercising it requires inserting a non-Data item via lower-level Keychain APIs, not justified for a single error branch. Justification baked into the new test file's header.
- `KeychainSecureStore.Failure.osStatus` mapping is similarly reachable only via fault-injection at `SecItem*`; SecureStore-level surfacing is already covered through `ThrowingSecureStore` in `ClinikoCredentialStoreTests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)