### PR TITLE
docs(clinical-notes): component AGENTS.md for ClinicalNotes services + Cliniko + ClinicalNotes views (#17)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -109,17 +109,45 @@ For every non-trivial PR, exercise all three:
 ```
 Sources/
 ├── SpeechToTextApp/     # App entry point (@main, AppDelegate, AppState)
-├── Services/            # Business logic layer (7 services)
-├── Models/              # Data structures (5 models)
-├── Views/               # SwiftUI views + ViewModels (12 files)
-│   └── Components/      # Reusable UI components (4 files)
+├── Services/            # Business logic layer
+│   ├── ClinicalNotes/   # SOAP pipeline: SessionStore, ClinicalNotesProcessor,
+│   │                    # ClinicalNotesPromptBuilder, LLMProvider,
+│   │                    # ManipulationsRepository, ExportFlowCoordinator
+│   │                    # → load AGENTS.md when editing
+│   ├── Cliniko/         # HTTP + creds + audit: ClinikoClient, ClinikoEndpoint,
+│   │                    # ClinikoError, ClinikoCredentialStore, ClinikoShard,
+│   │                    # ClinikoAuthProbe, ClinikoPatientService,
+│   │                    # ClinikoAppointmentService, TreatmentNoteExporter,
+│   │                    # AuditStore  → load AGENTS.md when editing
+│   └── (top-level)      # General STT + system: AudioCaptureService,
+│                        # FluidAudioService, HotkeyManager, KeychainSecureStore,
+│                        # PermissionService, SecureStore, SettingsService,
+│                        # ShortcutNames, StatisticsService, TextInsertionService,
+│                        # VoiceTriggerMonitoringService, WakeWordService
+├── Models/              # Data structures (Patient, Appointment, ClinicalSession,
+│                        # OpaqueClinikoID, TreatmentNotePayload, etc.)
+├── Views/               # SwiftUI views + ViewModels
+│   ├── ClinicalNotes/   # Disclaimer + Review + Picker + Export flow
+│   │                    # → load AGENTS.md when editing
+│   ├── MainView/        # Main window + sections
+│   ├── GlassOverlay/    # Recording overlay window
+│   └── Components/      # Reusable UI components
 └── Utilities/           # Extensions, constants, and logging
     └── Extensions/      # Color+Theme, etc.
 
 Tests/
-└── SpeechToTextTests/   # XCTest suite (24 test files)
+└── SpeechToTextTests/   # Mixed XCTest + Swift Testing
+    ├── Utilities/       # URLProtocolStub, InMemorySecureStore, TestTags,
+    │                    # MockLLMProvider, exemplars
+    ├── Fixtures/        # cliniko/, soap/, llm/ — test bundle resources
+    ├── Services/        # service unit tests
+    └── Views/           # ViewInspector + crash-detection + scoped snapshots
 
-UITests/                 # XCUITest E2E tests
+UITests/                 # XCUITest E2E tests (pre-push / remote Mac only)
+
+.claude/references/      # Topic-router refs — load on demand
+                         # concurrency / testing-conventions / cliniko-api /
+                         # phi-handling / mlx-lifecycle / menubar-integration
 
 scripts/                 # Build and test automation
 ├── build-app.sh         # Build signed .app bundle (--sync for remote Mac)
@@ -130,6 +158,15 @@ scripts/                 # Build and test automation
 ├── export-dmg.sh        # Create distributable DMG
 └── setup-ssh-for-mac.sh # Configure SSH for remote testing
 ```
+
+**Component AGENTS.md** files exist for the three clinical-notes-mode
+subdirs above — load the matching one when editing files in that folder
+(don't load all three together; the Topic Router pattern keeps context
+lean):
+
+- [`Sources/Services/ClinicalNotes/AGENTS.md`](../Sources/Services/ClinicalNotes/AGENTS.md)
+- [`Sources/Services/Cliniko/AGENTS.md`](../Sources/Services/Cliniko/AGENTS.md)
+- [`Sources/Views/ClinicalNotes/AGENTS.md`](../Sources/Views/ClinicalNotes/AGENTS.md)
 
 ## Key Architectural Patterns
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,10 +31,24 @@ them at once** — the whole point of the router is context efficiency.
 | Working on the LLM provider, model loading / warmup / fallback | [`.claude/references/mlx-lifecycle.md`](.claude/references/mlx-lifecycle.md) |
 | Touching the menu-bar icon, hotkey, recording modal window, or Accessibility text insertion | [`.claude/references/menubar-integration.md`](.claude/references/menubar-integration.md) |
 
-Component-scoped `AGENTS.md` files will live alongside new
-subdirectories as they're created (`Sources/Services/ClinicalNotes/`,
-`Sources/Services/Cliniko/`, `Sources/Views/ClinicalNotes/` — tracked
-in #17).
+Component-scoped `AGENTS.md` files live alongside the
+clinical-notes-mode subdirectories. Load the one whose folder you're
+editing in:
+
+- [`Sources/Services/ClinicalNotes/AGENTS.md`](Sources/Services/ClinicalNotes/AGENTS.md)
+  — `SessionStore`, `ClinicalNotesProcessor`, `ClinicalNotesPromptBuilder`,
+  `LLMProvider`, `ManipulationsRepository`, `ExportFlowCoordinator`.
+- [`Sources/Services/Cliniko/AGENTS.md`](Sources/Services/Cliniko/AGENTS.md)
+  — `ClinikoClient`, `ClinikoEndpoint`, `ClinikoError`,
+  `ClinikoCredentialStore`, `ClinikoShard`, `ClinikoAuthProbe`,
+  `ClinikoPatientService`, `ClinikoAppointmentService`,
+  `TreatmentNoteExporter`, `AuditStore`.
+- [`Sources/Views/ClinicalNotes/AGENTS.md`](Sources/Views/ClinicalNotes/AGENTS.md)
+  — `SafetyDisclaimerView`, `ReviewScreen` / `ReviewWindow` /
+  `ReviewWindowController` / `ReviewViewModel`, `SOAPSectionEditor`,
+  `ManipulationsChecklist`, `ExcludedContentDrawer`, `RawTranscriptSheet`,
+  `PatientPickerView` / `PatientPickerViewModel`, `ExportFlowView` /
+  `ExportFlowViewModel`.
 
 ---
 
@@ -226,6 +240,45 @@ UITests/             # XCUITest (pre-push / remote Mac only)
 docs/                # Long-form docs (also linked from references/)
 scripts/             # build, test, deploy automation
 ```
+
+---
+
+## Clinical Notes Mode (flow overview)
+
+The post-recording extension. From a completed transcript, produce a
+draft SOAP note, let the doctor edit it, and POST to Cliniko — all
+on-device, session-only PHI, opt-in via Settings.
+
+1. **Settings toggle** flips Clinical Notes Mode on (`AppState`
+   wires the dependencies — see `Sources/SpeechToTextApp/AppState.swift`).
+2. **Recording** runs unchanged (FluidAudio → `RecordingSession`).
+3. **Generate Notes** action on the recording modal hands the transcript to
+   `SessionStore` → `ClinicalNotesProcessor` → `LLMProvider`
+   (`MLXGemmaProvider` / `MockLLMProvider`). Retry-once on schema-invalid
+   JSON, raw-transcript fallback on second failure.
+4. **Safety Disclaimer** modal shows on first entry (one-time
+   `UserDefaults` ack — issue [#12](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/12)).
+5. **ReviewScreen** opens with two-column layout (SOAP editors +
+   manipulations checklist + excluded drawer — issue [#13](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/13)).
+6. **PatientPicker** sheet selects a Cliniko patient + appointment via
+   `ClinikoPatientService` / `ClinikoAppointmentService`.
+7. **Export** runs `ExportFlowCoordinator` → `TreatmentNoteExporter` →
+   `POST /treatment_notes` → metadata-only `AuditStore` row → success
+   surface clears `SessionStore`.
+
+Component AGENTS.md (load the one whose folder you're editing):
+
+- [`Sources/Services/ClinicalNotes/AGENTS.md`](Sources/Services/ClinicalNotes/AGENTS.md)
+  — pipeline services + LLM seam.
+- [`Sources/Services/Cliniko/AGENTS.md`](Sources/Services/Cliniko/AGENTS.md)
+  — HTTP client + credentials + audit ledger.
+- [`Sources/Views/ClinicalNotes/AGENTS.md`](Sources/Views/ClinicalNotes/AGENTS.md)
+  — Review / Picker / Export UI.
+
+EPIC: [#1 — Clinical Notes Mode](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/1).
+Locked technical decisions (LLM runtime, model v1, persistence, UI entry,
+Cliniko scope, testing stack) live in the EPIC body and
+`.claude/CLAUDE.md` — don't re-litigate without an explicit ask.
 
 ---
 

--- a/Sources/Services/ClinicalNotes/AGENTS.md
+++ b/Sources/Services/ClinicalNotes/AGENTS.md
@@ -97,9 +97,9 @@ The pipeline:
 
 ### Determinism / golden tests
 
-- `LLMOptions` defaults (`temperature: 0`, `topP: 1.0`, `seed: 42`)
-  + the deterministic prompt builder make `MLXGemmaProvider` output
-  reproducible for a given transcript. The nightly LLM goldens
+- `LLMOptions` defaults (`temperature: 0`, `topP: 1.0`, `seed: 42`),
+  paired with the deterministic prompt builder, make `MLXGemmaProvider`
+  output reproducible for a given transcript. The nightly LLM goldens
   (`RUN_MLX_GOLDEN=1`) depend on this. **Anything that breaks
   determinism breaks the goldens** — re-ordering the manipulations
   list, changing the prompt template's whitespace, varying option

--- a/Sources/Services/ClinicalNotes/AGENTS.md
+++ b/Sources/Services/ClinicalNotes/AGENTS.md
@@ -1,0 +1,181 @@
+# AGENTS.md — `Sources/Services/ClinicalNotes/`
+
+> **Load this when:** writing or reviewing anything in
+> `Sources/Services/ClinicalNotes/` — the post-recording SOAP-note
+> pipeline. For HTTP / Cliniko, see [`../Cliniko/AGENTS.md`](../Cliniko/AGENTS.md).
+> For the review surface, see [`../../Views/ClinicalNotes/AGENTS.md`](../../Views/ClinicalNotes/AGENTS.md).
+
+## Purpose
+
+This subdirectory owns the **transcript → structured SOAP →
+practitioner-ready ViewModel** seam. It sits between the recording
+layer (FluidAudio → `RecordingSession`) and the Cliniko export layer
+(`../Cliniko/`). Nothing in here makes network calls, nothing in here
+writes to disk, and nothing in here logs PHI — see
+[`../../../.claude/references/phi-handling.md`](../../../.claude/references/phi-handling.md).
+
+The pipeline:
+
+1. `SessionStore` ingests a completed `RecordingSession`.
+2. `ClinicalNotesProcessor` runs the transcript through an
+   `LLMProvider`, validates the response against the schema, and
+   produces a `StructuredNotes` (or a fallback sentinel).
+3. The practitioner edits the draft in `ReviewScreen`; manipulation
+   IDs resolve via `ManipulationsRepository`.
+4. On Export, `ExportFlowCoordinator` builds an `ExportFlowViewModel`
+   wired to the Cliniko exporter.
+
+---
+
+## Key types
+
+| Type | Role |
+|---|---|
+| `SessionStore` | `@MainActor` `@Observable`. Single-writer owner of the active `ClinicalSession` (transcript, draft, patient/appointment selection). Session-only — `clear()` on export success, quit, cancel, or `checkIdleTimeout()`. |
+| `ClinicalNotesProcessor` | `actor`. Drives transcript → `StructuredNotes` via `LLMProvider`. **Retry-once contract** on schema-invalid responses; falls back to raw transcript on second failure. Never throws — all failures resolve to `Outcome.rawTranscriptFallback(reason:)` with a structural sentinel. |
+| `ClinicalNotesPromptBuilder` | `struct` (`Sendable`). Pure-logic prompt assembly + JSON schema validation. Loads `Resources/Prompts/soap_v1.txt`; substitutes `{{manipulations_list}}` then `{{transcript}}`. `validate(json:)` returns `Result<RawLLMDraft, SchemaError>`; tolerates code fences + trailing commentary, rejects malformed payloads with **PHI-safe** structural errors only. |
+| `LLMProvider` (protocol) | `Actor`-constrained. `generate(prompt:options:)` → `String`; `nonisolated generateStream(...)` for incremental UIs. Concrete: `MLXGemmaProvider` (production) / `MockLLMProvider` (tests). See [`../../../.claude/references/concurrency.md`](../../../.claude/references/concurrency.md) §6 for why Actor-constrained — actors cannot be subclassed, so mocks must conform via the protocol. |
+| `LLMOptions` | `Sendable` struct of sampling knobs. **Defaults are deterministic**: `temperature: 0`, `seed: 42`. The processor passes these unchanged so the same transcript yields the same JSON across runs — the assumption the LLM golden tests rely on. |
+| `ManipulationsRepository` | Immutable value type; `Sendable` by construction. Loads the bundled chiropractic-manipulations taxonomy (`Resources/Manipulations/placeholder.json` for v1; one-file swap when the real Cliniko taxonomy lands). Consumed by the prompt builder, the ReviewScreen checklist, and the Cliniko export mapping. Not PHI. |
+| `ExportFlowCoordinator` | `@MainActor` singleton (`.shared`). Factory that wires `SessionStore` + `ManipulationsRepository` + `TreatmentNoteExporter` + AppKit callbacks (`closeReviewWindow`, `openClinikoSettings`) into a fresh `ExportFlowViewModel` per Export tap. Configured once by `AppState.init`. **Lives at the clinical-notes seam, not inside the Cliniko HTTP layer** — its job is wiring those collaborators together so `ReviewViewModel` doesn't have to know about Cliniko. Don't relitigate the placement. |
+
+---
+
+## Common pitfalls
+
+### PHI
+
+- **Never** log `transcript`, prompt body, LLM response text, SOAP
+  fields, patient name, DOB, or contact. `OSLog` `privacy: .public`
+  is reserved for **structural** values: attempt counter, `String(describing:
+  type(of: error))`, `SchemaError` case tags, dotted JSON `keyPath`s.
+- **Never** interpolate caught `Error.localizedDescription` into a
+  log line or fallback `reason` — `DecodingError`-style value-quoting
+  is the classic leak. The processor uses two opaque sentinels:
+  `reasonLLMError` and `reasonInvalidJSONAfterRetry`.
+- See [`../../../.claude/references/phi-handling.md`](../../../.claude/references/phi-handling.md)
+  for the full policy.
+
+### `LLMProvider` is `Actor`-constrained
+
+- Concrete providers (`MLXGemmaProvider`, `MockLLMProvider`) are
+  actors. Actors cannot be subclassed, so test doubles must conform
+  to `LLMProvider` directly. Use `MockLLMProvider` from
+  `Tests/SpeechToTextTests/Utilities/MockLLMProvider.swift`.
+- If you store `any LLMProvider` on an `@Observable` class, mark it
+  `@ObservationIgnored` or you will hit the actor-existential crash.
+  See [`../../../.claude/references/concurrency.md`](../../../.claude/references/concurrency.md) §1.
+
+### Retry-once contract on `ClinicalNotesProcessor`
+
+- First `generate` → if `validate(json:)` returns `.failure`, the
+  processor builds a retry prompt that **quotes the bad response
+  verbatim** and calls `generate` a second time.
+- Quoting the bad response is load-bearing: with `temperature: 0` and
+  a fixed `seed`, re-sending the original prompt would reproduce the
+  same invalid output. The quote perturbs context enough for the
+  model to attempt a correction.
+- If the retry also fails schema validation, the processor returns
+  `.rawTranscriptFallback(reason: reasonInvalidJSONAfterRetry)`. If
+  either `generate` call **throws**, it returns
+  `.rawTranscriptFallback(reason: reasonLLMError)`. The `process`
+  method itself never throws — `ReviewScreen` always has something
+  to render.
+
+### `SessionStore` is session-only
+
+- No `UserDefaults`, no on-disk persistence, no audit log of body
+  content. Every mutator is a no-op when `active == nil`.
+- `clear()` is called from: successful Cliniko export, app
+  termination, user cancel, and `checkIdleTimeout()` crossing the
+  injected threshold (default 30 min). The store does **not** own a
+  timer — the app lifecycle drives `checkIdleTimeout()` so tests stay
+  deterministic.
+- The store is `@MainActor` so SwiftUI views observe `active` without
+  actor hops. If you add an actor-typed dependency, it must be
+  `@ObservationIgnored`.
+
+### Determinism / golden tests
+
+- `LLMOptions` defaults (`temperature: 0`, `topP: 1.0`, `seed: 42`)
+  + the deterministic prompt builder make `MLXGemmaProvider` output
+  reproducible for a given transcript. The nightly LLM goldens
+  (`RUN_MLX_GOLDEN=1`) depend on this. **Anything that breaks
+  determinism breaks the goldens** — re-ordering the manipulations
+  list, changing the prompt template's whitespace, varying option
+  defaults per call site.
+- Substitution order in `buildPrompt` is deliberate:
+  `{{manipulations_list}}` first, `{{transcript}}` second. A
+  transcript that literally contains a `{{…}}` marker must not
+  re-trigger substitution.
+
+### `ExportFlowCoordinator.shared`
+
+- Singleton, configured once from `AppState.init`. **Don't construct
+  ad-hoc**, and don't store its dependencies on the review VM.
+  Tests swap fakes by re-calling `configure(...)`.
+- `makeViewModel()` returns a fresh VM per Export tap; the previous
+  one is dropped when the sheet dismisses. The FSM state is per-tap
+  on purpose — don't cache.
+- `isConfigured` gates the Export button so a misconfigured app
+  fails closed rather than crashing on first tap.
+- The `onSuccess` closure clears the `SessionStore` **before**
+  closing the review window. Order matters — see the call-site
+  comment.
+
+### MLX provider
+
+- The concrete `MLXGemmaProvider` ships in a follow-up PR against
+  this same area. For its load / warmup / fallback story, see
+  [`../../../.claude/references/mlx-lifecycle.md`](../../../.claude/references/mlx-lifecycle.md).
+
+---
+
+## Testing notes
+
+Match the framework to the situation —
+[`../../../.claude/references/testing-conventions.md`](../../../.claude/references/testing-conventions.md)
+is the canonical reference. Highlights for this subdirectory:
+
+- **Pure-logic + async tests** (`SessionStore`, `ClinicalNotesProcessor`,
+  `ClinicalNotesPromptBuilder`, `ManipulationsRepository`): Swift
+  Testing (`@Suite` / `@Test` / `#expect`); tag `.fast` via the
+  suite. `SessionStoreTests` is a `@MainActor`-isolated suite because
+  `SessionStore` is MainActor-isolated.
+- **Use the fakes — never the real thing in CI:** `MockLLMProvider`
+  for `LLMProvider`, `URLProtocolStub` for HTTP, `InMemorySecureStore`
+  for Keychain.
+- **`MockLLMProvider` modes** (see `Tests/SpeechToTextTests/Utilities/MockLLMProvider.swift`):
+  - `.fixedResponse(String)` — every call returns the same string.
+  - `.queuedResponses([String])` — pop-front; covers the retry-once
+    flow (enqueue invalid then valid, assert `.success` and one
+    retry).
+  - `.error(any Error & Sendable)` — every call throws; covers the
+    `.rawTranscriptFallback(reason: reasonLLMError)` path.
+  - `setBehavior(_:)` swaps mid-test if a single test needs a more
+    elaborate script.
+  - `calls()` / `lastCall()` / `callCount()` for invocation
+    assertions.
+- **LLM golden tests** against the real `MLXGemmaProvider` are gated
+  on `RUN_MLX_GOLDEN=1`, tagged `.slow` + `.requiresHardware`, and
+  run nightly only — never in the default CI path.
+- **Determinism in fixtures**: keep test transcripts and JSON
+  payloads PHI-free (synthetic clinical wording is fine; no real
+  patient names / DOBs).
+
+---
+
+## Related
+
+- Topic-router refs:
+  - [`../../../.claude/references/phi-handling.md`](../../../.claude/references/phi-handling.md) — never log PHI policy.
+  - [`../../../.claude/references/mlx-lifecycle.md`](../../../.claude/references/mlx-lifecycle.md) — model load / warmup / fallback.
+  - [`../../../.claude/references/concurrency.md`](../../../.claude/references/concurrency.md) — `@Observable` + actor existential, `Actor`-constrained protocols.
+  - [`../../../.claude/references/testing-conventions.md`](../../../.claude/references/testing-conventions.md) — frameworks, tags, fakes.
+- Sister `AGENTS.md`:
+  - [`../Cliniko/AGENTS.md`](../Cliniko/AGENTS.md) — HTTP client, endpoints, audit store, exporter.
+  - [`../../Views/ClinicalNotes/AGENTS.md`](../../Views/ClinicalNotes/AGENTS.md) — ReviewScreen, export flow UI, safety disclaimer.
+- GitHub:
+  - EPIC [#1 — Clinical Notes Mode](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/1).
+  - EPIC [#19 — Testing + Workflow Framework](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/19).
+  - Originating issues for files here: #2 (`SessionStore`), #3 (`LLMProvider`), #4 (`ClinicalNotesPromptBuilder`), #5 (`ClinicalNotesProcessor`), #6 (`ManipulationsRepository`), #14 (`ExportFlowCoordinator`).

--- a/Sources/Services/Cliniko/AGENTS.md
+++ b/Sources/Services/Cliniko/AGENTS.md
@@ -1,0 +1,149 @@
+# AGENTS.md — `Sources/Services/Cliniko/`
+
+## Purpose
+
+This subdirectory is the Cliniko integration layer: HTTP client,
+typed endpoints + errors, Keychain-backed credential storage, regional
+shard handling, and the metadata-only export audit ledger. **All
+network egress from the app passes through here** — every byte that
+leaves the doctor's Mac for Cliniko is built, signed, and logged by
+the types in this folder. Nowhere else in `Sources/` should construct
+a Cliniko `URLRequest` directly.
+
+For protocol-level reference (auth, error mapping, retry policy,
+endpoints, audit shape) see
+[`../../../.claude/references/cliniko-api.md`](../../../.claude/references/cliniko-api.md).
+For the PHI rules every file here enforces, see
+[`../../../.claude/references/phi-handling.md`](../../../.claude/references/phi-handling.md).
+
+---
+
+## Key types
+
+| File | Role |
+|---|---|
+| `ClinikoClient.swift` | `actor` wrapping `URLSession`. Single public `send<T>(_:)` method: builds an authenticated request from a `ClinikoEndpoint`, applies the retry policy, decodes 2xx into `T`, surfaces `ClinikoError` for everything else. Handles `Retry-After` (numeric + RFC 7231 HTTP-date), 429 / 5xx classification, transport / cancellation. |
+| `ClinikoEndpoint.swift` | Closed-set enum of in-scope endpoints (`usersMe`, `patientSearch`, `patientAppointments`, `createTreatmentNote`). Owns method, path template (log-safe), resource discriminator for 404, body / content-type, `isIdempotent` (drives 5xx + transport retry policy), and `buildURL(against:)`. |
+| `ClinikoError.swift` | Typed error set: `.unauthenticated`, `.forbidden`, `.notFound(resource:)`, `.validation(fields:)`, `.rateLimited(retryAfter:)`, `.server(status:)`, `.transport(URLError.Code)`, `.cancelled`, `.decoding(typeName:)`, `.nonHTTPResponse`. All payloads are structural — the whole enum is safe to interpolate at `OSLog` `.public`. |
+| `ClinikoCredentialStore.swift` | `actor` adapter over a `SecureStore` for the API key (Keychain) plus a `nonisolated` `UserDefaults` accessor for the shard. Owns the `serviceName`, account, and shard-key constants. Note: `KeychainSecureStore` (the generic Keychain wrapper) lives at `../KeychainSecureStore.swift` because it is not Cliniko-specific. |
+| `ClinikoShard.swift` | Regional-shard enum (`au1` … `eu1`) with `apiHost` + `displayName`. The single source of truth for the subdomain — no hostname strings live elsewhere in the codebase. |
+| `ClinikoAuthProbe.swift` | Standalone `actor` issuing `GET /users/me` for the Settings "Test connection" button (#7). Predates `ClinikoClient`; will likely fold into `client.send(.usersMe)` in a follow-up. |
+| `ClinikoPatientService.swift` | `actor` conforming to the actor-constrained protocol `ClinikoPatientSearching`. Thin wrapper around `client.send(.patientSearch(query:))`. The picker debounces; this layer is stateless. |
+| `ClinikoAppointmentService.swift` | `actor` conforming to `ClinikoAppointmentLoading`. Computes a UTC-pinned `[reference − 7 days, reference + 1 day)` window and delegates to `client.send(.patientAppointments(...))`. |
+| `TreatmentNoteExporter.swift` | `actor` orchestrating the `POST /treatment_notes` flow: composes the wire payload from `StructuredNotes` + selected manipulations, calls `client.send(.createTreatmentNote(body:))`, and on a successful 201 writes a metadata-only `AuditRecord`. Audit-write failure is non-fatal (returns `ExportOutcome(auditPersisted: false)`) so a ledger error never tempts a duplicate POST. |
+| `AuditStore.swift` | `AuditStore` protocol + `LocalAuditStore` (JSONL append to `~/Library/Application Support/<bundle>/audit.jsonl`, file mode `0o600`, line-level atomic) + `InMemoryAuditStore` (test fake with optional `recordHook` for failure injection). Carries the `AuditRecord` schema. |
+
+---
+
+## Common pitfalls
+
+### PHI in logs
+
+**Never** log request bodies, response bodies, bound URLs, patient
+names, query strings, or `String(describing: error)` — anywhere in
+this folder. `OSLog` `privacy: .public` is reserved for: HTTP method,
+**path template** (`pathTemplate` on `ClinikoEndpoint`, never the
+resolved URL), status code, latency, error-case name, decode-target
+type name, `URLError.Code.rawValue`, and `NSError.domain` /
+`NSError.code`. This is non-negotiable — see
+[`phi-handling.md`](../../../.claude/references/phi-handling.md). When
+in doubt, drop the log.
+
+### `AuditStore` invariants
+
+`AuditRecord` carries metadata only: `timestamp`, `patient_id`,
+`appointment_id`, `note_id`, `cliniko_status`, `app_version`. **Never**
+the SOAP body, transcript, patient name, or any free-text field. The
+type system enforces this — every field is a primitive (`Date`, `Int`,
+`String`-shaped via `OpaqueClinikoID`, `Int`, `String`). If you find
+yourself wanting to add a `String` field that could carry note content,
+stop: the on-disk schema is pinned by
+[`cliniko-api.md`](../../../.claude/references/cliniko-api.md) §Audit
+and `AuditStoreTests.line_keysMatchWhitelist` will fail the moment the
+key set widens. Coordinate a paired update of the reference doc + the
+EPIC's locked-decisions table before changing the shape.
+
+### Authorization header
+
+The API key lives in Keychain only, namespaced as
+`service: "com.speechtotext.cliniko"`, `account: "api_key"`, with
+accessibility `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` (no iCloud
+sync). **Never** in `UserDefaults`, **never** logged (not even
+obfuscated), **never** round-tripped back to the SwiftUI layer once
+stored. Callers needing to issue a request fetch a `ClinikoCredentials`
+value from `ClinikoCredentialStore.loadCredentials()` and hand it to
+`ClinikoClient`'s initialiser.
+
+### Retry policy
+
+Only 429 retries unconditionally (up to the `RetryPolicy.maxRetries`
+budget, honouring `Retry-After` floored at the policy's own delay).
+5xx + transport retry **only if `endpoint.isIdempotent` is true** —
+`createTreatmentNote` is **not** idempotent because we cannot tell
+whether a failed POST landed server-side, and a duplicate would
+double-write a clinical record. The full table lives in
+[`cliniko-api.md`](../../../.claude/references/cliniko-api.md)
+§"Retry policy".
+
+### Shard handling
+
+**Never** hardcode `api.au1.cliniko.com` (or any subdomain) anywhere
+in `Sources/`. Always derive from `ClinikoShard.apiHost` via
+`ClinikoCredentials.baseURL`. The shard is also encoded as a suffix on
+the API key (e.g. `MS-XXXXX-au1`) but v1 takes the explicit picker
+route — auto-detection is a possible follow-up.
+
+### Known limitation: `ClinikoClient.send<T>` doesn't thread the real HTTP status into audit rows
+
+`TreatmentNoteExporter` currently writes `clinikoStatus: 201` as a
+documented-contract constant rather than reading the actual response
+status, because `send<T>` discards the `HTTPURLResponse` after
+classifying 2xx into the success path. Tracked as
+[issue #58](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/58);
+when that lands, replace the literal in
+`TreatmentNoteExporter.export(...)` with the threaded value. Until
+then, the audit row's status is the documented value, not the observed
+one.
+
+---
+
+## Testing notes
+
+- **HTTP**: route `URLSession.data(for:)` through `URLProtocolStub`
+  (`Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift`) — a
+  hand-rolled, zero-dependency `Sendable` `URLProtocol` subclass.
+  Fixtures live under
+  `Tests/SpeechToTextTests/Fixtures/cliniko/{requests,responses}/`.
+- **Credentials**: use `InMemorySecureStore` (actor fake, never imports
+  `Security`) for `ClinikoCredentialStore` tests.
+- **Real Cliniko / real Keychain**: **never** in CI. Goldens that need
+  real services are gated behind env vars and run only in nightly /
+  remote-Mac.
+- **`AuditStore` byte-shape pin**:
+  `AuditStoreTests.line_pins_opaque_id_byte_shape` asserts the JSONL
+  encoding of `OpaqueClinikoID` (#59) stays a bare string, not the
+  `RawRepresentable` synthesised wrapping object. If you change
+  `AuditRecord`'s `Codable` strategy or `LocalAuditStore.makeEncoder()`
+  (`.sortedKeys`, `.iso8601`), this test will fail by design — coordinate
+  with `cliniko-api.md` §Audit before regenerating.
+- Canonical Swift Testing idiom + tag conventions:
+  [`testing-conventions.md`](../../../.claude/references/testing-conventions.md).
+  This folder's tests are tagged `.fast` and live in
+  `Tests/SpeechToTextTests/Services/`.
+
+PHI-free fixtures only: every `<patient>`, `<note_id>`,
+`<appointment_id>` is synthetic. Never copy production data, even
+redacted.
+
+---
+
+## Related
+
+- [`../../../.claude/references/cliniko-api.md`](../../../.claude/references/cliniko-api.md) — endpoints, auth, error mapping, retry table, audit schema.
+- [`../../../.claude/references/phi-handling.md`](../../../.claude/references/phi-handling.md) — PHI rules every log line in this folder follows.
+- [`../../../.claude/references/testing-conventions.md`](../../../.claude/references/testing-conventions.md) — `URLProtocolStub`, `InMemorySecureStore`, fixture layout, tags.
+- Sister AGENTS.md (when they land — tracked in #17):
+  [`../ClinicalNotes/AGENTS.md`](../ClinicalNotes/AGENTS.md),
+  [`../../Views/ClinicalNotes/AGENTS.md`](../../Views/ClinicalNotes/AGENTS.md).
+- [EPIC #1 — Clinical Notes Mode](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/1).
+- [Issue #58 — thread real HTTP status into `AuditStore` rows](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/58).

--- a/Sources/Views/ClinicalNotes/AGENTS.md
+++ b/Sources/Views/ClinicalNotes/AGENTS.md
@@ -1,0 +1,238 @@
+# AGENTS.md — `Sources/Views/ClinicalNotes/`
+
+> **Load this when:** writing or reviewing anything in
+> `Sources/Views/ClinicalNotes/` — the post-recording UI surface.
+> For the service seam underneath, see
+> [`../../Services/ClinicalNotes/AGENTS.md`](../../Services/ClinicalNotes/AGENTS.md).
+> For HTTP / Cliniko services, see
+> [`../../Services/Cliniko/AGENTS.md`](../../Services/Cliniko/AGENTS.md).
+
+## Purpose
+
+This subdirectory holds every post-recording clinical-notes view. The
+flow is:
+
+1. **Disclaimer** (one-time ack, gated by `UserDefaults`) — see
+   issue [#12](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/12).
+2. **ReviewScreen** (two-column SOAP editor + manipulations checklist
+   + excluded drawer, hosted in a non-floating `NSWindow`) — see
+   issue [#13](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/13).
+3. **PatientPicker** sheet (Cliniko search → appointment list).
+4. **ExportFlow** sheet (confirm → POST → success / failure) — see
+   issue [#14](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/14).
+
+All view models are `@Observable @MainActor`. All views adhere to the
+Warm Minimalism aesthetic from the root
+[`AGENTS.md`](../../../AGENTS.md) (frosted `.ultraThinMaterial`, amber
+palette in `Utilities/Extensions/Color+Theme.swift`, spring
+`(0.5, 0.7)` animations, minimal chrome).
+
+---
+
+## Key types
+
+### Disclaimer
+
+| Type | Role |
+|---|---|
+| `SafetyDisclaimerView` | One-time "drafting assistant, not a diagnostic tool" overlay. No close affordance, no ⎋, no tap-outside-to-dismiss — only the "I understand, continue" button. Carries no `@Observable` VM; the host (`LiquidGlassRecordingModal`) owns the `UserDefaults` ack flag. See [#12](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/12). |
+
+### Review
+
+| Type | Role |
+|---|---|
+| `ReviewScreen` | Two-column wireframe-locked layout (SOAP editors left, manipulations + excluded drawer right). Header with patient chip + draft badge, action bar with View raw transcript / Cancel / Export to Cliniko. Owns the shared `@FocusState<SOAPField?>` and the hidden ⌘1–⌘4 + ⌘E shortcut sink. |
+| `ReviewWindow` | `@MainActor` `NSObject` `NSWindowDelegate` wrapping a single `NSWindow`. **Window level is `.normal`** (long-form editor) — `isRestorable = false` so transcript / draft never lands in NSWindow restoration archives. `windowWillClose` calls `SessionStore.clear()` as the title-bar-X PHI chokepoint. |
+| `ReviewWindowController` | `@MainActor` singleton. Configured once by `AppState.init` with a `SessionStore`, `ManipulationsRepository`, and the export / patient-picker factories. Constructs the `ReviewViewModel` outside the SwiftUI root (concurrency §1 mitigation) and presents the window. |
+| `ReviewViewModel` | `@Observable @MainActor`. Owns SOAP-field bindings, manipulation toggles, focus tracking, excluded re-add routing, sheet presentation state for raw-transcript / export / patient-picker, and the cancel + export gestures. All service references are `@ObservationIgnored`. |
+| `SOAPSectionEditor` | One editable section. Receives a `Binding<String>` (via `viewModel.binding(for:)`) and the host's `FocusState<SOAPField?>.Binding` so all four sections share a single focus chain. |
+| `ManipulationsChecklist` | Right-column, stable-ordered taxonomy from `ManipulationsRepository`. Surfaces a structural empty-taxonomy banner when the bundle resource fails to load. View itself sees no PHI — manipulations are static taxonomy. |
+| `ExcludedContentDrawer` | Right-column collapsible drawer of LLM-excluded snippets, defaults to expanded. Each row has a re-add button. Header shows `Excluded (n)` from `viewModel.excludedRemainingCount`. |
+| `RawTranscriptSheet` | Read-only `.sheet` surface for the unmodified transcript. Used as a sanity-check during edit and as the primary surface in the LLM-fallback path. |
+
+### Picker
+
+| Type | Role |
+|---|---|
+| `PatientPickerView` | Two-pane SwiftUI surface — search field on the left with `SearchPhase`-driven results, appointment list on the right with `AppointmentPhase`-driven loading / loaded / error rows. Sheet chrome (Cancel / Done) lives in `ReviewScreen.PatientPickerSheetHost`. |
+| `PatientPickerViewModel` | `@Observable @MainActor` `Identifiable`. Owns the debounced search lifecycle (300ms default; `0` in tests), kicks off the appointment fetch on patient select, and writes selections through `SessionStore.setSelectedPatient(id:displayName:)` / `setSelectedAppointment(id:)`. Service refs are `@ObservationIgnored`. |
+
+### Export
+
+| Type | Role |
+|---|---|
+| `ExportFlowView` | `.sheet`-hosted FSM router over `viewModel.state` — `.idle` / `.confirming` / `.uploading` / `.succeeded` / `.failed`. Pure presentation; every gesture routes through the VM. Cancel is disabled during `.uploading` (POST is non-idempotent). |
+| `ExportFlowViewModel` | `@Observable @MainActor` `Identifiable` FSM. Computes the pre-flight `ExportSummary`, runs the single-shot upload Task, translates `ClinikoError` / `TreatmentNoteExporter.Failure` into a UI-shaped `ExportFailure`, and drives the `.rateLimited` countdown. Constructed via `ExportFlowCoordinator.shared.makeViewModel()` which lives at [`../../Services/ClinicalNotes/ExportFlowCoordinator.swift`](../../Services/ClinicalNotes/ExportFlowCoordinator.swift). |
+
+---
+
+## Re-add drawer behaviour
+
+The `ExcludedContentDrawer`'s "↺ re-add to SOAP section" affordance is
+the wireframe-defining mechanic for the right column:
+
+- Each row's re-add button calls `viewModel.reAddExcludedEntry(_:)`.
+- Destination is resolved by `ReviewViewModel.reAddTargetField()`:
+  the **last-focused SOAP field** if focus landed within the
+  `reAddTargetWindow` (default 5s) of `now()`, else `.subjective`.
+- The entry is appended to the destination field with a blank-line
+  separator if the destination is already non-empty (trailing
+  whitespace is normalised first so re-adding twice doesn't pile up
+  triple-newlines).
+- The re-added snippet is recorded on
+  `SessionStore.excludedReAdded`. The drawer's visible list is the
+  full `notes.excluded` minus a count-based subtraction of
+  `excludedReAdded` — so re-adding one of two duplicate snippets
+  leaves the second copy in the drawer (see `excludedEntries` for
+  the duplicate-handling rationale).
+- The rest of the drawer state (collapse / expand, other rows) is
+  untouched. No drawer-wide reset, no scroll jump.
+
+Full source for the destination resolution + write-through:
+`ReviewViewModel.reAddTargetField()` and
+`ReviewViewModel.reAddExcludedEntry(_:)`.
+
+---
+
+## Common pitfalls
+
+### `@Observable` + actor existential
+
+Every actor existential field on a view model in this directory must
+be `@ObservationIgnored` — otherwise SwiftUI's observation scan
+crashes with `EXC_BAD_ACCESS`. The SwiftLint custom rule
+`observable_actor_existential_warning` catches the pattern. View
+models in this directory all follow the rule (`SessionStore`,
+`ManipulationsRepository`, `TreatmentNoteExporter`, the picker
+services, and every factory closure are all annotated). See
+[`../../../.claude/references/concurrency.md`](../../../.claude/references/concurrency.md)
+§1 for the "construct VM outside the SwiftUI root" mitigation —
+`ReviewWindowController.present()` and the export / picker factories
+do this.
+
+### PHI in views
+
+Views in this directory see SOAP body, transcript, patient names,
+DOBs, emails, and excluded snippets. **None of that may be `print` /
+`OSLog` / `assertionFailure(...)` from a view.** All logging in this
+directory lives on the view models, and is structural-only (FSM case
+name, char counts, accessibility-id field tags). See
+[`../../../.claude/references/phi-handling.md`](../../../.claude/references/phi-handling.md).
+
+### Window level on `ReviewWindow`
+
+`ReviewWindow.makeWindow()` deliberately uses `level = .normal` (vs
+the recording modal's `.floating`) because the review surface is a
+long-form editor, not a transient capture overlay. Don't change it
+to `.floating` — the regression risk is the editor jumping above
+unrelated app windows the practitioner is referencing.
+
+`isRestorable = false` is also load-bearing — it prevents transcript
+or draft content from being archived in NSWindow state restoration.
+Don't flip this without a session-only-PHI review.
+
+### `ExportFlowCoordinator.shared` not configured
+
+`ReviewWindowController.configure(...)` accepts the export and
+patient-picker factories with `{ nil }` defaults. When Cliniko isn't
+set up (no API key in Keychain), the factory returns `nil`:
+
+- `ReviewViewModel.triggerExport()` shows
+  `"Cliniko isn't set up — configure your API key in Settings."` in
+  the action-bar error banner.
+- `ReviewViewModel.presentPatientPicker()` shows the same banner.
+- `canExport` stays `false` until a patient is selected, so ⌘E and
+  the Export button stay disabled too.
+
+Don't surface a sheet that the user can't act on — keep the banner
+copy aligned with the Settings entry-point name.
+
+### `@ObservedObject` / `@StateObject` / `ObservableObject`
+
+Forbidden in this codebase (root `AGENTS.md` rule). Use `@State` /
+`@Bindable` / `@Environment` with `@Observable`. Every view in this
+directory takes its VM as `@Bindable var viewModel`.
+
+### Accessibility focus order
+
+`ReviewScreen` ships a multi-pane focus chain: ⌘1–⌘4 route the
+shared `@FocusState<SOAPField?>` to the matching SOAP editor, and
+⌘E triggers Export. The hidden-button shortcut sink in
+`shortcutSink` is the only legitimate place to register those.
+Snapshot tests in `ReviewScreenRenderTests` pin the accessibility
+identifiers — if you reorder the focus chain or rename a shortcut,
+update them.
+
+---
+
+## Testing notes
+
+### ViewInspector crash-detection
+
+Every `@Observable` view model in this directory gets a render-crash
+test:
+
+- `Tests/SpeechToTextTests/Views/ReviewScreenRenderTests.swift`
+- `Tests/SpeechToTextTests/Views/SafetyDisclaimerViewRenderTests.swift`
+- `Tests/SpeechToTextTests/Views/PatientPickerViewRenderTests.swift`
+- `Tests/SpeechToTextTests/Views/ExportFlowViewRenderTests.swift`
+
+Standard idiom: instantiate the VM, then the view, then access
+`view.body`. See
+[`../../../.claude/references/testing-conventions.md`](../../../.claude/references/testing-conventions.md).
+
+### Snapshot tests
+
+Per the locked decisions in the root [`AGENTS.md`](../../../AGENTS.md),
+**snapshot tests are scoped to ReviewScreen + SafetyDisclaimer only**
+using `pointfreeco/swift-snapshot-testing` v1.17+. Don't add snapshot
+coverage for `PatientPickerView`, `ExportFlowView`, or any of the
+sub-components — render-crash + assertion tests are the contract for
+those.
+
+### No real LLM, no real Cliniko, no real Keychain
+
+Every test in this directory uses injected fakes:
+
+- `MockLLMProvider` for transcript → SOAP.
+- `URLProtocolStub` for Cliniko HTTP (see the `makeExporter()`
+  helper in `ExportFlowViewRenderTests`).
+- `InMemorySecureStore` / `InMemoryAuditStore` for the credential and
+  audit seams.
+
+Real LLM goldens are gated by `RUN_MLX_GOLDEN=1` and run nightly
+only. Real Cliniko / Keychain is never exercised in CI. See
+[`../../../.claude/references/testing-conventions.md`](../../../.claude/references/testing-conventions.md).
+
+### ViewInspector limitation on `keyboardShortcut`
+
+ViewInspector has no introspection API for `.keyboardShortcut(...)`
+— pinning a shortcut directly in a test will fail. Pin the button's
+**label text** or accessibility identifier instead. This came up in
+PR [#66](https://github.com/CloudbrokerAz/mac-speech-to-text/pull/66)
+and applies to the disclaimer's `.return` shortcut, the export
+sheet's confirm / retry buttons, and the review action bar.
+
+---
+
+## Related
+
+Topic-router references:
+
+- [`../../../.claude/references/concurrency.md`](../../../.claude/references/concurrency.md) — `@Observable` + actor existential rules (§1), Audio callbacks + `@MainActor` (§2).
+- [`../../../.claude/references/testing-conventions.md`](../../../.claude/references/testing-conventions.md) — ViewInspector + snapshot scoping.
+- [`../../../.claude/references/phi-handling.md`](../../../.claude/references/phi-handling.md) — never-log policy.
+- [`../../../.claude/references/menubar-integration.md`](../../../.claude/references/menubar-integration.md) — `NSWindow` / floating-window patterns.
+
+Sister AGENTS.md:
+
+- [`../../Services/ClinicalNotes/AGENTS.md`](../../Services/ClinicalNotes/AGENTS.md) — `SessionStore`, `ClinicalNotesProcessor`, `ExportFlowCoordinator`, `ManipulationsRepository`, `LLMProvider`.
+- [`../../Services/Cliniko/AGENTS.md`](../../Services/Cliniko/AGENTS.md) — `ClinikoClient`, `TreatmentNoteExporter`, `AuditStore`, `ClinikoCredentialStore`.
+
+Issues:
+
+- [#1 — Clinical Notes Mode (EPIC)](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/1)
+- [#12 — Safety Disclaimer modal](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/12)
+- [#13 — ReviewScreen two-column layout](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/13)
+- [#14 — Export flow (patient picker → confirm → POST)](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/14)
+- [#17 — Component AGENTS.md files (this file)](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/17)

--- a/Sources/Views/ClinicalNotes/AGENTS.md
+++ b/Sources/Views/ClinicalNotes/AGENTS.md
@@ -14,8 +14,8 @@ flow is:
 
 1. **Disclaimer** (one-time ack, gated by `UserDefaults`) — see
    issue [#12](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/12).
-2. **ReviewScreen** (two-column SOAP editor + manipulations checklist
-   + excluded drawer, hosted in a non-floating `NSWindow`) — see
+2. **ReviewScreen** (two-column SOAP editor with manipulations checklist
+   and excluded drawer, hosted in a non-floating `NSWindow`) — see
    issue [#13](https://github.com/CloudbrokerAz/mac-speech-to-text/issues/13).
 3. **PatientPicker** sheet (Cliniko search → appointment list).
 4. **ExportFlow** sheet (confirm → POST → success / failure) — see


### PR DESCRIPTION
## Summary

- Adds the three component-scoped `AGENTS.md` files #17 calls for: `Sources/Services/ClinicalNotes/`, `Sources/Services/Cliniko/`, `Sources/Views/ClinicalNotes/`.
- Updates root `AGENTS.md` Topic Router pointer (now lists all three) and adds a "Clinical Notes Mode" flow-overview section.
- Updates `.claude/CLAUDE.md` Quick Reference: Project Structure tree to reflect the nested layout that landed in PR-A (#67).

5 files, +668 / −10. Docs-only.

## Drafting + review

- The three new AGENTS.md were drafted in parallel by 3 Opus subagents, each scoped to one subdirectory's source files. Strict prompts: source-traceable claims only, "always/never" tone, relative links only, no PHI in examples, no code blocks > 10 lines, point at `.claude/references/*.md` for deep dives.
- Layer-1 `pr-review-toolkit:code-reviewer` (Opus) spot-verified every load-bearing claim against source — `ClinicalNotesProcessor` retry-once + sentinels, `LLMOptions` defaults, `MockLLMProvider` modes, `ExportFlowCoordinator.shared` wiring + `onSuccess`-then-close ordering, `AuditRecord` field set, `endpoint.isIdempotent` retry gating, Keychain accessibility constant, `#58` known-limitation, `ReviewWindow.level=.normal` + `isRestorable=false`, `reAddTargetField()` + `reAddExcludedEntry(_:)` behaviour with the 5s `reAddTargetWindow` default. All verified, no blockers, no nits.
- Cross-link spot-check: 40 relative links across the 3 new files all resolve; both root-file links resolve.

## Issue #17 acceptance criteria

| Criterion | Status |
|---|---|
| Each AGENTS.md covers: purpose, key types, common pitfalls, testing notes | ✅ all three |
| ReviewScreen architecture, re-add drawer behaviour, accessibility considerations | ✅ all in `Sources/Views/ClinicalNotes/AGENTS.md` |
| Links between AGENTS.md files are relative and correct | ✅ verified |
| Root AGENTS.md links to the EPIC for overall feature context | ✅ in the new "Clinical Notes Mode" section |

## Out of scope (intentional)

- The dirty pre-existing modifications under `.devcontainer/`, `.specify/`, `specs/`, etc. (pre-commit autocorrect leftovers) are left alone — not staged in this PR. They predate this branch.
- No code changes — PR-A (#67) handled the file moves.

Closes #17.

## Test plan

- [x] Layer-1 reviewer (Opus) — clean approve
- [ ] Gemini Code Assist on PR open
- [ ] CI green
- [ ] Markdown links resolve (manual spot check on GitHub render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)