### PR TITLE
feat(llm): MLXGemmaProvider real implementation + first-run model download (#3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -47,9 +47,9 @@ gh issue view <N> --comments   # for any specific issue you pick up
 
 | Area | Decision |
 |---|---|
-| LLM runtime | MLX Swift in-process (ml-explore/mlx-swift-examples) |
-| LLM model v1 | Gemma 3 4B-IT (MLX 4-bit); swap to Gemma 4 E4B when mlx-swift#389 lands (#18) |
-| Model delivery | Bundled in the .app (DMG distribution, not App Store) |
+| LLM runtime | MLX Swift in-process (ml-explore/mlx-swift-lm 3.31.x — replaces deprecated mlx-swift-examples per upstream PR #441, 2025-11) |
+| LLM model v1 | Gemma 3 4B-IT (MLX 4-bit text-only — `mlx-community/gemma-3-text-4b-it-4bit`); swap to Gemma 4 E4B when mlx-swift#389 lands (#18) |
+| Model delivery | First-run download with sha256-manifest verification → `~/Library/Application Support/<bundle-id>/Models/`. Updated 2026-04-26 in #3; supersedes earlier "bundled in .app". DMG stays ~50 MB; weights fetched on opt-in. See `.claude/references/mlx-lifecycle.md` |
 | Persistence | Session-only, cleared on export/quit — no on-disk PHI |
 | Cliniko | API integration in v1, mirror patterns from [CloudbrokerAz/epc-letter-generation](https://github.com/CloudbrokerAz/epc-letter-generation/tree/main/Sources/Services) |
 | Manipulations | Placeholder JSON v1 (#6); user supplies real Cliniko taxonomy later |

--- a/.claude/references/mlx-lifecycle.md
+++ b/.claude/references/mlx-lifecycle.md
@@ -26,13 +26,34 @@ on Apple Silicon.
 
 ## Deployment
 
-- **Bundled in the `.app`**: the 4-bit Gemma 3 4B-IT weights ship in
-  `Resources/Models/gemma-3-4b-it-4bit/` (~2.5 GB). DMG distribution,
-  not App Store.
-- **Git LFS vs build-time download**: decide in #3's PR. LFS keeps the
-  repo self-contained but bloats clone size. Build-time download from
-  the `mlx-community` Hugging Face org is smaller at `git clone` time
-  but adds a network hop to the first build.
+**First-run download with sha256-manifest verification.** *(Updated
+2026-04-26 in #3 — supersedes the earlier "bundled in .app" decision.)*
+
+- The bundled `.app` ships only a small JSON manifest at
+  `Resources/Models/gemma-3-text-4b-it-4bit/manifest.json` (HF revision
+  pin + per-file size + sha256 for the LFS-tracked binaries). DMG is
+  ~50 MB — model weights stay out.
+- `ModelDownloader` (in `Sources/Services/ClinicalNotes/`) fetches
+  files from `https://huggingface.co/mlx-community/gemma-3-text-4b-it-4bit/resolve/<revision>/`
+  on first run, streams sha256 verification, atomically renames into
+  `~/Library/Application Support/<bundle-id>/Models/gemma-3-text-4b-it-4bit/`.
+  Idempotent — re-launches with files present + verified are no-ops.
+- `MLXGemmaProvider.warmup()` mmaps the verified directory via
+  `MLXLLM.LLMModelFactory.shared.loadContainer(from:using:)`.
+- **Why not bundled**: 2.6 GB inside the `.app` would (a) burn GitHub
+  LFS bandwidth (10 GiB / month free quota → ~1 week of CI), (b) slow
+  every notarisation, (c) force a full new DMG for every model swap
+  (the Gemma 4 E4B migration in #18 becomes a manifest-revision bump
+  instead of a re-DMG). Mirrors the existing `FluidAudioService`
+  pattern (`AsrModels.downloadAndLoad(version: .v3)`).
+- **Trigger UX**: today the download fires lazily on the first
+  Generate-Notes tap (with the existing empty-draft fallback if it
+  fails). A follow-up PR will move the trigger to the Settings
+  Clinical-Notes-Mode toggle so the user opts in *before* the first
+  recording, and surfaces progress via `AppState.llmDownloadProgress`
+  / `llmDownloadState`.
+- **No HF auth needed** for `mlx-community` public weights, so the
+  downloader uses `URLSession` with no token plumbing.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+        # Xcode 16.4 ships Swift 6.1 (Xcode 16.2 ships 6.0.3, which fails to
+        # resolve mlx-swift-lm 3.31.x — that package's Package.swift declares
+        # `swift-tools-version: 6.1`). Bumped 2026-04-26 in #3.
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Show Xcode and Swift versions
         run: |
@@ -267,7 +270,10 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Select Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+        # Xcode 16.4 ships Swift 6.1 (Xcode 16.2 ships 6.0.3, which fails to
+        # resolve mlx-swift-lm 3.31.x — that package's Package.swift declares
+        # `swift-tools-version: 6.1`). Bumped 2026-04-26 in #3.
+        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
 
       - name: Cache Swift Package Manager dependencies
         uses: actions/cache@v5

--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,14 @@ xcode-project/DerivedData/
 .signing-fingerprint
 xcode-project/Config/Signing.xcconfig
 
-# ML Models (large files, download separately)
-Resources/Models/
+# ML Models — large weight files (~2.6 GB) downloaded separately at first run.
+# Per-model manifest.json (sha256-pinned download recipe for ModelDownloader)
+# is the EXCEPTION: small (~1 KB), source of truth for which weights to fetch.
+# Two-step negation pattern is required because git cannot re-include files
+# from a wholly-excluded directory — we exclude contents (`Models/*`) instead.
+Resources/Models/*
+!Resources/Models/*/
+!Resources/Models/*/manifest.json
 *.onnx
 *.bpe.model
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,15 @@
 {
+  "originHash" : "1f350edb52df5a6f2b4bd1cabebb37ccb8fb8a3650a25aad539153c8f91fb0e2",
   "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
     {
       "identity" : "fluidaudio",
       "kind" : "remoteSourceControl",
@@ -19,6 +29,123 @@
       }
     },
     {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "61b9e011e09a62b489f6bd647958f1555bdf2896",
+        "version" : "0.31.3"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
+      "state" : {
+        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
+        "version" : "3.31.3"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "b38443e44d93eca770f2eb68e2a4d0fa100f9aa2",
+        "version" : "1.3.0"
+      }
+    },
+    {
       "identity" : "viewinspector",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nalexn/ViewInspector.git",
@@ -26,7 +153,16 @@
         "revision" : "e9a06346499a3a889165647e3f23f8a7b2609a1c",
         "version" : "0.10.3"
       }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,11 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.1
+//
+// Bumped from 5.9 → 6.1 (2026-04-26, #3) to allow ml-explore/mlx-swift-lm 3.31.3
+// — that package requires tools-version 6.1 to vend MLXLLM/MLXLMCommon.
+// Swift language mode is pinned to .v5 per-target so existing strict-concurrency
+// warnings remain warnings (not errors), matching prior behaviour. Swift compiler
+// is 6.2.x; the SwiftLint custom rules `observable_actor_existential_warning`
+// and `nonisolated_unsafe_warning` continue to enforce concurrency discipline.
 import PackageDescription
 
 let package = Package(
@@ -22,6 +29,22 @@ let package = Package(
         .package(
             url: "https://github.com/sindresorhus/KeyboardShortcuts",
             from: "2.0.0"
+        ),
+        // Local-LLM stack for clinical-notes generation (#3).
+        // mlx-swift-lm replaces the deprecated mlx-swift-examples (PR #441,
+        // 2025-11-11). Pin to .upToNextMinor so a 3.31.x patch release is
+        // pulled automatically but a 3.32 minor is opt-in.
+        .package(
+            url: "https://github.com/ml-explore/mlx-swift-lm",
+            .upToNextMinor(from: "3.31.3")
+        ),
+        // Tokenizers + Hub helpers for loading the bundled-once-downloaded
+        // Gemma weights from disk. We do NOT use HubApi for the actual
+        // weight download — that is hand-rolled in `ModelDownloader` so
+        // the sha256-manifest verification flow is under our control.
+        .package(
+            url: "https://github.com/huggingface/swift-transformers",
+            from: "1.3.0"
         )
     ],
     targets: [
@@ -30,6 +53,9 @@ let package = Package(
             dependencies: [
                 .product(name: "FluidAudio", package: "FluidAudio"),
                 .product(name: "KeyboardShortcuts", package: "KeyboardShortcuts"),
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
                 "SherpaOnnxSwift"
             ],
             path: "Sources",
@@ -42,7 +68,12 @@ let package = Package(
             ],
             swiftSettings: [
                 .enableUpcomingFeature("BareSlashRegexLiterals"),
-                // Disable strict concurrency checking for Swift 6 compatibility
+                // Pin language mode to 5 to preserve prior strict-concurrency
+                // warning (not error) behaviour now that tools-version is 6.1.
+                .swiftLanguageMode(.v5),
+                // Frontend flags carried over from the 5.9 manifest. The
+                // unsafe-flags wrapper survives the language-mode pin
+                // because it operates at the frontend layer.
                 .unsafeFlags(["-Xfrontend", "-disable-availability-checking",
                               "-Xfrontend", "-warn-concurrency",
                               "-Xfrontend", "-enable-actor-data-race-checks"])
@@ -98,6 +129,13 @@ let package = Package(
             path: "Tests/SpeechToTextTests",
             resources: [
                 .copy("Fixtures")
+            ],
+            swiftSettings: [
+                // Mirror the main target's language-mode pin so existing
+                // pre-Swift-6-mode tests (e.g. AudioCaptureServiceTests'
+                // non-Sendable level callback) keep compiling now that
+                // tools-version is 6.1.
+                .swiftLanguageMode(.v5)
             ]
         )
     ]

--- a/Resources/Models/gemma-3-text-4b-it-4bit/manifest.json
+++ b/Resources/Models/gemma-3-text-4b-it-4bit/manifest.json
@@ -1,0 +1,47 @@
+{
+  "model_id": "mlx-community/gemma-3-text-4b-it-4bit",
+  "revision": "4f665a4c50ecfe4ecdc34056ab52fe3e3c4abf9e",
+  "files": [
+    {
+      "path": "config.json",
+      "size": 928,
+      "sha256": null
+    },
+    {
+      "path": "model.safetensors",
+      "size": 2560876251,
+      "sha256": "4992b5af91dcece8eb3911dd02c4196a7bb88c5379918f19a0b1e1be93f64ac6"
+    },
+    {
+      "path": "model.safetensors.index.json",
+      "size": 79914,
+      "sha256": null
+    },
+    {
+      "path": "special_tokens_map.json",
+      "size": 662,
+      "sha256": null
+    },
+    {
+      "path": "added_tokens.json",
+      "size": 35,
+      "sha256": null
+    },
+    {
+      "path": "tokenizer.json",
+      "size": 33384568,
+      "sha256": "4667f2089529e8e7657cfb6d1c19910ae71ff5f28aa7ab2ff2763330affad795"
+    },
+    {
+      "path": "tokenizer.model",
+      "size": 4689074,
+      "sha256": "1299c11d7cf632ef3b4e11937501358ada021bbdf7c47638d13c0ee982f2e79c"
+    },
+    {
+      "path": "tokenizer_config.json",
+      "size": 1156999,
+      "sha256": null
+    }
+  ],
+  "total_bytes": 2600188431
+}

--- a/Sources/Models/LLMDownloadState.swift
+++ b/Sources/Models/LLMDownloadState.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Coarse-grained UI-binding state for the clinical-notes LLM pipeline
+/// (`ModelDownloader` + `MLXGemmaProvider`).
+///
+/// **Issue #3.** The `@Observable` `AppState` exposes one of these so a
+/// future Settings-side download surface can drive a progress sheet,
+/// retry button, and "model ready" indicator without reaching into the
+/// downloader's per-byte event stream. The granular `bytesReceived`
+/// events stay inside the `applyDownloadProgress` aggregator, which
+/// updates a separate `Double` property.
+///
+/// PHI-free by construction — every payload is structural (a directory
+/// URL the model lives at) or unit (`Void`-bearing cases).
+public enum LLMDownloadState: Sendable, Equatable {
+    /// Pipeline has not yet been driven; manifest is bundled but no
+    /// download has been attempted this launch.
+    case idle
+
+    /// Files are being fetched from Hugging Face. Pair with
+    /// `AppState.llmDownloadProgress` for the `[0, 1]` value.
+    case downloading
+
+    /// All manifest files present + sha256-verified at `directory`.
+    /// Provider warmup is the next step before generation can run.
+    case verified(directory: URL)
+
+    /// Model loaded into the `ModelContainer`; `MLXGemmaProvider.generate`
+    /// is ready to serve.
+    case ready
+
+    /// Active download was cancelled. Re-entering the pipeline resumes
+    /// from the next missing file (the downloader is idempotent).
+    case cancelled
+
+    /// Last attempt to ensure the model failed (download IO, hash
+    /// mismatch, or warmup load failure). The exact cause is logged
+    /// structurally; UI surfaces a generic "couldn't prepare model"
+    /// with a retry affordance.
+    case failed
+}

--- a/Sources/Models/ModelManifest.swift
+++ b/Sources/Models/ModelManifest.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// Pinned record of a Hugging Face model snapshot consumed by `ModelDownloader`.
+///
+/// **Issue #3.** The clinical-notes LLM (Gemma 3 4B-IT, MLX 4-bit) ships
+/// as a first-run download into `~/Library/Application Support/<bundle-id>/Models/`
+/// rather than bundled into the .app — the locked-decision change is recorded
+/// in `.claude/CLAUDE.md` and `.claude/references/mlx-lifecycle.md`. The
+/// manifest is the integrity record that the downloader walks: it pins a
+/// HF git revision SHA so re-downloads cannot silently swap weights, and
+/// holds per-file sha256s for the large LFS-tracked binary blobs.
+///
+/// PHI: the manifest carries no PHI of any kind. It is safe to log every
+/// field with `privacy: .public`.
+public struct ModelManifest: Codable, Sendable, Equatable {
+    /// Hugging Face repo id (e.g. `"mlx-community/gemma-3-text-4b-it-4bit"`).
+    public let modelId: String
+
+    /// Hugging Face git commit SHA that this manifest pins. The downloader
+    /// pulls files at `https://huggingface.co/<modelId>/resolve/<revision>/<path>`,
+    /// so a manifest re-publish requires bumping `revision` and re-computing
+    /// any changed file hashes.
+    public let revision: String
+
+    /// Files to download. Order is for human-readability only; the downloader
+    /// streams them concurrently up to a fixed parallelism (the large file
+    /// dominates wall-clock anyway).
+    public let files: [ModelFile]
+
+    /// Sum of `files[i].size`. Used by the progress stream as the "total
+    /// bytes" denominator and by `ModelDownloader` for the disk-space
+    /// pre-check (`URLResourceKey.volumeAvailableCapacityForImportantUsageKey`).
+    public let totalBytes: Int64
+
+    public init(modelId: String, revision: String, files: [ModelFile]) {
+        self.modelId = modelId
+        self.revision = revision
+        self.files = files
+        self.totalBytes = files.reduce(into: Int64(0)) { $0 += $1.size }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelId = "model_id"
+        case revision
+        case files
+        case totalBytes = "total_bytes"
+    }
+
+    /// Required for `Decodable` + custom `init(...)` co-existence. Validates
+    /// that the on-disk `total_bytes` matches the sum of the file sizes —
+    /// a tampered or hand-edited manifest with a stale total throws
+    /// `DecodingError.dataCorrupted` rather than decoding into an
+    /// inconsistent value.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.modelId = try container.decode(String.self, forKey: .modelId)
+        self.revision = try container.decode(String.self, forKey: .revision)
+        self.files = try container.decode([ModelFile].self, forKey: .files)
+        let declared = try container.decode(Int64.self, forKey: .totalBytes)
+        let computed = self.files.reduce(into: Int64(0)) { $0 += $1.size }
+        guard declared == computed else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: container.codingPath + [CodingKeys.totalBytes],
+                    debugDescription: "ModelManifest.total_bytes (\(declared)) does not match sum(files.size) (\(computed))"
+                )
+            )
+        }
+        self.totalBytes = declared
+    }
+}
+
+/// Single-file entry inside a `ModelManifest`.
+public struct ModelFile: Codable, Sendable, Equatable {
+    /// Path relative to the model directory (and to the HF repo root).
+    /// Forward-slash separated on disk too — the downloader maps `/` → the
+    /// platform separator at write time.
+    public let path: String
+
+    /// Expected on-disk size in bytes. The downloader compares this against
+    /// the live `Content-Length` and against the actual bytes-written count.
+    public let size: Int64
+
+    /// Hex sha256 of the file contents. `nil` is allowed for small config
+    /// files whose integrity is bounded by the manifest's `revision` pin —
+    /// LFS-tracked files (`*.safetensors`, `tokenizer.json`, `tokenizer.model`)
+    /// MUST carry a hash. The downloader's `verify(file:)` treats `nil` as
+    /// "size-only check"; populate via `scripts/build-model-manifest.sh` if
+    /// you want stronger guarantees.
+    public let sha256: String?
+
+    public init(path: String, size: Int64, sha256: String?) {
+        self.path = path
+        self.size = size
+        self.sha256 = sha256
+    }
+
+    /// Decode-time validation: rejects path-traversal segments,
+    /// negative sizes, and absolute paths so a malicious or
+    /// hand-typed manifest can't reach outside the model directory
+    /// when `ModelDownloader.appendingPathComponent(file.path)` runs.
+    /// `sha256` is allowed `nil` (manifest revision pin covers
+    /// integrity for small config files) but rejected if present
+    /// as an empty string — that's neither a hash nor a "skip".
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let path = try container.decode(String.self, forKey: .path)
+        let size = try container.decode(Int64.self, forKey: .size)
+        let sha256 = try container.decodeIfPresent(String.self, forKey: .sha256)
+
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.split(separator: "/").contains(".."),
+              !path.contains("\\") else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: container.codingPath + [CodingKeys.path],
+                    debugDescription: "ModelFile.path '\(path)' is empty, absolute, or contains traversal segments"
+                )
+            )
+        }
+        guard size >= 0 else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: container.codingPath + [CodingKeys.size],
+                    debugDescription: "ModelFile.size must be non-negative; got \(size)"
+                )
+            )
+        }
+        if let sha256, sha256.isEmpty {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: container.codingPath + [CodingKeys.sha256],
+                    debugDescription: "ModelFile.sha256 must be nil or non-empty"
+                )
+            )
+        }
+
+        self.path = path
+        self.size = size
+        self.sha256 = sha256
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case path
+        case size
+        case sha256
+    }
+}

--- a/Sources/Models/ModelManifest.swift
+++ b/Sources/Models/ModelManifest.swift
@@ -32,6 +32,16 @@ public struct ModelManifest: Codable, Sendable, Equatable {
     /// pre-check (`URLResourceKey.volumeAvailableCapacityForImportantUsageKey`).
     public let totalBytes: Int64
 
+    /// Repo-name segment of `modelId` — i.e. everything after the final
+    /// `/` (e.g. `"mlx-community/gemma-3-text-4b-it-4bit"` →
+    /// `"gemma-3-text-4b-it-4bit"`). Used as the on-disk directory name
+    /// under `~/Library/Application Support/<bundle-id>/Models/`.
+    /// Falls back to `"model"` for the (impossible-by-decode-validation)
+    /// case where `modelId` has no `/` segment.
+    public var modelDirectoryName: String {
+        modelId.split(separator: "/").last.map(String.init) ?? "model"
+    }
+
     public init(modelId: String, revision: String, files: [ModelFile]) {
         self.modelId = modelId
         self.revision = revision

--- a/Sources/Services/ClinicalNotes/AGENTS.md
+++ b/Sources/Services/ClinicalNotes/AGENTS.md
@@ -125,9 +125,31 @@ The pipeline:
 
 ### MLX provider
 
-- The concrete `MLXGemmaProvider` ships in a follow-up PR against
-  this same area. For its load / warmup / fallback story, see
-  [`../../../.claude/references/mlx-lifecycle.md`](../../../.claude/references/mlx-lifecycle.md).
+- `MLXGemmaProvider` (this directory) is the production `LLMProvider`,
+  running Gemma 3 4B-IT (MLX 4-bit, text-only) in-process via
+  `ml-explore/mlx-swift-lm` 3.31.x on Apple Silicon. `MockLLMProvider`
+  (in `Tests/`) is the test/preview shim.
+- **Two-phase init.** Construct cheaply with the model directory
+  (`init(modelDirectory:)`), then `await warmup()` to load weights
+  into the `ModelContainer` before the first `generate` call.
+  `warmup()` is idempotent — safe to call from multiple entry points
+  (Settings toggle, lazy first-tap fallback in `AppState`).
+- **Weights live off-bundle.** `ModelDownloader` (sibling file)
+  fetches them on first run from
+  `mlx-community/gemma-3-text-4b-it-4bit` into Application Support,
+  verifies sha256 against `Resources/Models/gemma-3-text-4b-it-4bit/manifest.json`,
+  then `MLXGemmaProvider` mmaps from the verified directory. See the
+  Deployment section of [`mlx-lifecycle.md`](../../../.claude/references/mlx-lifecycle.md)
+  for the full story.
+- **Stop sequences.** `LLMOptions.stop` is enforced post-stream (mlx
+  has no native `extraEOSTokens` on the AsyncStream API); the
+  `firstStopRange` / `safeFlushBoundary` helpers buffer just enough
+  to avoid emitting partial stop matches.
+- **TokenizerLoader.** A small `SwiftTransformersTokenizerLoader`
+  bridges `Tokenizers.AutoTokenizer.from(modelFolder:)` (swift-transformers)
+  into `MLXLMCommon.Tokenizer`. Written by hand instead of using the
+  `MLXHuggingFace` `#huggingFaceTokenizerLoader()` macro to avoid
+  pulling the macro plugin + extra SPM products for ~30 LOC of bridge.
 
 ---
 

--- a/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
+++ b/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
@@ -1,0 +1,351 @@
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import OSLog
+import Tokenizers
+
+/// Concrete `LLMProvider` running Gemma 3 4B-IT (MLX 4-bit) in-process via
+/// `ml-explore/mlx-swift-lm` on Apple Silicon.
+///
+/// **Issue #3.** This is the production-side counterpart to `MockLLMProvider`
+/// shipped in #51. The protocol contract (deterministic defaults, PHI-safe
+/// logging, retry-once at the processor level) is unchanged — see
+/// `LLMProvider.swift` for the protocol docs and
+/// `.claude/references/mlx-lifecycle.md` for the load / warmup / fallback
+/// story.
+///
+/// ### Lifecycle
+/// Two-phase init: construct cheaply with the model directory, then
+/// `warmup()` to load weights into the `ModelContainer` before the first
+/// call. Subsequent `generate` / `generateStream` calls reuse the loaded
+/// container. The model is held for the app lifetime — eviction would
+/// just force a re-load on the next session, and the dominant cost is
+/// the cold mmap + dequantize of ~2.5 GB of weights.
+///
+/// ### Concurrency
+/// `actor` per the `LLMProvider: Actor` protocol constraint (mockability —
+/// actors cannot be subclassed, see `.claude/references/concurrency.md` §6).
+/// The underlying `MLXLMCommon.ModelContainer` is itself a thread-safe
+/// `final class Sendable` that serialises model access internally; this
+/// actor adds a thin layer of state ownership (`container: ModelContainer?`)
+/// and request-shaping. We don't add a second serialisation layer because
+/// `ModelContainer` already provides it.
+///
+/// ### Privacy
+/// **Never** logs prompt or response content. Structural values only:
+/// token counts, latency, error-case names. The
+/// `String(describing: type(of: error))` idiom is the canonical
+/// PHI-safe error log shape.
+public actor MLXGemmaProvider: LLMProvider {
+    /// Errors thrown by `MLXGemmaProvider`. Cases carry only structural
+    /// metadata; raw upstream `Error` chains are caught and re-raised as
+    /// `.modelLoadFailed(kind:)` / `.generationFailed(kind:)` to prevent
+    /// `localizedDescription`-driven PHI leakage.
+    public enum ProviderError: Error, Sendable, Equatable {
+        /// `ModelContainer` failed to load. `kind` is
+        /// `String(describing: type(of: error))`.
+        case modelLoadFailed(kind: String)
+        /// `prepare(input:)` or `generate(...)` failed mid-flight.
+        case generationFailed(kind: String)
+        /// `generate` was called before `warmup()` and lazy-load also failed.
+        case notLoaded
+    }
+
+    private let modelDirectory: URL
+    private let tokenizerLoader: any TokenizerLoader
+    private let logger: Logger
+    private var container: ModelContainer?
+
+    /// - Parameters:
+    ///   - modelDirectory: directory holding the manifest's files post-download
+    ///     (typically `<app-support>/<bundle-id>/Models/<model-dir>/`).
+    ///     `ModelDownloader.ensureModelDownloaded()` produces this URL.
+    ///   - tokenizerLoader: defaults to a `swift-transformers` AutoTokenizer
+    ///     bridge. Overridable in tests.
+    public init(
+        modelDirectory: URL,
+        tokenizerLoader: (any TokenizerLoader)? = nil
+    ) {
+        self.modelDirectory = modelDirectory
+        self.tokenizerLoader = tokenizerLoader ?? SwiftTransformersTokenizerLoader()
+        self.logger = Logger(
+            subsystem: Bundle.main.bundleIdentifier ?? "com.cloudbroker.mac-speech-to-text",
+            category: "mlx-provider"
+        )
+    }
+
+    /// Eagerly load weights into a `ModelContainer`. Idempotent — a second
+    /// call is a no-op once `container` is set. Wired from the Clinical
+    /// Notes Mode toggle in `AppState` so the practitioner pays the
+    /// load cost up-front rather than on the first "Generate Notes" tap.
+    public func warmup() async throws {
+        if container != nil { return }
+        let started = ContinuousClock.now
+        do {
+            let loaded = try await LLMModelFactory.shared.loadContainer(
+                from: modelDirectory,
+                using: tokenizerLoader
+            )
+            container = loaded
+            let elapsed = ContinuousClock.now - started
+            // Log millisecond-precision so sub-second warmups (the
+            // common warm-cache case) don't truncate to "0s".
+            let ms = (elapsed.components.seconds * 1_000)
+                + Int64(elapsed.components.attoseconds / 1_000_000_000_000_000)
+            logger.info(
+                "MLX warmup completed in \(ms, privacy: .public)ms"
+            )
+        } catch {
+            let kind = String(describing: type(of: error))
+            logger.error("MLX warmup failed kind=\(kind, privacy: .public)")
+            throw ProviderError.modelLoadFailed(kind: kind)
+        }
+    }
+
+    public func generate(
+        prompt: String,
+        options: LLMOptions
+    ) async throws -> String {
+        // Reuses the same actor method that backs `generateStream` so
+        // both surfaces share one code path. Collect chunks into a
+        // single result string.
+        var collected = ""
+        try await runGeneration(
+            prompt: prompt,
+            options: options
+        ) { chunk in
+            collected.append(chunk)
+        }
+        return collected
+    }
+
+    /// Single-task `AsyncThrowingStream` adapter — outer cancellation
+    /// (e.g. UI consumer drops the stream) propagates straight through
+    /// to `runGeneration`'s `Task.checkCancellation` because there's
+    /// only one Task in flight. The earlier shape wrapped one stream
+    /// inside another and silently leaked compute on cancel.
+    public nonisolated func generateStream(
+        prompt: String,
+        options: LLMOptions
+    ) -> AsyncThrowingStream<String, any Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { [weak self] in
+                guard let self else {
+                    continuation.finish(throwing: ProviderError.notLoaded)
+                    return
+                }
+                do {
+                    try await self.runGeneration(
+                        prompt: prompt,
+                        options: options
+                    ) { chunk in
+                        continuation.yield(chunk)
+                    }
+                    continuation.finish()
+                } catch is CancellationError {
+                    continuation.finish(throwing: CancellationError())
+                } catch let providerError as ProviderError {
+                    continuation.finish(throwing: providerError)
+                } catch {
+                    let kind = String(describing: type(of: error))
+                    self.logGenerationError(kind: kind)
+                    continuation.finish(
+                        throwing: ProviderError.generationFailed(kind: kind)
+                    )
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Actor-isolated generation core. Accepts a `@Sendable` chunk-yield
+    /// closure so both the collect-to-String (`generate`) and stream
+    /// (`generateStream`) surfaces share the same stop-sequence flushing
+    /// + cancellation behaviour. Throws `CancellationError` directly
+    /// when the parent Task is cancelled — the public surfaces translate.
+    private func runGeneration(
+        prompt: String,
+        options: LLMOptions,
+        yield: @Sendable (String) -> Void
+    ) async throws {
+        let container = try await requireContainer()
+        let parameters = Self.makeParameters(from: options)
+        let stops = options.stop
+
+        let userInput = UserInput(prompt: prompt)
+        let prepared = try await container.prepare(input: userInput)
+        let stream = try await container.generate(
+            input: prepared,
+            parameters: parameters
+        )
+
+        var pendingTail = ""
+        for await item in stream {
+            try Task.checkCancellation()
+            guard case let .chunk(text) = item else { continue }
+            if stops.isEmpty {
+                yield(text)
+                continue
+            }
+            pendingTail += text
+            if let stopRange = Self.firstStopRange(in: pendingTail, stops: stops) {
+                let prefix = String(pendingTail[..<stopRange.lowerBound])
+                if !prefix.isEmpty {
+                    yield(prefix)
+                }
+                break
+            }
+            let safeBoundary = Self.safeFlushBoundary(
+                in: pendingTail,
+                stops: stops
+            )
+            if safeBoundary > pendingTail.startIndex {
+                let flushable = String(pendingTail[..<safeBoundary])
+                yield(flushable)
+                pendingTail = String(pendingTail[safeBoundary...])
+            }
+        }
+    }
+
+    /// Lazy-load on first call if `warmup()` was skipped — surfaces the same
+    /// `.modelLoadFailed` shape so callers can fall back to raw-transcript
+    /// (`.rawTranscriptFallback(reason: reasonLLMError)` in the processor).
+    private func requireContainer() async throws -> ModelContainer {
+        if let container { return container }
+        try await warmup()
+        guard let container else {
+            throw ProviderError.notLoaded
+        }
+        return container
+    }
+
+    /// Logs a `generationFailed` event with PHI-safe `kind` only — no
+    /// `localizedDescription`, no prompt, no completion text.
+    private nonisolated func logGenerationError(kind: String) {
+        // Construct the logger inside the call so this stays nonisolated;
+        // the `logger` property is actor-isolated and can't be touched here.
+        let log = Logger(
+            subsystem: Bundle.main.bundleIdentifier ?? "com.cloudbroker.mac-speech-to-text",
+            category: "mlx-provider"
+        )
+        log.error("MLX generate failed kind=\(kind, privacy: .public)")
+    }
+
+    /// Map our `LLMOptions` onto MLX's `GenerateParameters`. `temperature: 0`
+    /// triggers MLX's `ArgMaxSampler` (greedy) — `topP` becomes irrelevant
+    /// at temperature zero, which is the deterministic default our prompt
+    /// builder + JSON-schema guard assume.
+    static func makeParameters(from options: LLMOptions) -> GenerateParameters {
+        var p = GenerateParameters()
+        p.temperature = options.temperature
+        p.topP = options.topP
+        p.maxTokens = options.maxTokens
+        return p
+    }
+
+    /// First range of any stop sequence inside `text`. Returns the
+    /// earliest match across all stops (greedy-left). Returns `nil` if no
+    /// stop is fully present yet — the caller may have only received a
+    /// partial match and should keep buffering.
+    static func firstStopRange(
+        in text: String,
+        stops: [String]
+    ) -> Range<String.Index>? {
+        var earliest: Range<String.Index>?
+        for stop in stops where !stop.isEmpty {
+            guard let range = text.range(of: stop) else { continue }
+            if let current = earliest {
+                if range.lowerBound < current.lowerBound {
+                    earliest = range
+                }
+            } else {
+                earliest = range
+            }
+        }
+        return earliest
+    }
+
+    /// Safe flush boundary when buffering for stop-sequence matching:
+    /// returns the largest index up to which we can flush without risking
+    /// emitting a partial stop sequence we'd later need to claw back.
+    /// Concretely, retain the last `(maxStopLength - 1)` characters.
+    static func safeFlushBoundary(
+        in text: String,
+        stops: [String]
+    ) -> String.Index {
+        let maxStopLen = stops.map(\.count).max() ?? 0
+        let keepBack = max(0, maxStopLen - 1)
+        guard text.count > keepBack else { return text.startIndex }
+        return text.index(text.endIndex, offsetBy: -keepBack)
+    }
+}
+
+// MARK: - TokenizerLoader bridge
+
+/// Loads tokenizer files from a local directory via `swift-transformers`
+/// (`Tokenizers.AutoTokenizer.from(modelFolder:)`) and wraps the result so
+/// it satisfies `MLXLMCommon.Tokenizer`.
+///
+/// This is the explicit form of `MLXHuggingFace`'s `#huggingFaceTokenizerLoader()`
+/// macro — written out by hand to avoid the macro plugin (and the extra
+/// `MLXHuggingFace` + `HuggingFace` SPM products) since the bridge is
+/// only ~30 lines. If we later want HF Hub-based loading, switching to the
+/// macro is a one-line change.
+public struct SwiftTransformersTokenizerLoader: TokenizerLoader {
+    public init() {}
+
+    public func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        let upstream = try await Tokenizers.AutoTokenizer.from(modelFolder: directory)
+        return SwiftTransformersTokenizerBridge(upstream)
+    }
+}
+
+/// Bridges `Tokenizers.Tokenizer` (swift-transformers) to
+/// `MLXLMCommon.Tokenizer`. Thin pass-through with one shape adjustment:
+/// upstream uses `decode(tokens:skipSpecialTokens:)`, downstream uses
+/// `decode(tokenIds:skipSpecialTokens:)`.
+private struct SwiftTransformersTokenizerBridge: MLXLMCommon.Tokenizer {
+    private let upstream: any Tokenizers.Tokenizer
+
+    init(_ upstream: any Tokenizers.Tokenizer) {
+        self.upstream = upstream
+    }
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] {
+        upstream.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        upstream.decode(tokens: tokenIds, skipSpecialTokens: skipSpecialTokens)
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        upstream.convertTokenToId(token)
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        upstream.convertIdToToken(id)
+    }
+
+    var bosToken: String? { upstream.bosToken }
+    var eosToken: String? { upstream.eosToken }
+    var unknownToken: String? { upstream.unknownToken }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] {
+        do {
+            return try upstream.applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext
+            )
+        } catch Tokenizers.TokenizerError.missingChatTemplate {
+            throw MLXLMCommon.TokenizerError.missingChatTemplate
+        }
+    }
+}

--- a/Sources/Services/ClinicalNotes/ModelDownloader.swift
+++ b/Sources/Services/ClinicalNotes/ModelDownloader.swift
@@ -1,0 +1,459 @@
+import CryptoKit
+import Foundation
+import OSLog
+
+/// Downloads + verifies the bundled `ModelManifest`'s files into a stable
+/// on-disk location for `MLXGemmaProvider` to mmap from.
+///
+/// **Issue #3.** The clinical-notes LLM (~2.6 GB of MLX 4-bit Gemma 3 4B-IT
+/// weights) is **not** bundled in the .app — see the locked-decision update
+/// in `.claude/CLAUDE.md` and `.claude/references/mlx-lifecycle.md`. The
+/// downloader fetches the manifest's files from Hugging Face on first run
+/// (triggered by the user enabling Clinical Notes Mode in Settings, the
+/// same `warmup()` hook that pre-loads the model), verifies sha256 against
+/// the manifest, and atomically renames into
+/// `~/Library/Application Support/<bundle-id>/Models/<model-dir>/`.
+///
+/// ### Privacy
+/// Manifest data, file paths, byte counts, and HF URLs are all PHI-free
+/// by construction. `OSLog` calls use `privacy: .public` for these values.
+/// The downloader **never** sees transcripts, draft notes, or any
+/// patient-identifying data — those live downstream in
+/// `SessionStore` / `ClinicalNotesProcessor`.
+///
+/// ### Concurrency
+/// `actor` for single-threaded mutation of the download state. The progress
+/// callback is `@Sendable` and may be invoked from inside the actor's
+/// executor; UI layers should hop to `@MainActor` themselves rather than
+/// relying on this actor's isolation. `Task.checkCancellation()` is honoured
+/// at every per-file boundary so a cancelled `Settings` toggle does not
+/// leak a 2.5 GB download.
+public actor ModelDownloader {
+    /// PHI-free progress event surfaced via the optional callback to
+    /// `ensureModelDownloaded(progress:)`. Every payload field is structural
+    /// — sizes, paths, error tags — never user content.
+    public enum DownloadProgress: Sendable, Equatable {
+        /// Download began. `totalBytes` is the manifest sum; the UI layer
+        /// uses it as the progress-bar denominator.
+        case starting(totalBytes: Int64)
+        /// A specific file began transferring (or was skipped because it
+        /// already exists + verifies). `expectedBytes` is the manifest size.
+        case fileStarted(path: String, expectedBytes: Int64)
+        /// Cumulative bytes received for the current file. The UI layer
+        /// rolls up across files itself; we don't aggregate here so the
+        /// per-file callback shape is simple.
+        case bytesReceived(path: String, received: Int64, total: Int64)
+        /// File finished + verified. Atomically renamed into place.
+        case fileVerified(path: String)
+        /// All files present + verified.
+        case completed(directory: URL)
+        /// Cancelled mid-flight. Idempotent re-call will resume from the
+        /// next missing file.
+        case cancelled
+    }
+
+    /// Sendable callback shape for progress reporting. `nil` to suppress.
+    public typealias ProgressCallback = @Sendable (DownloadProgress) -> Void
+
+    /// Errors thrown by `ensureModelDownloaded`. Cases carry only structural
+    /// metadata — never PHI, never raw `Error` chains that might quote
+    /// downstream PHI.
+    public enum DownloaderError: Error, Equatable, Sendable {
+        /// Hugging Face responded with a non-2xx status. `path` is the
+        /// manifest-relative file path; `status` is the HTTP code.
+        case httpStatus(path: String, status: Int)
+        /// Bytes received do not match the manifest's `size`.
+        case sizeMismatch(path: String, expected: Int64, got: Int64)
+        /// Computed sha256 does not match the manifest's `sha256`.
+        case hashMismatch(path: String)
+        /// Network / I/O failure. `kind` is `String(describing: type(of: error))`
+        /// — captures the error class without stringifying its contents.
+        case io(path: String, kind: String)
+        /// Manifest is malformed (missing keys, negative sizes, etc.).
+        case malformedManifest(reason: String)
+        /// Disk-space pre-check failed. `availableBytes` is the volume's
+        /// "important usage" capacity at the time of the check.
+        case insufficientDiskSpace(needed: Int64, available: Int64)
+    }
+
+    private let manifest: ModelManifest
+    private let baseDirectory: URL
+    private let session: URLSession
+    private let logger: Logger
+    private var inFlightTask: URLSessionDataTask?
+
+    /// - Parameters:
+    ///   - manifest: pinned `ModelManifest` (typically loaded from
+    ///     `Resources/Models/<model-dir>/manifest.json` via `Bundle.main`).
+    ///   - baseDirectory: parent directory under which `<model-dir>/` is
+    ///     written. Defaults to `~/Library/Application Support/<bundle-id>/Models/`.
+    ///   - session: injected for tests (`URLProtocolStub`); production uses
+    ///     `URLSession.shared`.
+    public init(
+        manifest: ModelManifest,
+        baseDirectory: URL? = nil,
+        session: URLSession = .shared
+    ) {
+        self.manifest = manifest
+        if let baseDirectory {
+            self.baseDirectory = baseDirectory
+        } else {
+            self.baseDirectory = Self.defaultBaseDirectory()
+        }
+        self.session = session
+        self.logger = Logger(
+            subsystem: Bundle.main.bundleIdentifier ?? "com.cloudbroker.mac-speech-to-text",
+            category: "model-downloader"
+        )
+    }
+
+    /// Per-bundle Application-Support root. Falls back to the Caches
+    /// directory if Application Support is somehow unavailable, so the
+    /// downloader still functions on pathological environments where
+    /// the system directory is missing or unwritable.
+    public static func defaultBaseDirectory() -> URL {
+        let fm = FileManager.default
+        let bundleId = Bundle.main.bundleIdentifier ?? "com.cloudbroker.mac-speech-to-text"
+        let root: URL
+        if let appSupport = try? fm.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) {
+            root = appSupport
+        } else if let caches = try? fm.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        ) {
+            root = caches
+        } else {
+            // Last-resort: tmp. This branch is essentially unreachable on
+            // a normal macOS install — both Application Support and Caches
+            // would have to be inaccessible — but never crash on launch.
+            root = URL(fileURLWithPath: NSTemporaryDirectory())
+        }
+        return root
+            .appendingPathComponent(bundleId, isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+    }
+
+    /// Idempotent: returns immediately if every manifest file is already
+    /// present at the expected size + (when supplied) sha256. Otherwise
+    /// downloads the missing/stale ones, verifies, and atomically renames
+    /// into place.
+    ///
+    /// Returns the directory containing the verified model files —
+    /// `<baseDirectory>/<modelDirName>/`.
+    public func ensureModelDownloaded(
+        progress: ProgressCallback? = nil
+    ) async throws -> URL {
+        let modelDir = try makeModelDirectory()
+        let needsBytes = try await bytesToDownload(into: modelDir)
+        if needsBytes == 0 {
+            logger.info("Model already complete at \(modelDir.path, privacy: .public)")
+            progress?(.completed(directory: modelDir))
+            return modelDir
+        }
+
+        try preflightDiskSpace(needed: needsBytes)
+        progress?(.starting(totalBytes: manifest.totalBytes))
+
+        for file in manifest.files {
+            try Task.checkCancellation()
+            let dest = modelDir.appendingPathComponent(file.path)
+            if try await fileSatisfiesManifest(file, at: dest) {
+                progress?(.fileVerified(path: file.path))
+                continue
+            }
+            progress?(.fileStarted(path: file.path, expectedBytes: file.size))
+            try await downloadAndVerify(file: file, into: modelDir, progress: progress)
+            progress?(.fileVerified(path: file.path))
+        }
+
+        progress?(.completed(directory: modelDir))
+        logger.info("Model download verified at \(modelDir.path, privacy: .public)")
+        return modelDir
+    }
+
+    /// Cancels the current in-flight URLSession task. Subsequent calls to
+    /// `ensureModelDownloaded` resume from the next missing file (or
+    /// throw `CancellationError` if the parent Task is cancelled too).
+    public func cancel() {
+        inFlightTask?.cancel()
+        inFlightTask = nil
+    }
+
+    // MARK: - Internals
+
+    /// On-disk model directory (`<baseDirectory>/<modelDirName>/`). The
+    /// directory name is derived from the manifest's `modelId` so two
+    /// different models can coexist on disk.
+    private func makeModelDirectory() throws -> URL {
+        let dirName = manifest.modelId
+            .split(separator: "/")
+            .last
+            .map(String.init) ?? "model"
+        let dir = baseDirectory.appendingPathComponent(dirName, isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: dir,
+            withIntermediateDirectories: true
+        )
+        return dir
+    }
+
+    /// Sum of bytes still required to satisfy the manifest. 0 means every
+    /// file is already complete + verified.
+    private func bytesToDownload(into modelDir: URL) async throws -> Int64 {
+        var total: Int64 = 0
+        for file in manifest.files {
+            let dest = modelDir.appendingPathComponent(file.path)
+            if try await fileSatisfiesManifest(file, at: dest) {
+                continue
+            }
+            total += file.size
+        }
+        return total
+    }
+
+    /// Per-file completeness check. Size must match exactly; sha256 must
+    /// match when the manifest carries one. A `nil` manifest hash means
+    /// "size-only check, integrity bounded by the manifest revision pin".
+    private func fileSatisfiesManifest(
+        _ file: ModelFile,
+        at url: URL
+    ) async throws -> Bool {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
+        guard let size = attrs?[.size] as? Int64, size == file.size else {
+            return false
+        }
+        guard let expectedHash = file.sha256, !expectedHash.isEmpty else {
+            return true
+        }
+        let actual = try await Self.sha256Hex(of: url)
+        return actual.caseInsensitiveCompare(expectedHash) == .orderedSame
+    }
+
+    /// Download + verify + atomic-rename a single file.
+    ///
+    /// Uses `URLSession.download(for:)` rather than `bytes(for:)`. Two
+    /// reasons: (a) per-byte AsyncSequence iteration over a multi-GB
+    /// body is wall-clock catastrophic — billions of suspensions and
+    /// `Data.append` calls; (b) `download(for:)` propagates Swift
+    /// `CancellationError` through `Task.cancel()` cleanly, whereas
+    /// `bytes(for:)` reifies cancellation into `URLError(.cancelled)`,
+    /// which would land in the generic `catch` and surface as
+    /// `DownloaderError.io` rather than the user-friendly `.cancelled`
+    /// progress event. Hashing happens after the download via
+    /// `Self.sha256Hex(of:)`, which streams in 4 MB chunks off disk.
+    private func downloadAndVerify(
+        file: ModelFile,
+        into modelDir: URL,
+        progress: ProgressCallback?
+    ) async throws {
+        let url = try Self.huggingFaceURL(
+            modelId: manifest.modelId,
+            revision: manifest.revision,
+            path: file.path
+        )
+        let request = URLRequest(url: url)
+
+        let tempURL: URL
+        let response: URLResponse
+        do {
+            (tempURL, response) = try await session.download(for: request)
+        } catch is CancellationError {
+            progress?(.cancelled)
+            throw CancellationError()
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            // URLSession reifies `Task.cancel()` into `URLError(.cancelled)`
+            // for some transports. Map back to the structural shape so UI
+            // sees `.cancelled`, not `.io(URLError)`.
+            progress?(.cancelled)
+            throw CancellationError()
+        } catch {
+            throw DownloaderError.io(
+                path: file.path,
+                kind: String(describing: type(of: error))
+            )
+        }
+
+        try Self.assertHTTPSuccess(response: response, path: file.path)
+
+        // After the download completes, validate size against the
+        // manifest *before* the (more expensive) sha256 hash. We move
+        // the temp file into our `<file>.partial` slot first so the
+        // verify step is atomic with the rename and any failure leaves
+        // a single recoverable artifact rather than two.
+        let partialURL = modelDir.appendingPathComponent("\(file.path).partial")
+        try FileManager.default.createDirectory(
+            at: partialURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: partialURL.path) {
+            try FileManager.default.removeItem(at: partialURL)
+        }
+        try FileManager.default.moveItem(at: tempURL, to: partialURL)
+
+        try await verifyAndRename(
+            file: file,
+            partialURL: partialURL,
+            modelDir: modelDir,
+            progress: progress
+        )
+    }
+
+    /// Validate size + sha256 (when supplied), then atomic-rename
+    /// `<file>.partial` → `<file>`. Cleans the partial on any failure.
+    /// `progress.bytesReceived` is emitted once at full size for UI
+    /// feedback (the underlying `download(for:)` API does not surface
+    /// streaming progress; per-file `.fileStarted` / `.fileVerified`
+    /// remain the primary granularity).
+    private func verifyAndRename(
+        file: ModelFile,
+        partialURL: URL,
+        modelDir: URL,
+        progress: ProgressCallback?
+    ) async throws {
+        let attrs = try FileManager.default.attributesOfItem(atPath: partialURL.path)
+        let written = (attrs[.size] as? Int64) ?? -1
+        guard written == file.size else {
+            try? FileManager.default.removeItem(at: partialURL)
+            throw DownloaderError.sizeMismatch(
+                path: file.path,
+                expected: file.size,
+                got: written
+            )
+        }
+        progress?(.bytesReceived(
+            path: file.path,
+            received: written,
+            total: file.size
+        ))
+
+        if let expected = file.sha256, !expected.isEmpty {
+            let actualHex = try await Self.sha256Hex(of: partialURL)
+            guard actualHex.caseInsensitiveCompare(expected) == .orderedSame else {
+                try? FileManager.default.removeItem(at: partialURL)
+                throw DownloaderError.hashMismatch(path: file.path)
+            }
+        }
+
+        let dest = modelDir.appendingPathComponent(file.path)
+        do {
+            if FileManager.default.fileExists(atPath: dest.path) {
+                try FileManager.default.removeItem(at: dest)
+            }
+            try FileManager.default.moveItem(at: partialURL, to: dest)
+        } catch {
+            // If the destination overwrite fails (permissions, race),
+            // the partial file would otherwise linger and `bytesToDownload`
+            // wouldn't notice (it only checks `dest`). Clean it explicitly.
+            try? FileManager.default.removeItem(at: partialURL)
+            throw DownloaderError.io(
+                path: file.path,
+                kind: String(describing: type(of: error))
+            )
+        }
+    }
+
+    /// Common HTTP-success guard. Pulled out so the parent download
+    /// function stays inside the cyclomatic-complexity budget.
+    /// `NonHTTPResponse` is defensive cruft for `URLProtocolStub`-driven
+    /// tests; `URLSession` over HTTPS always produces `HTTPURLResponse`
+    /// in production.
+    private static func assertHTTPSuccess(
+        response: URLResponse,
+        path: String
+    ) throws {
+        guard let http = response as? HTTPURLResponse else {
+            throw DownloaderError.io(path: path, kind: "NonHTTPResponse")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            throw DownloaderError.httpStatus(path: path, status: http.statusCode)
+        }
+    }
+
+    /// Disk-space precondition: caller needs `needed` bytes plus a small
+    /// headroom buffer. Throws `insufficientDiskSpace` on shortage so the
+    /// UI layer can tell the user *before* a 2.5 GB download starts and
+    /// inevitably fails halfway.
+    private func preflightDiskSpace(needed: Int64) throws {
+        let buffer: Int64 = 256 * 1024 * 1024 // 256 MB headroom
+        let required = needed + buffer
+        let values = try? baseDirectory.resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        )
+        // `volumeAvailableCapacityForImportantUsageKey` is the
+        // user-perspective free space (purgeable + free). nil means we
+        // couldn't measure; do not block the download in that case.
+        guard let available = values?.volumeAvailableCapacityForImportantUsage else {
+            return
+        }
+        if available < required {
+            throw DownloaderError.insufficientDiskSpace(
+                needed: required,
+                available: available
+            )
+        }
+    }
+
+    // MARK: - Static helpers
+
+    /// `https://huggingface.co/<model-id>/resolve/<revision>/<path>` — HF's
+    /// stable, redirect-followed URL pattern. URLSession follows the
+    /// 302 → CDN redirect transparently.
+    ///
+    /// Throws `DownloaderError.malformedManifest` rather than silently
+    /// returning a degenerate URL — the prior shape would have surfaced
+    /// a misleading `httpStatus(404)` from `huggingface.co/` in release
+    /// builds while only `assertionFailure`-ing in debug. Path validation
+    /// (no `..`, non-empty, no leading `/`) is repeated here as
+    /// belt-and-braces against `ModelFile`'s decode-time check.
+    static func huggingFaceURL(
+        modelId: String,
+        revision: String,
+        path: String
+    ) throws -> URL {
+        guard !modelId.isEmpty, modelId.contains("/") else {
+            throw DownloaderError.malformedManifest(reason: "modelId")
+        }
+        guard !revision.isEmpty else {
+            throw DownloaderError.malformedManifest(reason: "revision")
+        }
+        guard !path.isEmpty,
+              !path.hasPrefix("/"),
+              !path.contains("..") else {
+            throw DownloaderError.malformedManifest(reason: "path:\(path)")
+        }
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "huggingface.co"
+        components.path = "/\(modelId)/resolve/\(revision)/\(path)"
+        guard let url = components.url else {
+            throw DownloaderError.malformedManifest(reason: "url-components:\(path)")
+        }
+        return url
+    }
+
+    /// Streamed sha256 over a file on disk. Reads in 4 MB chunks so a
+    /// 2.5 GB safetensors file does not balloon resident memory during
+    /// the idempotency check.
+    static func sha256Hex(of url: URL) async throws -> String {
+        try await Task.detached(priority: .utility) {
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+            var hasher = SHA256()
+            let chunk = 4 * 1024 * 1024
+            while true {
+                let data = try handle.read(upToCount: chunk) ?? Data()
+                if data.isEmpty { break }
+                hasher.update(data: data)
+            }
+            let digest = hasher.finalize()
+            return digest.map { String(format: "%02x", $0) }.joined()
+        }.value
+    }
+}

--- a/Sources/Services/ClinicalNotes/ModelDownloader.swift
+++ b/Sources/Services/ClinicalNotes/ModelDownloader.swift
@@ -80,7 +80,6 @@ public actor ModelDownloader {
     private let baseDirectory: URL
     private let session: URLSession
     private let logger: Logger
-    private var inFlightTask: URLSessionDataTask?
 
     /// - Parameters:
     ///   - manifest: pinned `ModelManifest` (typically loaded from
@@ -178,25 +177,28 @@ public actor ModelDownloader {
         return modelDir
     }
 
-    /// Cancels the current in-flight URLSession task. Subsequent calls to
-    /// `ensureModelDownloaded` resume from the next missing file (or
-    /// throw `CancellationError` if the parent Task is cancelled too).
-    public func cancel() {
-        inFlightTask?.cancel()
-        inFlightTask = nil
-    }
+    // MARK: - Cancellation
+    //
+    // There is no explicit `cancel()` on this actor: cancellation flows
+    // through Swift structured concurrency. Cancel the parent `Task` that
+    // called `ensureModelDownloaded(progress:)` and `URLSession.download(for:)`
+    // unwinds via `CancellationError`, which the per-file catch translates
+    // into a `.cancelled` progress event before re-throwing. A previous
+    // shape held a `URLSessionDataTask?` field for explicit cancel — that
+    // was dead code after the refactor to `download(for:)` and was removed
+    // (Gemini Code Assist on PR #70).
 
     // MARK: - Internals
 
     /// On-disk model directory (`<baseDirectory>/<modelDirName>/`). The
     /// directory name is derived from the manifest's `modelId` so two
-    /// different models can coexist on disk.
+    /// different models can coexist on disk. See
+    /// `ModelManifest.modelDirectoryName` for the derivation rule.
     private func makeModelDirectory() throws -> URL {
-        let dirName = manifest.modelId
-            .split(separator: "/")
-            .last
-            .map(String.init) ?? "model"
-        let dir = baseDirectory.appendingPathComponent(dirName, isDirectory: true)
+        let dir = baseDirectory.appendingPathComponent(
+            manifest.modelDirectoryName,
+            isDirectory: true
+        )
         try FileManager.default.createDirectory(
             at: dir,
             withIntermediateDirectories: true
@@ -248,6 +250,17 @@ public actor ModelDownloader {
     /// `DownloaderError.io` rather than the user-friendly `.cancelled`
     /// progress event. Hashing happens after the download via
     /// `Self.sha256Hex(of:)`, which streams in 4 MB chunks off disk.
+    ///
+    /// Limitation acknowledged (Gemini Code Assist, PR #70): the async
+    /// `download(for:)` returns the full body to a temp URL and surfaces
+    /// no intra-file progress, so the UI bar is static during a single
+    /// large file (the ~2.6 GB `model.safetensors` dominates wall-clock).
+    /// A `URLSessionDownloadDelegate`-based shape would surface
+    /// per-byte progress at the cost of a delegate seam + Sendable-shaped
+    /// progress closure marshalling. Deferred until the Settings UI for
+    /// download progress is actually wired (today's UI consumer is just
+    /// the `AppState.llmDownloadProgress` observable, which advances at
+    /// per-file boundaries). Tracked as a follow-up.
     private func downloadAndVerify(
         file: ModelFile,
         into modelDir: URL,

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -29,15 +29,40 @@ class AppState {
     /// `ClinicalSession` only ever exists between the end of a recording and
     /// either successful Cliniko export, idle timeout, or app quit. PHI lives
     /// here exclusively — see `.claude/references/phi-handling.md`.
-    ///
-    /// `clinicalNotesProcessor` (the `actor ClinicalNotesProcessor` from #5)
-    /// injection is deferred until the concrete `MLXGemmaProvider` lands —
-    /// only the `LLMProvider` protocol + `MockLLMProvider` shipped in #3, so
-    /// there is no production-shaped LLM to construct a default processor
-    /// against. Wiring is a one-line addition once that provider exists; the
-    /// store on its own is a no-op when the toggle is off and provides no
-    /// PHI surface area.
     @ObservationIgnored let sessionStore: SessionStore
+
+    /// Production-side `LLMProvider` (`MLXGemmaProvider`) + downloader +
+    /// processor wiring (#3). The pipeline is constructed eagerly at
+    /// launch but the model weights and the `ModelContainer` are *not*
+    /// touched until `prepareClinicalNotesPipeline()` is invoked
+    /// (today: lazily on the first `Generate Notes` tap; in a follow-up
+    /// PR: from the Settings toggle when Clinical Notes Mode is enabled).
+    /// `clinicalNotesProcessor` is `nil` only when the prompt template
+    /// fails to load from the bundle, which would also have failed
+    /// earlier asserts.
+    @ObservationIgnored let modelDownloader: ModelDownloader?
+    @ObservationIgnored let llmProvider: MLXGemmaProvider?
+    @ObservationIgnored let clinicalNotesProcessor: ClinicalNotesProcessor?
+    /// Cached pointer to the bundled manifest so per-file size lookups
+    /// in `applyDownloadProgress` don't have to enter the downloader
+    /// actor. Source-of-truth lives in `Resources/Models/<dir>/manifest.json`.
+    @ObservationIgnored let llmManifest: ModelManifest?
+
+    /// Observable hooks for the (future) Settings UI download surface.
+    /// Updated from the `ModelDownloader` progress callback via
+    /// `@MainActor` hops. UI consumers can bind directly; the values
+    /// stay in `0...1` for `progress` and at `.idle` when no download
+    /// is in flight. PHI-free by construction (model bytes only).
+    var llmDownloadProgress: Double = 0
+    var llmDownloadState: LLMDownloadState = .idle
+    /// Sum of bytes fully downloaded + verified so far this session.
+    /// Used by the `applyDownloadProgress` aggregator to advance the
+    /// progress bar smoothly across file boundaries — without it,
+    /// per-file `.bytesReceived` events would reset the bar each time
+    /// a new file started.
+    @ObservationIgnored private var llmDownloadCompletedBytes: Int64 = 0
+    /// Manifest's total bytes — captured once at `.starting`.
+    @ObservationIgnored private var llmDownloadTotalBytes: Int64 = 0
 
     /// Static manipulations taxonomy bundled with the app (#6). Loaded
     /// once at launch and handed to `ReviewWindowController` so the
@@ -97,6 +122,18 @@ class AppState {
         self.manipulations = Self.loadManipulationsTaxonomy()
         self.clinikoCredentialStore = ClinikoCredentialStore()
         self.auditStore = Self.makeAuditStore()
+
+        // Construct the clinical-notes LLM pipeline (#3). All four are
+        // optional: the manifest may be missing in pathological dev
+        // builds, and the prompt template may fail to load (asserts but
+        // doesn't crash). Each `nil` translates downstream into the
+        // existing raw-transcript fallback path — we never crash the
+        // app on a missing model.
+        let llmPipeline = Self.makeLLMPipeline(manipulations: self.manipulations)
+        self.modelDownloader = llmPipeline.downloader
+        self.llmProvider = llmPipeline.provider
+        self.clinicalNotesProcessor = llmPipeline.processor
+        self.llmManifest = llmPipeline.manifest
 
         // Load settings before any closure captures self — Swift's
         // definite-init checker treats `[weak self]` captures as
@@ -226,13 +263,15 @@ class AppState {
     /// Handle the Generate-Notes hand-off. Builds a minimal
     /// `RecordingSession` carrying the transcript, hops PHI into
     /// `SessionStore`, seeds an empty `StructuredNotes` so the editor is
-    /// immediately interactive in the no-LLM path (production wiring of
-    /// `ClinicalNotesProcessor` lands in the same PR series as
-    /// `MLXGemmaProvider` per the comment on `sessionStore` above and
-    /// the `#18` blocker), then presents the review window.
+    /// immediately interactive while the LLM runs, presents the review
+    /// window, then kicks off the LLM pipeline (#3) in a background
+    /// Task. When the processor returns, the draft is replaced with the
+    /// generated SOAP payload (or stays as the empty seed on
+    /// `.rawTranscriptFallback`, mirroring the existing UX contract).
     ///
     /// PHI: only the transcript length and "session started" structural
-    /// markers cross the log boundary. See
+    /// markers cross the log boundary. The transcript itself flows into
+    /// `SessionStore` and `ClinicalNotesProcessor` in-memory only — see
     /// `.claude/references/phi-handling.md`.
     private func handleClinicalNotesGenerateRequested(transcript: String) {
         AppLogger.app.info(
@@ -246,15 +285,202 @@ class AppState {
         recording.transcribedText = transcript
 
         sessionStore.start(from: recording)
-        // Seed an empty draft so the SOAP editor is interactive without
-        // waiting on the LLM (the practitioner can compose from the raw
-        // transcript via the "View raw transcript" sheet). Once the LLM
-        // wiring lands, this seed will be replaced with the
-        // `ClinicalNotesProcessor.Outcome` payload before the window
-        // presents.
         sessionStore.setDraftNotes(StructuredNotes())
 
         ReviewWindowController.shared.present()
+
+        // Kick off LLM processing without blocking the UI present.
+        // `runClinicalNotesPipeline` ensures-download + warms-up + runs
+        // the processor; any failure resolves to the existing empty-draft
+        // fallback so the practitioner can edit manually.
+        Task { @MainActor [weak self] in
+            await self?.runClinicalNotesPipeline(transcript: transcript)
+        }
+    }
+
+    /// Drive the LLM pipeline end-to-end for a single transcript. Idempotent
+    /// across model state — re-entry while a download is in flight returns
+    /// fast (the downloader is itself idempotent + actor-serialised).
+    /// Failures are absorbed into structural log entries and leave the
+    /// existing empty `StructuredNotes` draft in place so the practitioner
+    /// keeps a working surface.
+    private func runClinicalNotesPipeline(transcript: String) async {
+        guard
+            let downloader = modelDownloader,
+            let provider = llmProvider,
+            let processor = clinicalNotesProcessor
+        else {
+            AppLogger.app.warning(
+                "AppState: clinical-notes pipeline unavailable (missing manifest or template)"
+            )
+            return
+        }
+        do {
+            llmDownloadState = .downloading
+            let modelDir = try await downloader.ensureModelDownloaded { [weak self] event in
+                Task { @MainActor [weak self] in
+                    self?.applyDownloadProgress(event)
+                }
+            }
+            llmDownloadState = .verified(directory: modelDir)
+            try await provider.warmup()
+            llmDownloadState = .ready
+        } catch is CancellationError {
+            // User-initiated cancel is a clean state transition, not a
+            // failure. Don't overwrite to `.failed` — `applyDownloadProgress`
+            // may have already set `.cancelled`, and either order yields the
+            // correct final state.
+            AppLogger.app.info("AppState: clinical-notes pipeline cancelled")
+            if llmDownloadState != .cancelled {
+                llmDownloadState = .cancelled
+            }
+            return
+        } catch {
+            AppLogger.app.error(
+                "AppState: clinical-notes warmup failed kind=\(String(describing: type(of: error)), privacy: .public)"
+            )
+            llmDownloadState = .failed
+            return
+        }
+
+        let outcome = await processor.process(transcript: transcript)
+        switch outcome {
+        case .success(let notes):
+            sessionStore.setDraftNotes(notes)
+            AppLogger.app.info("AppState: clinical-notes draft populated")
+        case .rawTranscriptFallback(let reason):
+            AppLogger.app.info(
+                "AppState: clinical-notes fell back reason=\(reason, privacy: .public)"
+            )
+        }
+    }
+
+    /// Translate a `ModelDownloader.DownloadProgress` event into the
+    /// `@Observable` properties the (future) Settings UI surface binds
+    /// against. Aggregates per-file progress into a single overall
+    /// `llmDownloadProgress` in `[0, 1]` so the bar advances smoothly
+    /// across the multi-file manifest (file boundaries no longer leave
+    /// the UI looking frozen).
+    private func applyDownloadProgress(_ event: ModelDownloader.DownloadProgress) {
+        switch event {
+        case .starting(let totalBytes):
+            llmDownloadProgress = 0
+            llmDownloadCompletedBytes = 0
+            llmDownloadTotalBytes = totalBytes
+            llmDownloadState = .downloading
+        case .fileStarted(let path, let expected):
+            AppLogger.app.info(
+                "AppState: clinical-notes download begin file=\(path, privacy: .public) bytes=\(expected, privacy: .public)"
+            )
+        case .bytesReceived(_, let received, let total):
+            // Aggregate progress across the whole manifest, not just the
+            // active file: previously-completed bytes plus the active
+            // file's running tally. Latches at 1.0 so a stale event after
+            // `.completed` cannot regress the bar.
+            let denom = max(llmDownloadTotalBytes, 1)
+            let raw = Double(llmDownloadCompletedBytes + received) / Double(denom)
+            llmDownloadProgress = min(max(raw, llmDownloadProgress), 1.0)
+            _ = total // expected denominator at the per-file level — we use the manifest-wide denom instead
+        case .fileVerified(let path):
+            // A verified file's bytes graduate from "in flight" to
+            // "completed" so the next file's `bytesReceived` rolls up
+            // from the right baseline. The manifest is the authority for
+            // the file's size.
+            if let file = downloadedFileSize(path: path) {
+                llmDownloadCompletedBytes += file
+            }
+            AppLogger.app.info(
+                "AppState: clinical-notes download verified file=\(path, privacy: .public)"
+            )
+        case .completed(let dir):
+            llmDownloadProgress = 1
+            llmDownloadState = .verified(directory: dir)
+        case .cancelled:
+            llmDownloadState = .cancelled
+        }
+    }
+
+    /// Lookup the manifest-declared size of a file by its repo-relative
+    /// path. Returns `nil` for an unknown path so the aggregator can
+    /// no-op rather than miscount.
+    private func downloadedFileSize(path: String) -> Int64? {
+        guard let downloader = modelDownloader else { return nil }
+        // The downloader's manifest is the source of truth. We only need
+        // the size lookup, which is cheap and does not require entering
+        // the actor — but we don't have direct access to the manifest
+        // through the downloader's public API. Cache via the bundled
+        // manifest read once at init time. (The manifest is already
+        // in-memory inside `makeLLMPipeline`; we save a copy here.)
+        _ = downloader
+        return llmManifest?.files.first(where: { $0.path == path })?.size
+    }
+
+    // MARK: - LLM pipeline construction
+
+    private struct LLMPipeline {
+        let downloader: ModelDownloader?
+        let provider: MLXGemmaProvider?
+        let processor: ClinicalNotesProcessor?
+        let manifest: ModelManifest?
+    }
+
+    /// Build the `ModelDownloader` + `MLXGemmaProvider` + `ClinicalNotesProcessor`
+    /// trio from bundled resources. Any missing piece (manifest absent,
+    /// prompt template missing) returns `nil` for the corresponding
+    /// member so callers fall back to the empty-draft path; we never
+    /// crash on a misconfigured bundle.
+    private static func makeLLMPipeline(
+        manipulations: ManipulationsRepository
+    ) -> LLMPipeline {
+        guard let manifestURL = Bundle.module.url(
+            forResource: "manifest",
+            withExtension: "json",
+            subdirectory: "Models/gemma-3-text-4b-it-4bit"
+        ) else {
+            AppLogger.app.warning(
+                "AppState: LLM manifest not bundled — clinical-notes LLM disabled"
+            )
+            return LLMPipeline(downloader: nil, provider: nil, processor: nil, manifest: nil)
+        }
+        let manifest: ModelManifest
+        do {
+            let data = try Data(contentsOf: manifestURL)
+            manifest = try JSONDecoder().decode(ModelManifest.self, from: data)
+        } catch {
+            AppLogger.app.error(
+                "AppState: LLM manifest decode failed kind=\(String(describing: type(of: error)), privacy: .public)"
+            )
+            return LLMPipeline(downloader: nil, provider: nil, processor: nil, manifest: nil)
+        }
+        let downloader = ModelDownloader(manifest: manifest)
+        let modelDir = ModelDownloader.defaultBaseDirectory()
+            .appendingPathComponent(
+                manifest.modelId.split(separator: "/").last.map(String.init) ?? "model",
+                isDirectory: true
+            )
+        let provider = MLXGemmaProvider(modelDirectory: modelDir)
+        let processor: ClinicalNotesProcessor?
+        do {
+            let promptBuilder = try ClinicalNotesPromptBuilder.loadFromBundle(
+                manipulations: manipulations
+            )
+            processor = ClinicalNotesProcessor(
+                provider: provider,
+                promptBuilder: promptBuilder,
+                manipulations: manipulations
+            )
+        } catch {
+            AppLogger.app.error(
+                "AppState: prompt builder load failed kind=\(String(describing: type(of: error)), privacy: .public) — clinical-notes processor disabled"
+            )
+            processor = nil
+        }
+        return LLMPipeline(
+            downloader: downloader,
+            provider: provider,
+            processor: processor,
+            manifest: manifest
+        )
     }
 
     // MARK: - Cliniko export pipeline (#14)

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -317,6 +317,17 @@ class AppState {
         }
         do {
             llmDownloadState = .downloading
+            // Per-event Task hops to MainActor are not strictly ordered
+            // (Gemini Code Assist, PR #70). After the refactor to
+            // `URLSession.download(for:)` the events are far apart in
+            // time (one `.fileStarted` / `.bytesReceived` / `.fileVerified`
+            // per file in the manifest, not per byte) so practical
+            // reordering is highly unlikely. The aggregator
+            // (`applyDownloadProgress`) is also hardened to be order-
+            // insensitive: progress monotonically increases and latches
+            // at 1.0 on `.completed`, and `.cancelled` / `.failed` are
+            // terminal. Promote to an `AsyncStream`-piped source if a
+            // future progress event design becomes per-byte.
             let modelDir = try await downloader.ensureModelDownloaded { [weak self] event in
                 Task { @MainActor [weak self] in
                     self?.applyDownloadProgress(event)
@@ -455,7 +466,7 @@ class AppState {
         let downloader = ModelDownloader(manifest: manifest)
         let modelDir = ModelDownloader.defaultBaseDirectory()
             .appendingPathComponent(
-                manifest.modelId.split(separator: "/").last.map(String.init) ?? "model",
+                manifest.modelDirectoryName,
                 isDirectory: true
             )
         let provider = MLXGemmaProvider(modelDirectory: modelDir)

--- a/Tests/SpeechToTextTests/Models/ModelManifestTests.swift
+++ b/Tests/SpeechToTextTests/Models/ModelManifestTests.swift
@@ -4,6 +4,21 @@ import Testing
 
 @Suite("ModelManifest", .tags(.fast))
 struct ModelManifestTests {
+    @Test("modelDirectoryName takes the segment after the final slash",
+          arguments: [
+              ("mlx-community/gemma-3-text-4b-it-4bit", "gemma-3-text-4b-it-4bit"),
+              ("ns/repo", "repo"),
+              ("a/b/c", "c")
+          ])
+    func modelDirectoryNameDerivation(modelId: String, expected: String) {
+        let manifest = ModelManifest(
+            modelId: modelId,
+            revision: "abc",
+            files: []
+        )
+        #expect(manifest.modelDirectoryName == expected)
+    }
+
     @Test("init computes total_bytes from files")
     func totalBytesFromFiles() {
         let manifest = ModelManifest(

--- a/Tests/SpeechToTextTests/Models/ModelManifestTests.swift
+++ b/Tests/SpeechToTextTests/Models/ModelManifestTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+@Suite("ModelManifest", .tags(.fast))
+struct ModelManifestTests {
+    @Test("init computes total_bytes from files")
+    func totalBytesFromFiles() {
+        let manifest = ModelManifest(
+            modelId: "ns/repo",
+            revision: "deadbeef",
+            files: [
+                ModelFile(path: "a.bin", size: 100, sha256: nil),
+                ModelFile(path: "b.bin", size: 250, sha256: "abc")
+            ]
+        )
+        #expect(manifest.totalBytes == 350)
+    }
+
+    @Test("decode rejects total_bytes that disagrees with sum(files.size)")
+    func decodeRejectsStaleTotal() throws {
+        let json = """
+        {
+          "model_id": "ns/repo",
+          "revision": "deadbeef",
+          "files": [
+            { "path": "a.bin", "size": 100, "sha256": null }
+          ],
+          "total_bytes": 999
+        }
+        """.data(using: .utf8)!
+        // Tampered or hand-edited manifest with a stale total surfaces
+        // as `DecodingError.dataCorrupted` rather than decoding into an
+        // inconsistent value that bites later.
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(ModelManifest.self, from: json)
+        }
+    }
+
+    @Test("decode passes when total_bytes matches sum(files.size)")
+    func decodePassesOnConsistentTotal() throws {
+        let json = """
+        {
+          "model_id": "ns/repo",
+          "revision": "deadbeef",
+          "files": [
+            { "path": "a.bin", "size": 100, "sha256": null },
+            { "path": "b.bin", "size": 200, "sha256": null }
+          ],
+          "total_bytes": 300
+        }
+        """.data(using: .utf8)!
+        let manifest = try JSONDecoder().decode(ModelManifest.self, from: json)
+        #expect(manifest.totalBytes == 300)
+        #expect(manifest.files.count == 2)
+    }
+
+    @Test("decode rejects ModelFile with malformed path or negative size",
+          arguments: [
+              // (path, size, expectThrow)
+              ("../etc/passwd", Int64(10), true),
+              ("/abs/path", Int64(10), true),
+              ("a/../b", Int64(10), true),
+              ("", Int64(10), true),
+              ("ok/path", Int64(-1), true),
+              ("ok/path", Int64(0), false),     // zero-size files are valid (empty config)
+              ("nested/dir/file.bin", Int64(123), false)
+          ])
+    func decodeValidatesModelFile(path: String, size: Int64, expectThrow: Bool) throws {
+        // Paths embedded with care; this test exists because
+        // `ModelDownloader.appendingPathComponent(file.path)` would
+        // otherwise be a path-traversal vector.
+        let json = """
+        { "path": \(jsonEncode(path)), "size": \(size), "sha256": null }
+        """.data(using: .utf8)!
+        if expectThrow {
+            #expect(throws: DecodingError.self) {
+                _ = try JSONDecoder().decode(ModelFile.self, from: json)
+            }
+        } else {
+            let file = try JSONDecoder().decode(ModelFile.self, from: json)
+            #expect(file.path == path)
+            #expect(file.size == size)
+        }
+    }
+
+    @Test("decode rejects empty-string sha256")
+    func decodeRejectsEmptyHash() throws {
+        let json = #"{ "path": "ok", "size": 1, "sha256": "" }"#.data(using: .utf8)!
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder().decode(ModelFile.self, from: json)
+        }
+    }
+
+    /// Minimal JSON-string encoder for the parameterised test above.
+    /// Tests use known-safe path inputs, so escaping just `"` is enough;
+    /// no general-purpose escaping needed.
+    private func jsonEncode(_ s: String) -> String {
+        return "\"\(s.replacingOccurrences(of: "\"", with: "\\\""))\""
+    }
+
+    @Test("encode round-trips through Decoder")
+    func encodeDecodeRoundTrip() throws {
+        let original = ModelManifest(
+            modelId: "mlx-community/gemma-3-text-4b-it-4bit",
+            revision: "4f665a4c50ecfe4ecdc34056ab52fe3e3c4abf9e",
+            files: [
+                ModelFile(path: "config.json", size: 928, sha256: nil),
+                ModelFile(path: "model.safetensors", size: 2_560_876_251, sha256: "ABC")
+            ]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let data = try encoder.encode(original)
+        let decoded = try JSONDecoder().decode(ModelManifest.self, from: data)
+        #expect(decoded == original)
+    }
+
+    @Test("snake_case JSON keys decode")
+    func snakeCaseKeys() throws {
+        let json = #"""
+        {
+          "model_id": "x/y",
+          "revision": "abc",
+          "files": [],
+          "total_bytes": 0
+        }
+        """#.data(using: .utf8)!
+        let manifest = try JSONDecoder().decode(ModelManifest.self, from: json)
+        #expect(manifest.modelId == "x/y")
+        #expect(manifest.totalBytes == 0)
+        #expect(manifest.files.isEmpty)
+    }
+
+    @Test("bundled gemma-3-text-4b-it-4bit manifest is structurally sound (off-disk)")
+    func bundledManifestDecodes() throws {
+        // The manifest resource lives in the main `SpeechToText` target's
+        // Resources/, NOT in the test bundle's resources, so `Bundle.module`
+        // here doesn't see it. Read the file directly off the workspace
+        // path (test runs from the project root) so this test exercises
+        // the actual checked-in manifest rather than a duplicate fixture.
+        let manifestPath = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent("Resources/Models/gemma-3-text-4b-it-4bit/manifest.json")
+        guard FileManager.default.fileExists(atPath: manifestPath.path) else {
+            // CI / Xcode test schemes may run from a different cwd. Skip
+            // cleanly — production wiring (`AppState.makeLLMPipeline`)
+            // is the canonical correctness check.
+            return
+        }
+        let data = try Data(contentsOf: manifestPath)
+        let manifest = try JSONDecoder().decode(ModelManifest.self, from: data)
+        #expect(manifest.modelId == "mlx-community/gemma-3-text-4b-it-4bit")
+        #expect(manifest.revision.count == 40) // git SHA
+        #expect(manifest.files.count == 8)
+        let computedTotal = manifest.files.reduce(into: Int64(0)) { $0 += $1.size }
+        #expect(computedTotal == manifest.totalBytes)
+        // The big binary file MUST have a sha256 — it's where tampering
+        // would matter. Smaller config files may rely on revision pinning.
+        let bigFile = manifest.files.first(where: { $0.path == "model.safetensors" })
+        #expect(bigFile?.sha256?.isEmpty == false)
+        #expect(bigFile?.size ?? 0 > 2_500_000_000)
+    }
+}

--- a/Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift
+++ b/Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift
@@ -1,0 +1,163 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+/// `MLXGemmaProvider` tests that don't require a real model on disk.
+///
+/// **#3.** The provider's parameter mapping and stop-sequence flush logic
+/// is pure-logic and stays in the default CI path. Real-inference golden
+/// tests live in `MLXGemmaProviderGoldenTests` and are gated on
+/// `RUN_MLX_GOLDEN=1` + `.requiresHardware` so CI's macOS-14 runner skips
+/// them.
+@Suite("MLXGemmaProvider — pure logic", .tags(.fast))
+struct MLXGemmaProviderUnitTests {
+    @Test("makeParameters maps temperature, topP, maxTokens 1:1")
+    func parameterMapping() {
+        let opts = LLMOptions(
+            temperature: 0.0,
+            topP: 1.0,
+            maxTokens: 1024,
+            seed: 42,
+            stop: []
+        )
+        let p = MLXGemmaProvider.makeParameters(from: opts)
+        #expect(p.temperature == 0.0)
+        #expect(p.topP == 1.0)
+        #expect(p.maxTokens == 1024)
+    }
+
+    @Test("makeParameters honours non-default temperature")
+    func parameterMappingNonZeroTemp() {
+        let opts = LLMOptions(temperature: 0.7, topP: 0.9, maxTokens: 512)
+        let p = MLXGemmaProvider.makeParameters(from: opts)
+        #expect(p.temperature == 0.7)
+        #expect(p.topP == 0.9)
+        #expect(p.maxTokens == 512)
+    }
+
+    @Test("firstStopRange returns earliest match across multiple stops")
+    func firstStopMatchesEarliest() {
+        let text = "subjective: ...} more}"
+        let r = MLXGemmaProvider.firstStopRange(in: text, stops: ["}", "more"])
+        #expect(r != nil)
+        // The first `}` appears before `more`, so it wins.
+        let prefix = String(text[..<r!.lowerBound])
+        #expect(prefix == "subjective: ...")
+    }
+
+    @Test("firstStopRange returns nil when no stop is present")
+    func firstStopNilWhenAbsent() {
+        let r = MLXGemmaProvider.firstStopRange(
+            in: "no closer here",
+            stops: ["}"]
+        )
+        #expect(r == nil)
+    }
+
+    @Test("firstStopRange ignores empty stop strings")
+    func firstStopIgnoresEmpty() {
+        let r = MLXGemmaProvider.firstStopRange(in: "any text", stops: [""])
+        #expect(r == nil)
+    }
+
+    @Test("safeFlushBoundary retains (maxStopLen − 1) characters at the tail")
+    func safeFlushBoundaryRetainsTail() {
+        let text = "abcdefghij"
+        let boundary = MLXGemmaProvider.safeFlushBoundary(
+            in: text,
+            stops: ["xyz"]
+        )
+        // maxStopLen=3 → keep back 2 chars.
+        let kept = String(text[boundary...])
+        #expect(kept.count == 2)
+        #expect(kept == "ij")
+    }
+
+    @Test("safeFlushBoundary returns startIndex when text shorter than max-stop tail")
+    func safeFlushBoundaryShortText() {
+        let text = "ab"
+        let boundary = MLXGemmaProvider.safeFlushBoundary(
+            in: text,
+            stops: ["xyz"]
+        )
+        #expect(boundary == text.startIndex)
+    }
+
+    @Test("safeFlushBoundary returns endIndex when no stops are configured")
+    func safeFlushBoundaryNoStops() {
+        let text = "anything"
+        let boundary = MLXGemmaProvider.safeFlushBoundary(in: text, stops: [])
+        // maxStopLen=0 → keepBack=0 → boundary at endIndex (full flush OK).
+        #expect(boundary == text.endIndex)
+    }
+}
+
+/// Real-inference tests against a downloaded `MLXGemmaProvider`.
+///
+/// **Gate:** `RUN_MLX_GOLDEN=1` env var + `.requiresHardware` tag. CI's
+/// Linux/macOS-14 default path does NOT exercise these. They run on the
+/// remote-Mac nightly job (or locally during dev) — see
+/// `.claude/references/mlx-lifecycle.md` for the load expectations.
+///
+/// Each test relies on a model directory either at the path provided in
+/// `MLX_GEMMA_DIR` env var, or — if absent — the default
+/// `~/Library/Application Support/<bundle-id>/Models/gemma-3-text-4b-it-4bit/`
+/// produced by `ModelDownloader.ensureModelDownloaded()`.
+@Suite("MLXGemmaProvider — real inference", .tags(.slow, .requiresHardware))
+struct MLXGemmaProviderGoldenTests {
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["RUN_MLX_GOLDEN"] == "1"
+    }
+
+    private static func modelDirectory() -> URL? {
+        if let override = ProcessInfo.processInfo.environment["MLX_GEMMA_DIR"] {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+        let base = ModelDownloader.defaultBaseDirectory()
+            .appendingPathComponent("gemma-3-text-4b-it-4bit", isDirectory: true)
+        if FileManager.default.fileExists(atPath: base.path) {
+            return base
+        }
+        return nil
+    }
+
+    @Test("warmup loads ModelContainer in < 30s on M-series", .enabled(if: enabled))
+    func warmupLoads() async throws {
+        guard let dir = Self.modelDirectory() else {
+            Issue.record("model directory not available; set MLX_GEMMA_DIR or run downloader first")
+            return
+        }
+        let provider = MLXGemmaProvider(modelDirectory: dir)
+        let started = ContinuousClock.now
+        try await provider.warmup()
+        let elapsed = ContinuousClock.now - started
+        let seconds = elapsed.components.seconds
+        // Loose budget — load latency varies wildly with thermal state
+        // and disk pressure. The hard contract is just "completes".
+        #expect(seconds < 30, "warmup took \(seconds)s, expected <30s")
+    }
+
+    @Test("greedy generation is deterministic across two calls", .enabled(if: enabled))
+    func deterministicGeneration() async throws {
+        guard let dir = Self.modelDirectory() else {
+            Issue.record("model directory not available")
+            return
+        }
+        let provider = MLXGemmaProvider(modelDirectory: dir)
+        try await provider.warmup()
+
+        let opts = LLMOptions(
+            temperature: 0,
+            topP: 1.0,
+            maxTokens: 32,
+            stop: []
+        )
+        // Synthetic, PHI-free clinical wording per
+        // .claude/references/testing-conventions.md.
+        let prompt = "Briefly summarise: the patient reports left shoulder pain after gardening yesterday."
+
+        let first = try await provider.generate(prompt: prompt, options: opts)
+        let second = try await provider.generate(prompt: prompt, options: opts)
+        #expect(first == second, "greedy decode (temp=0) must be deterministic")
+    }
+}

--- a/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
+++ b/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
@@ -1,0 +1,393 @@
+import Foundation
+import Testing
+import CryptoKit
+@testable import SpeechToText
+
+@Suite("ModelDownloader", .tags(.fast), .serialized)
+struct ModelDownloaderTests {
+    // MARK: - Serialisation note
+    //
+    // `.serialized` is load-bearing: `URLProtocolStub` keeps a single
+    // global `currentResponder`, and `URLProtocolStub.install` /
+    // `URLProtocolStub.reset` mutate it. Tests running in parallel
+    // would race — one's `defer { reset() }` would null the responder
+    // mid-flight in another test, falling through to the real network
+    // (HF, which 401s unauthenticated requests). Per-suite serialisation
+    // scopes the global cleanly.
+    // MARK: - Test scaffolding
+
+    /// Per-test temp directory. Each test creates a fresh sub-folder so the
+    /// downloader's atomic-rename + idempotency machinery has a clean slate.
+    private static func makeTempBase() throws -> URL {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("model-downloader-tests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(
+            at: tmp,
+            withIntermediateDirectories: true
+        )
+        return tmp
+    }
+
+    /// Small canned manifest with a 4-byte payload `"hello"`'s prefix
+    /// `"hell"` so we can pre-compute the sha256 once and reuse across
+    /// tests that exercise the verification path.
+    private static let helloPayload = Data("hell".utf8) // 4 bytes
+    private static let helloSHA256: String = {
+        let digest = SHA256.hash(data: helloPayload)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }()
+
+    private static func helloManifest(includeHash: Bool = true) -> ModelManifest {
+        ModelManifest(
+            modelId: "fixtures/hello-model",
+            revision: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            files: [
+                ModelFile(
+                    path: "weights.bin",
+                    size: Int64(helloPayload.count),
+                    sha256: includeHash ? helloSHA256 : nil
+                )
+            ]
+        )
+    }
+
+    private static func makeOKResponder(
+        path: String = "/fixtures/hello-model/resolve/deadbeefdeadbeefdeadbeefdeadbeefdeadbeef/weights.bin",
+        body: Data = helloPayload
+    ) -> @Sendable (URLRequest) throws -> (HTTPURLResponse, Data) {
+        return { request in
+            let url = request.url ?? URL(string: "https://huggingface.co\(path)")!
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Length": "\(body.count)"]
+            )!
+            return (response, body)
+        }
+    }
+
+    // MARK: - Idempotency
+
+    @Test("second call is a no-op when files already verify")
+    func idempotentSkipWhenFilesPresent() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        // Pre-place a verified copy at <base>/<model-dir>/weights.bin.
+        let modelDir = base.appendingPathComponent("hello-model", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: modelDir,
+            withIntermediateDirectories: true
+        )
+        try Self.helloPayload.write(
+            to: modelDir.appendingPathComponent("weights.bin")
+        )
+
+        // The responder should NEVER fire — if it does, the test fails.
+        let config = URLProtocolStub.install { _ in
+            Issue.record("Downloader should not have made any requests")
+            throw URLError(.cancelled)
+        }
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        let resolved = try await downloader.ensureModelDownloaded()
+        #expect(resolved == modelDir)
+    }
+
+    @Test("emits .completed exactly once on the no-download path")
+    func noDownloadProgressEvents() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let modelDir = base.appendingPathComponent("hello-model", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: modelDir,
+            withIntermediateDirectories: true
+        )
+        try Self.helloPayload.write(
+            to: modelDir.appendingPathComponent("weights.bin")
+        )
+
+        let events = EventCollector()
+        let config = URLProtocolStub.install { _ in
+            Issue.record("Should not request anything")
+            throw URLError(.cancelled)
+        }
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        _ = try await downloader.ensureModelDownloaded { events.append($0) }
+        let captured = await events.snapshot()
+        // Single .completed — no .starting / .fileStarted because the
+        // pre-flight loop short-circuited.
+        #expect(captured.count == 1)
+        if case .completed = captured.first {} else {
+            Issue.record("expected .completed first, got \(String(describing: captured.first))")
+        }
+    }
+
+    // MARK: - Happy-path download
+
+    @Test("downloads, verifies sha256, and atomically writes the file")
+    func happyPathDownload() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let config = URLProtocolStub.install(Self.makeOKResponder())
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        let resolved = try await downloader.ensureModelDownloaded()
+        let written = try Data(
+            contentsOf: resolved.appendingPathComponent("weights.bin")
+        )
+        #expect(written == Self.helloPayload)
+    }
+
+    @Test("happy path emits .starting → .fileStarted → .fileVerified → .completed")
+    func happyPathProgressOrdering() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let events = EventCollector()
+        let config = URLProtocolStub.install(Self.makeOKResponder())
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        _ = try await downloader.ensureModelDownloaded { events.append($0) }
+
+        let captured = await events.snapshot()
+        // Loose check on event sequence — .bytesReceived may or may not
+        // fire for a 4-byte file depending on the chunk-flush threshold,
+        // so we assert structure not exact count.
+        guard captured.count >= 3 else {
+            Issue.record("expected ≥3 events, got \(captured.count)")
+            return
+        }
+        if case .starting = captured.first {} else {
+            Issue.record("first event should be .starting")
+        }
+        let last = captured.last
+        if case .completed = last {} else {
+            Issue.record("last event should be .completed; got \(String(describing: last))")
+        }
+        // .fileVerified must appear once for our single file.
+        let verifiedCount = captured.filter {
+            if case .fileVerified = $0 { return true } else { return false }
+        }.count
+        #expect(verifiedCount == 1)
+    }
+
+    // MARK: - Error paths
+
+    @Test("HTTP 404 raises .httpStatus")
+    func http404SurfacesAsHTTPStatus() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        let config = URLProtocolStub.install { request in
+            let url = request.url ?? URL(string: "https://huggingface.co/")!
+            let response = HTTPURLResponse(
+                url: url,
+                statusCode: 404,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        await #expect(throws: ModelDownloader.DownloaderError.self) {
+            _ = try await downloader.ensureModelDownloaded()
+        }
+    }
+
+    @Test("size mismatch raises .sizeMismatch and does not move the partial file into place")
+    func sizeMismatchRaises() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        // Manifest expects 4 bytes; we serve 8.
+        let config = URLProtocolStub.install(
+            Self.makeOKResponder(body: Data("hellworld".utf8))
+        )
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        do {
+            _ = try await downloader.ensureModelDownloaded()
+            Issue.record("expected sizeMismatch; succeeded instead")
+        } catch let err as ModelDownloader.DownloaderError {
+            if case .sizeMismatch = err {} else {
+                Issue.record("expected .sizeMismatch; got \(err)")
+            }
+        }
+        // No file at the final destination, no `.partial` lingering.
+        let dest = base
+            .appendingPathComponent("hello-model")
+            .appendingPathComponent("weights.bin")
+        let partial = base
+            .appendingPathComponent("hello-model")
+            .appendingPathComponent("weights.bin.partial")
+        #expect(!FileManager.default.fileExists(atPath: dest.path))
+        #expect(!FileManager.default.fileExists(atPath: partial.path))
+    }
+
+    @Test("hash mismatch raises .hashMismatch")
+    func hashMismatchRaises() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        // Right size (4 bytes), wrong content.
+        let config = URLProtocolStub.install(
+            Self.makeOKResponder(body: Data("XXXX".utf8))
+        )
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        do {
+            _ = try await downloader.ensureModelDownloaded()
+            Issue.record("expected hashMismatch; succeeded instead")
+        } catch let err as ModelDownloader.DownloaderError {
+            if case .hashMismatch = err {} else {
+                Issue.record("expected .hashMismatch; got \(err)")
+            }
+        }
+    }
+
+    @Test("nil manifest sha256 → size-only check passes when bytes match")
+    func nilSha256SizeOnlyPasses() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+
+        // Wrong content but right size, manifest doesn't carry a hash.
+        let config = URLProtocolStub.install(
+            Self.makeOKResponder(body: Data("XXXX".utf8))
+        )
+        defer { URLProtocolStub.reset() }
+
+        let downloader = ModelDownloader(
+            manifest: Self.helloManifest(includeHash: false),
+            baseDirectory: base,
+            session: URLSession(configuration: config)
+        )
+        _ = try await downloader.ensureModelDownloaded()
+        let written = try Data(
+            contentsOf: base
+                .appendingPathComponent("hello-model")
+                .appendingPathComponent("weights.bin")
+        )
+        #expect(written == Data("XXXX".utf8))
+    }
+
+    // MARK: - URL composition
+
+    @Test("HF URL composes from <model-id>/resolve/<revision>/<path>")
+    func huggingFaceURLShape() throws {
+        let url = try ModelDownloader.huggingFaceURL(
+            modelId: "mlx-community/gemma-3-text-4b-it-4bit",
+            revision: "4f665a4c50ecfe4ecdc34056ab52fe3e3c4abf9e",
+            path: "model.safetensors"
+        )
+        #expect(url.absoluteString
+                == "https://huggingface.co/mlx-community/gemma-3-text-4b-it-4bit/resolve/4f665a4c50ecfe4ecdc34056ab52fe3e3c4abf9e/model.safetensors")
+    }
+
+    @Test("HF URL rejects malformed inputs")
+    func huggingFaceURLRejectsMalformed() {
+        // Each of these must throw rather than silently producing a
+        // degenerate URL that lands as a misleading 404 in production.
+        for bad in [
+            // (modelId, revision, path)
+            ("", "rev", "f"),                // empty modelId
+            ("noslash", "rev", "f"),         // modelId without /
+            ("a/b", "", "f"),                // empty revision
+            ("a/b", "rev", ""),              // empty path
+            ("a/b", "rev", "/abs"),          // absolute path
+            ("a/b", "rev", "../etc/passwd"), // traversal
+            ("a/b", "rev", "x/../y")         // embedded traversal
+        ] {
+            #expect(throws: ModelDownloader.DownloaderError.self) {
+                _ = try ModelDownloader.huggingFaceURL(
+                    modelId: bad.0,
+                    revision: bad.1,
+                    path: bad.2
+                )
+            }
+        }
+    }
+
+    // MARK: - Streamed sha256 helper
+
+    @Test("sha256Hex(of:) matches CryptoKit one-shot hash")
+    func sha256MatchesCryptoKit() async throws {
+        let base = try Self.makeTempBase()
+        defer { try? FileManager.default.removeItem(at: base) }
+        let file = base.appendingPathComponent("payload.bin")
+        let data = Data((0..<10_000).map { UInt8($0 & 0xff) })
+        try data.write(to: file)
+
+        let oneShot = SHA256.hash(data: data)
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let streamed = try await ModelDownloader.sha256Hex(of: file)
+        #expect(streamed == oneShot)
+    }
+}
+
+// MARK: - Helpers
+
+/// Sendable accumulator for `DownloadProgress` events. Synchronous lock
+/// rather than an actor: the downloader's progress callback shape is
+/// `@Sendable (DownloadProgress) -> Void` (sync), and an actor-backed
+/// implementation that fire-and-forgets a `Task` introduces a race
+/// against the test's read where pending appends may not have drained
+/// even after `Task.yield()`. A lock-protected box appends synchronously
+/// from the callback site so `snapshot()` always sees every event.
+private final class EventCollector: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [ModelDownloader.DownloadProgress] = []
+
+    func append(_ event: ModelDownloader.DownloadProgress) {
+        lock.lock()
+        events.append(event)
+        lock.unlock()
+    }
+
+    func snapshot() async -> [ModelDownloader.DownloadProgress] {
+        lock.lock()
+        defer { lock.unlock() }
+        return events
+    }
+}


### PR DESCRIPTION
Closes #3 (the second half — protocol + mock half shipped via #51).

## Summary
- Real `MLXGemmaProvider` running Gemma 3 4B-IT (MLX 4-bit, text-only) in-process via `ml-explore/mlx-swift-lm` 3.31.3 on Apple Silicon.
- `ModelDownloader` first-run download with sha256-manifest verification → `~/Library/Application Support/<bundle-id>/Models/`.
- `AppState` wired end-to-end: launch constructs the pipeline, first Generate-Notes tap triggers download + warmup, processor runs, draft populates.
- Updates locked decisions in `.claude/CLAUDE.md` + `.claude/references/mlx-lifecycle.md` (LLM runtime / model repo / delivery).

## Three locked-decision deviations from the original issue body — each justified

| Decision | Original | This PR | Why |
|---|---|---|---|
| SPM dep | `ml-explore/mlx-swift-examples` | **`ml-explore/mlx-swift-lm` 3.31.3** | Examples repo deprecated 2025-11 (PR #441); MLXLLM/MLXLMCommon extracted to new `mlx-swift-lm`. Examples `2.29.1` is the last release with the old API. |
| Model | `mlx-community/gemma-3-4b-it-4bit` | **`mlx-community/gemma-3-text-4b-it-4bit`** | Text-only single-shard repo (~2.6 GB) loads cleanly through `MLXLLM` text path; multimodal repo bloats disk + RAM with vision tower we'd never use (~3.4 GB). |
| Delivery | Bundled in .app | **First-run download with sha256-manifest verification** | 2.6 GB bundled would burn LFS bandwidth (10 GiB/month → ~1 week of CI), slow notarisation, force a DMG re-roll for #18 Gemma 4 migration. Mirrors existing FluidAudio `AsrModels.downloadAndLoad(...)` pattern. Locked-decision update recorded in CLAUDE.md. |

`Package.swift` tools-version bumped 5.9 → 6.1 (mlx-swift-lm requires it); language mode pinned to `.v5` on both targets so existing Swift-6 strict-concurrency warnings stay warnings.

## Adds (15 files, +2,252 / −37)

- `Sources/Services/ClinicalNotes/MLXGemmaProvider.swift` — actor conforming to `LLMProvider`. Two-phase init, single-task generation core (avoids cancel-leak from outer-wrapping streams), post-stream stop-sequence flushing, PHI-safe logging only.
- `Sources/Services/ClinicalNotes/ModelDownloader.swift` — actor; uses `URLSession.download(for:)` (not `bytes(for:)` which is per-byte over multi-GB and reifies cancel into `URLError`); sha256 streaming verify; atomic rename; cancellation propagation via `CancellationError`.
- `Sources/Models/ModelManifest.swift` — Codable types with **decode-time validation**: `total_bytes == sum(files.size)`, `path` rejects `..` traversal / absolute / empty, `sha256` is `nil` or non-empty.
- `Sources/Models/LLMDownloadState.swift` — UI-binding state machine.
- `Resources/Models/gemma-3-text-4b-it-4bit/manifest.json` — pinned to HF revision `4f665a4c50ecfe4ecdc34056ab52fe3e3c4abf9e`.
- `.gitignore` — exception so `Resources/Models/*/manifest.json` is tracked while the rest of `Resources/Models/` stays ignored.

## Wires

- `AppState.makeLLMPipeline` constructs all four (downloader + provider + processor + cached manifest) at launch.
- `runClinicalNotesPipeline` handles `CancellationError` separately so user-cancel doesn't get written as `.failed` (race-free with `applyDownloadProgress(.cancelled)`).
- Per-file progress aggregator advances smoothly across the multi-file manifest (no frozen UI between files).

## Pre-PR review pipeline (3 Opus subagents in parallel)

| Subagent | Findings | Status |
|---|---|---|
| `pr-review-toolkit:code-reviewer` | per-byte streaming over 2.6 GB, double-stream cancel leak, force-unwrap fallback URL | All 3 fixed ✅ |
| `pr-review-toolkit:silent-failure-hunter` | `URLError(.cancelled)` reification, AppState cancel/failed race, frozen progress between files, `EventCollector` `Task.yield()` race | All 4 fixed ✅ |
| `pr-review-toolkit:type-design-analyzer` | unenforced `total_bytes` invariant, path-traversal vector | Both fixed via decode-time validation ✅ |

Deferred (logged for follow-up): `String?` sha256 → `enum FileIntegrity` (next schema bump); drop `directory: URL` payload from `LLMDownloadState.verified` (cosmetic).

## Test plan

- [x] SwiftLint `--strict` — 0 violations on changed files
- [x] `swift build` clean (all warnings pre-existing in unrelated files)
- [x] `swift test --parallel` with CI skip flags — **316 / 316 pass** (was 312; +4 new validation tests)
- [x] Pre-commit diff-scoped pass on staged files only
- [ ] Awaiting CI on this PR (Build and Test, SwiftLint, pre-commit)
- [ ] Verify post-merge `main` CI run per AGENTS.md workflow
- [ ] Real-inference golden tests (`RUN_MLX_GOLDEN=1`, `.requiresHardware`) — skipped in CI; run nightly on remote Mac

## Watch-list / out-of-scope (follow-ups)

- **Settings UI for download progress** — observable hooks (`llmDownloadProgress`, `llmDownloadState`) are in place; the actual SettingsSection binding ships separately.
- **Pre-trigger download from Settings toggle** instead of lazy-on-first-Generate-Notes (better UX) — keep the lazy fallback regardless.
- **Path-traversal regression test on `ModelFile`** is covered by decode validation; consider a separate test on `ModelDownloader` confirming the `appendingPathComponent` call site is bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)