### PR TITLE
test: per-test UserDefaults suite for GeneralSectionPersistenceTests (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,8 +163,6 @@ jobs:
       #   TextInsertionServiceTests         CGEventPost + display server
       #   VoiceTriggerMonitoringServiceTests transitively needs real mic
       #   WakeWordServiceTests              reads real WAV fixtures from models
-      #   GeneralSectionPersistenceTests    shared UserDefaults race under --parallel;
-      #                                     tracked for fix, runs pre-push serially.
       #   KeychainSecureStoreTests          real macOS Keychain — Swift Testing suite
       #                                     tagged .requiresHardware; will migrate to
       #                                     --skip-tag requiresHardware once #31 lands.
@@ -179,7 +177,6 @@ jobs:
             --skip TextInsertionServiceTests \
             --skip VoiceTriggerMonitoringServiceTests \
             --skip WakeWordServiceTests \
-            --skip GeneralSectionPersistenceTests \
             --skip KeychainSecureStoreTests 2>&1 | tee test.log
 
       # Coverage export is a *required* part of this job — the whole point is

--- a/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
+++ b/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
@@ -145,10 +145,8 @@ final class PasteBehaviorTests: XCTestCase {
 @MainActor
 final class GeneralSectionPersistenceTests: XCTestCase {
     // Justification: lifecycle-managed by setUp/tearDown — XCTest skips
-    // tearDown if setUp throws, so reads of these IUOs are always gated
+    // tearDown if setUp throws, so reads of this IUO are always gated
     // behind successful assignment.
-    var userDefaults: UserDefaults!
-    // Justification: lifecycle-managed by setUp/tearDown.
     var settingsService: SettingsService!
     // Justification: lifecycle-managed by setUp/tearDown.
     var suiteName: String!
@@ -164,21 +162,19 @@ final class GeneralSectionPersistenceTests: XCTestCase {
         )
         defaults.removePersistentDomain(forName: name)
         suiteName = name
-        userDefaults = defaults
         settingsService = SettingsService(userDefaults: defaults)
     }
 
     override func tearDown() async throws {
-        // setUp may have failed before assigning these; guard so a setUp
+        // setUp may have failed before assigning suiteName; guard so a setUp
         // crash doesn't get masked by a tearDown crash on the IUO unwrap.
         // `removePersistentDomain(forName:)` operates on the named domain
-        // regardless of receiver, so `.standard` works even if `userDefaults`
-        // never got assigned (per Apple docs).
+        // regardless of receiver, so `.standard` works without needing a
+        // separate handle to the per-test suite (per Apple docs).
         if let suiteName {
             UserDefaults.standard.removePersistentDomain(forName: suiteName)
         }
         settingsService = nil
-        userDefaults = nil
         suiteName = nil
         try await super.tearDown()
     }

--- a/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
+++ b/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
@@ -144,10 +144,13 @@ final class PasteBehaviorTests: XCTestCase {
 
 @MainActor
 final class GeneralSectionPersistenceTests: XCTestCase {
-    // IUOs assigned in setUp / cleared in tearDown; reads are gated behind
-    // setUp success — XCTest skips tearDown if setUp throws.
+    // Justification: lifecycle-managed by setUp/tearDown — XCTest skips
+    // tearDown if setUp throws, so reads of these IUOs are always gated
+    // behind successful assignment.
     var userDefaults: UserDefaults!
+    // Justification: lifecycle-managed by setUp/tearDown.
     var settingsService: SettingsService!
+    // Justification: lifecycle-managed by setUp/tearDown.
     var suiteName: String!
 
     override func setUp() async throws {
@@ -168,8 +171,11 @@ final class GeneralSectionPersistenceTests: XCTestCase {
     override func tearDown() async throws {
         // setUp may have failed before assigning these; guard so a setUp
         // crash doesn't get masked by a tearDown crash on the IUO unwrap.
+        // `removePersistentDomain(forName:)` operates on the named domain
+        // regardless of receiver, so `.standard` works even if `userDefaults`
+        // never got assigned (per Apple docs).
         if let suiteName {
-            userDefaults?.removePersistentDomain(forName: suiteName)
+            UserDefaults.standard.removePersistentDomain(forName: suiteName)
         }
         settingsService = nil
         userDefaults = nil

--- a/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
+++ b/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
@@ -144,6 +144,8 @@ final class PasteBehaviorTests: XCTestCase {
 
 @MainActor
 final class GeneralSectionPersistenceTests: XCTestCase {
+    // IUOs assigned in setUp / cleared in tearDown; reads are gated behind
+    // setUp success — XCTest skips tearDown if setUp throws.
     var userDefaults: UserDefaults!
     var settingsService: SettingsService!
     var suiteName: String!
@@ -152,14 +154,23 @@ final class GeneralSectionPersistenceTests: XCTestCase {
         try await super.setUp()
         // Per-test suite name keeps `swift test --parallel` runs from racing on
         // shared UserDefaults — see #32. Pattern mirrors SettingsServiceTests.
-        suiteName = "com.speechtotext.tests.\(UUID().uuidString)"
-        userDefaults = UserDefaults(suiteName: suiteName)!
-        userDefaults.removePersistentDomain(forName: suiteName)
-        settingsService = SettingsService(userDefaults: userDefaults)
+        let name = "com.speechtotext.tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: name),
+            "Failed to create UserDefaults suite \(name)"
+        )
+        defaults.removePersistentDomain(forName: name)
+        suiteName = name
+        userDefaults = defaults
+        settingsService = SettingsService(userDefaults: defaults)
     }
 
     override func tearDown() async throws {
-        userDefaults.removePersistentDomain(forName: suiteName)
+        // setUp may have failed before assigning these; guard so a setUp
+        // crash doesn't get masked by a tearDown crash on the IUO unwrap.
+        if let suiteName {
+            userDefaults?.removePersistentDomain(forName: suiteName)
+        }
         settingsService = nil
         userDefaults = nil
         suiteName = nil

--- a/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
+++ b/Tests/SpeechToTextTests/Views/GeneralSectionTests.swift
@@ -144,15 +144,25 @@ final class PasteBehaviorTests: XCTestCase {
 
 @MainActor
 final class GeneralSectionPersistenceTests: XCTestCase {
+    var userDefaults: UserDefaults!
     var settingsService: SettingsService!
+    var suiteName: String!
 
     override func setUp() async throws {
         try await super.setUp()
-        settingsService = SettingsService()
+        // Per-test suite name keeps `swift test --parallel` runs from racing on
+        // shared UserDefaults — see #32. Pattern mirrors SettingsServiceTests.
+        suiteName = "com.speechtotext.tests.\(UUID().uuidString)"
+        userDefaults = UserDefaults(suiteName: suiteName)!
+        userDefaults.removePersistentDomain(forName: suiteName)
+        settingsService = SettingsService(userDefaults: userDefaults)
     }
 
     override func tearDown() async throws {
+        userDefaults.removePersistentDomain(forName: suiteName)
         settingsService = nil
+        userDefaults = nil
+        suiteName = nil
         try await super.tearDown()
     }
 
@@ -168,10 +178,6 @@ final class GeneralSectionPersistenceTests: XCTestCase {
         // Then
         let reloadedSettings = settingsService.load()
         XCTAssertEqual(reloadedSettings.general.autoInsertText, !originalValue)
-
-        // Cleanup - restore original value
-        settings.general.autoInsertText = originalValue
-        try? settingsService.save(settings)
     }
 
     func test_settingsSave_persistsRecordingMode() {
@@ -187,10 +193,6 @@ final class GeneralSectionPersistenceTests: XCTestCase {
         // Then
         let reloadedSettings = settingsService.load()
         XCTAssertEqual(reloadedSettings.ui.recordingMode, newMode)
-
-        // Cleanup - restore original value
-        settings.ui.recordingMode = originalMode
-        try? settingsService.save(settings)
     }
 
     func test_settingsSave_persistsCopyToClipboard() {
@@ -205,9 +207,5 @@ final class GeneralSectionPersistenceTests: XCTestCase {
         // Then
         let reloadedSettings = settingsService.load()
         XCTAssertEqual(reloadedSettings.general.copyToClipboard, !originalValue)
-
-        // Cleanup - restore original value
-        settings.general.copyToClipboard = originalValue
-        try? settingsService.save(settings)
     }
 }


### PR DESCRIPTION
Closes #32.

## Problem

`GeneralSectionPersistenceTests` instantiated `SettingsService()` with the default `UserDefaults.standard` and read/mutated/restored shared keys. Under `swift test --parallel` the three tests interleaved on the same backing store and intermittently clobbered each other's state between save and reload — reproduces ~1-in-3 locally and surfaced on CI in F1 (#26). The class was added to the CI `--skip` list as a temporary mitigation.

## Fix

Adopt the per-test `UserDefaults(suiteName: UUID().uuidString)` pattern already used by `SettingsServiceTests`:

- `setUp` creates a unique suite, wipes it, and constructs `SettingsService(userDefaults: …)`.
- `tearDown` removes the persistent domain.
- Per-test "restore original value" cleanup blocks dropped — the suite wipe makes them redundant, and they were never load-bearing (assertion already ran on the flipped value before restore).

Removes the `--skip GeneralSectionPersistenceTests` entry (and its 2-line comment) from `.github/workflows/ci.yml`.

`SettingsService.init(userDefaults:)` already exists, so the change is test-only — no Source / production change.

## Side benefit

`AppStateTests` wipes the `settingsKey` on `UserDefaults.standard`, and `SessionStoreTests.lifecycle_doesNotTouchUserDefaults` snapshots `.standard` before/after. Previously `GeneralSectionPersistenceTests` was a latent flake source against both. Isolated suite removes that risk too.

## Verification

- ✅ 10× `swift test --parallel --filter GeneralSectionPersistenceTests` — 10/10 green (acceptance criterion).
- ✅ Full CI-shape `swift test --parallel --enable-code-coverage` with the new (smaller) `--skip` set — 317 tests / 30 suites pass.
- ✅ `swiftlint lint --strict` on the changed file — 0 violations.
- ✅ `pre-commit run --files Tests/.../GeneralSectionTests.swift .github/workflows/ci.yml` — all hooks pass.
- ✅ Pre-PR Opus `pr-review-toolkit:code-reviewer`: GO, no blockers.

## Out of scope

- `GeneralSectionTests.test_generalSection_loadsRecordingMode` also writes to `UserDefaults.standard` without restoring. It isn't in the CI skip list and isn't what #32 is filed against — separate sweep.
- `try?` in the test bodies is pre-existing style, matches the original tests.

Awaiting CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)