### PR TITLE
ci: opt into Node.js 24 + bump actions/checkout v5 → v6 (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,22 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Force every JavaScript action (including transitives we can't bump
+# directly — notably pre-commit/action@v3.0.1 which depends on
+# actions/cache@v4 internally and has no newer release) to run on
+# Node.js 24. Resolves #34's June 2026 deadline; keeps deprecation
+# warnings out of every run. Drop this opt-in once the runner default
+# becomes Node.js 24 in June 2026.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   lint:
     name: SwiftLint
     runs-on: macos-15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install SwiftLint
         run: brew install swiftlint
@@ -30,7 +39,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # Need history back to the PR base so pre-commit can diff against it
           # and only check files changed in this PR.
@@ -86,7 +95,7 @@ jobs:
     needs: [lint, pre-commit]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Select Xcode version
         # Xcode 16.4 ships Swift 6.1 (Xcode 16.2 ships 6.0.3, which fails to
@@ -267,7 +276,7 @@ jobs:
     needs: test
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Select Xcode version
         # Xcode 16.4 ships Swift 6.1 (Xcode 16.2 ships 6.0.3, which fails to


### PR DESCRIPTION
Closes #34.

## Summary
- **Workflow-level \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'\` env** — catches every JS action including transitives (notably \`pre-commit/action@v3.0.1\` which pulls \`actions/cache@v4\` internally and has no newer release).
- **\`actions/checkout@v5 → @v6\`** in all four uses — typical Node-version-only major bump.
- Resolves the Node 20 deprecation warnings annotated on every CI run since #23 landed.

## Left as-is (env var covers them — bumps deferred for safer diff testing)
- \`actions/upload-artifact@v5 → v7\` would be a 2-major jump; v6→v7 had behavior change re duplicate artifact handling.
- \`codecov/codecov-action@v5 → v6\` — codecov majors typically need config tweaks.
- \`actions/cache@v5\`, \`actions/setup-python@v6\` — already on latest major.

## Test plan
- [ ] Pre-commit + SwiftLint pass.
- [ ] Build and Test pass — the only file changed is \`.github/workflows/ci.yml\`; no \`Sources/\` or \`Tests/\` changes.
- [ ] Build Release pass.
- [ ] **Node 20 deprecation annotations no longer appear** on the Build and Test or pre-commit jobs (the success criterion for this PR).
- [ ] Verify post-merge \`main\` CI run per AGENTS.md workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)