### PR TITLE
test(URLProtocolStub): RAII Installation handle + routed install (#30)

### DIFF
--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
@@ -180,22 +180,32 @@ extension URLProtocolStub {
         }
     }
 
+    /// Builds the multiplexed responder used by both `install(routes:)` and
+    /// `installScoped(routes:)`. Only the URL *path* is interpolated into the
+    /// no-match error message — query parameters and full host can carry PHI
+    /// (e.g. patient_id in a Cliniko URL), and `URLError.localizedDescription`
+    /// surfaces in test failure logs which CI runners may persist. The path
+    /// alone is enough to diagnose a stub typo.
+    private static func makeRoutedResponder(_ routes: [Route]) -> Responder {
+        { request in
+            for route in routes where route.matches(request) {
+                return try route.respond(request)
+            }
+            let path = request.url?.path ?? "<no path>"
+            throw URLError(
+                .unsupportedURL,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "URLProtocolStub: no Route matched \(path)"
+                ]
+            )
+        }
+    }
+
     /// Routed install: dispatches each request to the first matching `Route`.
     /// The single-closure `install(_:)` form remains available unchanged for
     /// tests that only stub one endpoint.
     static func install(routes: [Route]) -> URLSessionConfiguration {
-        install { request in
-            for route in routes where route.matches(request) {
-                return try route.respond(request)
-            }
-            let url = request.url?.absoluteString ?? "<no url>"
-            throw URLError(
-                .unsupportedURL,
-                userInfo: [
-                    NSLocalizedDescriptionKey: "URLProtocolStub: no Route matched \(url)"
-                ]
-            )
-        }
+        install(makeRoutedResponder(routes))
     }
 
     /// RAII variant of `install(_:)`. Returns an `Installation` whose `deinit`
@@ -212,19 +222,7 @@ extension URLProtocolStub {
     /// tied to the returned handle. Always assign to a `let`.
     static func installScoped(routes: [Route]) -> Installation {
         let token = UUID()
-        let routedResponder: Responder = { request in
-            for route in routes where route.matches(request) {
-                return try route.respond(request)
-            }
-            let url = request.url?.absoluteString ?? "<no url>"
-            throw URLError(
-                .unsupportedURL,
-                userInfo: [
-                    NSLocalizedDescriptionKey: "URLProtocolStub: no Route matched \(url)"
-                ]
-            )
-        }
-        let configuration = installWithToken(routedResponder, token: token)
+        let configuration = installWithToken(makeRoutedResponder(routes), token: token)
         return Installation(configuration: configuration, token: token)
     }
 }

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
@@ -141,16 +141,22 @@ extension URLProtocolStub {
         }
 
         /// Convenience for the common HTTP method + URL path case (most
-        /// Cliniko service tests). Defaults to `GET`.
+        /// Cliniko service tests). Defaults to `GET`. The method and path
+        /// are normalized once at Route construction (uppercased / leading
+        /// slash enforced) so the per-request match is a pair of plain
+        /// string equality checks — also makes a missing leading slash in
+        /// the call site (`"v1/users"` vs `"/v1/users"`) a non-issue.
         static func path(
             _ path: String,
             method: String = "GET",
             respond: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
         ) -> Route {
-            Route(
+            let normalizedMethod = method.uppercased()
+            let normalizedPath = path.hasPrefix("/") ? path : "/" + path
+            return Route(
                 matches: { request in
-                    (request.httpMethod ?? "GET").uppercased() == method.uppercased()
-                        && request.url?.path == path
+                    (request.httpMethod ?? "GET").uppercased() == normalizedMethod
+                        && request.url?.path == normalizedPath
                 },
                 respond: respond
             )

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
@@ -31,6 +31,12 @@ final class URLProtocolStub: URLProtocol, @unchecked Sendable {
 
     private static let lock = NSLock()
     nonisolated(unsafe) private static var currentResponder: Responder?
+    /// Generation token for the responder currently installed via
+    /// `installScoped(_:)` / `installScoped(routes:)`. `Installation.deinit`
+    /// clears `currentResponder` only when its captured token still matches —
+    /// stops a stale handle from clobbering a newer install. The closure-form
+    /// `install(_:)` clears the token (it has no RAII partner anyway).
+    nonisolated(unsafe) private static var currentInstallationToken: UUID?
 
     /// Install the stub as the first protocol class in a new `URLSessionConfiguration`.
     /// Callers create a `URLSession` from the returned config; every request through
@@ -39,6 +45,7 @@ final class URLProtocolStub: URLProtocol, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         currentResponder = responder
+        currentInstallationToken = nil
 
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [URLProtocolStub.self] + (config.protocolClasses ?? [])
@@ -50,6 +57,33 @@ final class URLProtocolStub: URLProtocol, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         currentResponder = nil
+        currentInstallationToken = nil
+    }
+
+    /// Internal: install with a generation token so `Installation.deinit` can
+    /// no-op if a newer install has already replaced this one.
+    fileprivate static func installWithToken(
+        _ responder: @escaping Responder,
+        token: UUID
+    ) -> URLSessionConfiguration {
+        lock.lock()
+        defer { lock.unlock() }
+        currentResponder = responder
+        currentInstallationToken = token
+
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [URLProtocolStub.self] + (config.protocolClasses ?? [])
+        return config
+    }
+
+    /// Internal: reset only if the installation token still matches. Lets a
+    /// stale `Installation.deinit` no-op when a later install has taken over.
+    fileprivate static func resetIfTokenMatches(_ token: UUID) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard currentInstallationToken == token else { return }
+        currentResponder = nil
+        currentInstallationToken = nil
     }
 
     // MARK: - URLProtocol overrides
@@ -83,5 +117,114 @@ final class URLProtocolStub: URLProtocol, @unchecked Sendable {
 
     override func stopLoading() {
         // No-op; work completes synchronously in startLoading.
+    }
+}
+
+// MARK: - Routed installation + RAII handle
+
+extension URLProtocolStub {
+    /// One leg of a routed stub. The first `Route` in the array whose
+    /// `matches` returns true serves the request. If none match,
+    /// `install(routes:)` throws a descriptive `URLError` so a typo in a
+    /// test path fails loudly instead of silently returning a
+    /// `cannotLoadFromNetwork`.
+    struct Route: Sendable {
+        let matches: @Sendable (URLRequest) -> Bool
+        let respond: @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+
+        init(
+            matches: @escaping @Sendable (URLRequest) -> Bool,
+            respond: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+        ) {
+            self.matches = matches
+            self.respond = respond
+        }
+
+        /// Convenience for the common HTTP method + URL path case (most
+        /// Cliniko service tests). Defaults to `GET`.
+        static func path(
+            _ path: String,
+            method: String = "GET",
+            respond: @escaping @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
+        ) -> Route {
+            Route(
+                matches: { request in
+                    (request.httpMethod ?? "GET").uppercased() == method.uppercased()
+                        && request.url?.path == path
+                },
+                respond: respond
+            )
+        }
+    }
+
+    /// RAII handle returned from `installScoped(_:)` / `installScoped(routes:)`.
+    /// On `deinit` the handle conditionally clears the stub — only if its
+    /// captured installation token is still current — so a stale handle that
+    /// outlives a newer install will no-op rather than nuke the active stub.
+    ///
+    /// Assign the return value to a `let`; discarding it would let ARC tear
+    /// the stub down before the test runs. `@unchecked Sendable` mirrors
+    /// `URLProtocolStub`; `deinit` may run on an arbitrary thread but only
+    /// touches lock-protected static state.
+    final class Installation: @unchecked Sendable {
+        let configuration: URLSessionConfiguration
+        private let token: UUID
+
+        fileprivate init(configuration: URLSessionConfiguration, token: UUID) {
+            self.configuration = configuration
+            self.token = token
+        }
+
+        deinit {
+            URLProtocolStub.resetIfTokenMatches(token)
+        }
+    }
+
+    /// Routed install: dispatches each request to the first matching `Route`.
+    /// The single-closure `install(_:)` form remains available unchanged for
+    /// tests that only stub one endpoint.
+    static func install(routes: [Route]) -> URLSessionConfiguration {
+        install { request in
+            for route in routes where route.matches(request) {
+                return try route.respond(request)
+            }
+            let url = request.url?.absoluteString ?? "<no url>"
+            throw URLError(
+                .unsupportedURL,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "URLProtocolStub: no Route matched \(url)"
+                ]
+            )
+        }
+    }
+
+    /// RAII variant of `install(_:)`. Returns an `Installation` whose `deinit`
+    /// calls `reset()` — drop the manual `tearDown { URLProtocolStub.reset() }`
+    /// when adopting this form. Always assign to a `let`; discarding the
+    /// return value would let ARC tear the stub down immediately.
+    static func installScoped(_ responder: @escaping Responder) -> Installation {
+        let token = UUID()
+        let configuration = installWithToken(responder, token: token)
+        return Installation(configuration: configuration, token: token)
+    }
+
+    /// RAII variant of `install(routes:)`. Same dispatch semantics, lifetime
+    /// tied to the returned handle. Always assign to a `let`.
+    static func installScoped(routes: [Route]) -> Installation {
+        let token = UUID()
+        let routedResponder: Responder = { request in
+            for route in routes where route.matches(request) {
+                return try route.respond(request)
+            }
+            let url = request.url?.absoluteString ?? "<no url>"
+            throw URLError(
+                .unsupportedURL,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "URLProtocolStub: no Route matched \(url)"
+                ]
+            )
+        }
+        let configuration = installWithToken(routedResponder, token: token)
+        return Installation(configuration: configuration, token: token)
     }
 }

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStubTests.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStubTests.swift
@@ -179,6 +179,28 @@ final class URLProtocolStubTests: XCTestCase {
 
     // MARK: - Routed install (multi-endpoint)
 
+    /// `HTTPURLResponse(url:statusCode:httpVersion:headerFields:)` returns nil
+    /// only for malformed URLs; the URLs in this file are all hardcoded
+    /// `https://...`. `try XCTUnwrap` keeps the styleguide's no-force-unwrap
+    /// rule honoured and produces a descriptive failure if a future test
+    /// passes a degenerate URL.
+    private func makeHTTPResponse(
+        url: URL,
+        statusCode: Int = 200,
+        httpVersion: String? = "HTTP/1.1",
+        headerFields: [String: String]? = nil
+    ) throws -> HTTPURLResponse {
+        try XCTUnwrap(
+            HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: httpVersion,
+                headerFields: headerFields
+            ),
+            "HTTPURLResponse init returned nil for url=\(url)"
+        )
+    }
+
     /// Exemplar for `URLProtocolStub.install(routes:)`. Two endpoints stubbed
     /// in one install call; each request is routed to the first matching
     /// `Route`. New tests that exercise more than one Cliniko endpoint at
@@ -186,27 +208,27 @@ final class URLProtocolStubTests: XCTestCase {
     /// request.url?.path { … }` inside a single closure. Uses the
     /// `Route.path(_:method:respond:)` convenience builder.
     func test_routes_dispatchToFirstMatchingEndpoint() async throws {
-        let usersMeURL = URL(string: "https://api.au1.cliniko.com/v1/users/me")!
-        let patientsURL = URL(string: "https://api.au1.cliniko.com/v1/patients?q=sample")!
+        let usersMeURL = try XCTUnwrap(URL(string: "https://api.au1.cliniko.com/v1/users/me"))
+        let patientsURL = try XCTUnwrap(URL(string: "https://api.au1.cliniko.com/v1/patients?q=sample"))
 
         let config = URLProtocolStub.install(routes: [
             .path("/v1/users/me", respond: { request in
-                let response = HTTPURLResponse(
+                let response = try XCTUnwrap(HTTPURLResponse(
                     url: request.url ?? usersMeURL,
                     statusCode: 200,
                     httpVersion: "HTTP/1.1",
                     headerFields: ["Content-Type": "application/json"]
-                )!
+                ))
                 let body = try HTTPStubFixture.load("cliniko/responses/users_me.json")
                 return (response, body)
             }),
             .path("/v1/patients", respond: { request in
-                let response = HTTPURLResponse(
+                let response = try XCTUnwrap(HTTPURLResponse(
                     url: request.url ?? patientsURL,
                     statusCode: 200,
                     httpVersion: "HTTP/1.1",
                     headerFields: ["Content-Type": "application/json"]
-                )!
+                ))
                 let body = try HTTPStubFixture.load("cliniko/responses/patients_search.json")
                 return (response, body)
             })
@@ -225,18 +247,24 @@ final class URLProtocolStubTests: XCTestCase {
         XCTAssertEqual(patientsData, expected)
     }
 
-    func test_routes_methodMismatch_doesNotMatch() async {
+    func test_routes_methodMismatch_doesNotMatch() async throws {
         // `Route.path` defaults to GET — a POST to the same path must miss.
+        let fallback = try XCTUnwrap(URL(string: "https://example.test"))
         let config = URLProtocolStub.install(routes: [
             .path("/v1/users/me", respond: { request in
-                (HTTPURLResponse(url: request.url!, statusCode: 200,
-                                 httpVersion: nil, headerFields: nil)!,
-                 Data())
+                let response = try XCTUnwrap(HTTPURLResponse(
+                    url: request.url ?? fallback,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                ))
+                return (response, Data())
             })
         ])
         let session = URLSession(configuration: config)
 
-        var post = URLRequest(url: URL(string: "https://example.test/v1/users/me")!)
+        let postURL = try XCTUnwrap(URL(string: "https://example.test/v1/users/me"))
+        var post = URLRequest(url: postURL)
         post.httpMethod = "POST"
 
         do {
@@ -251,27 +279,34 @@ final class URLProtocolStubTests: XCTestCase {
         }
     }
 
-    func test_routes_unmatchedRequest_throwsDescriptiveURLError() async {
+    func test_routes_unmatchedRequest_throwsDescriptiveURLError() async throws {
+        let fallback = try XCTUnwrap(URL(string: "https://example.test"))
         let config = URLProtocolStub.install(routes: [
             .path("/v1/users/me", respond: { request in
-                (HTTPURLResponse(url: request.url!, statusCode: 200,
-                                 httpVersion: nil, headerFields: nil)!,
-                 Data())
+                let response = try XCTUnwrap(HTTPURLResponse(
+                    url: request.url ?? fallback,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                ))
+                return (response, Data())
             })
         ])
         let session = URLSession(configuration: config)
 
+        let unmatched = try XCTUnwrap(URL(string: "https://api.au1.cliniko.com/v1/patients"))
+
         do {
-            _ = try await session.data(
-                from: URL(string: "https://api.au1.cliniko.com/v1/patients")!
-            )
+            _ = try await session.data(from: unmatched)
             XCTFail("expected unmatched route to throw")
         } catch {
             // The thrown URLError is bridged to NSError before reaching the
             // session boundary; the descriptive message lives on
             // localizedDescription. Asserting both substrings (structural
-            // marker AND the requested URL) so a regression that drops
-            // either piece is caught.
+            // marker AND the URL path) so a regression that drops either
+            // piece is caught. Note: only the path is interpolated into the
+            // error — full URLs can carry PHI in real Cliniko traffic, so
+            // the no-match message is path-only by design (#30 review).
             let nsError = error as NSError
             let message = nsError.localizedDescription
             XCTAssertTrue(
@@ -290,7 +325,8 @@ final class URLProtocolStubTests: XCTestCase {
     /// blocks do NOT guarantee ARC release at the closing brace, so the
     /// helper-function form is the reliable shape.
     func test_installScoped_resetsOnHandleDeinit() async throws {
-        let request = URLRequest(url: URL(string: "https://example.test/")!)
+        let probeURL = try XCTUnwrap(URL(string: "https://example.test/"))
+        let request = URLRequest(url: probeURL)
 
         try await runWithScopedInstallation(probeRequest: request)
 
@@ -303,23 +339,23 @@ final class URLProtocolStubTests: XCTestCase {
     }
 
     private func runWithScopedInstallation(probeRequest: URLRequest) async throws {
+        let fallback = try XCTUnwrap(URL(string: "https://example.test"))
         let installation = URLProtocolStub.installScoped { request in
-            let response = HTTPURLResponse(
-                url: request.url ?? URL(string: "https://example.test")!,
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? fallback,
                 statusCode: 200,
                 httpVersion: nil,
                 headerFields: nil
-            )!
+            ))
             return (response, Data())
         }
 
         // Stub is live while the handle is in scope.
         XCTAssertTrue(URLProtocolStub.canInit(with: probeRequest))
 
+        let dataURL = try XCTUnwrap(URL(string: "https://example.test/"))
         let session = URLSession(configuration: installation.configuration)
-        let (_, response) = try await session.data(
-            from: URL(string: "https://example.test/")!
-        )
+        let (_, response) = try await session.data(from: dataURL)
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
 
@@ -328,23 +364,22 @@ final class URLProtocolStubTests: XCTestCase {
     /// `Installation.deinit` is what makes `installScoped` safe even if a
     /// caller accidentally keeps an old handle alive past the install of the
     /// next one (e.g. captured in a Task).
-    func test_installScoped_staleHandleDeinit_doesNotClobberNewerInstall() async {
-        let probe = URLRequest(url: URL(string: "https://example.test/")!)
+    func test_installScoped_staleHandleDeinit_doesNotClobberNewerInstall() throws {
+        let probeURL = try XCTUnwrap(URL(string: "https://example.test/"))
+        let probe = URLRequest(url: probeURL)
+        let responseURL = try XCTUnwrap(URL(string: "https://example.test"))
+
+        let firstResponse = try makeHTTPResponse(url: responseURL, statusCode: 200, httpVersion: nil)
+        let secondResponse = try makeHTTPResponse(url: responseURL, statusCode: 201, httpVersion: nil)
 
         var firstHandle: URLProtocolStub.Installation? = URLProtocolStub.installScoped { _ in
-            (HTTPURLResponse(url: URL(string: "https://example.test")!,
-                             statusCode: 200,
-                             httpVersion: nil,
-                             headerFields: nil)!, Data())
+            (firstResponse, Data())
         }
         XCTAssertNotNil(firstHandle)
 
         // A second `installScoped` takes over (different token).
         let secondHandle = URLProtocolStub.installScoped { _ in
-            (HTTPURLResponse(url: URL(string: "https://example.test")!,
-                             statusCode: 201,
-                             httpVersion: nil,
-                             headerFields: nil)!, Data())
+            (secondResponse, Data())
         }
 
         // Drop the first handle — its deinit's reset is token-gated, so it

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStubTests.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStubTests.swift
@@ -176,4 +176,188 @@ final class URLProtocolStubTests: XCTestCase {
         XCTAssertEqual(a, b)
         XCTAssertNotEqual(a, c)
     }
+
+    // MARK: - Routed install (multi-endpoint)
+
+    /// Exemplar for `URLProtocolStub.install(routes:)`. Two endpoints stubbed
+    /// in one install call; each request is routed to the first matching
+    /// `Route`. New tests that exercise more than one Cliniko endpoint at
+    /// once should follow this shape rather than building a `switch
+    /// request.url?.path { … }` inside a single closure. Uses the
+    /// `Route.path(_:method:respond:)` convenience builder.
+    func test_routes_dispatchToFirstMatchingEndpoint() async throws {
+        let usersMeURL = URL(string: "https://api.au1.cliniko.com/v1/users/me")!
+        let patientsURL = URL(string: "https://api.au1.cliniko.com/v1/patients?q=sample")!
+
+        let config = URLProtocolStub.install(routes: [
+            .path("/v1/users/me", respond: { request in
+                let response = HTTPURLResponse(
+                    url: request.url ?? usersMeURL,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                let body = try HTTPStubFixture.load("cliniko/responses/users_me.json")
+                return (response, body)
+            }),
+            .path("/v1/patients", respond: { request in
+                let response = HTTPURLResponse(
+                    url: request.url ?? patientsURL,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                let body = try HTTPStubFixture.load("cliniko/responses/patients_search.json")
+                return (response, body)
+            })
+        ])
+        let session = URLSession(configuration: config)
+
+        let (usersData, _) = try await session.data(from: usersMeURL)
+        struct UserMe: Decodable { let id: Int }
+        let user = try JSONDecoder().decode(UserMe.self, from: usersData)
+        XCTAssertEqual(user.id, 12345)
+
+        let (patientsData, _) = try await session.data(from: patientsURL)
+        // Just verify the body matches the patients fixture; full decoding
+        // belongs in the patient-service tests, not the stub exemplar.
+        let expected = try HTTPStubFixture.load("cliniko/responses/patients_search.json")
+        XCTAssertEqual(patientsData, expected)
+    }
+
+    func test_routes_methodMismatch_doesNotMatch() async {
+        // `Route.path` defaults to GET — a POST to the same path must miss.
+        let config = URLProtocolStub.install(routes: [
+            .path("/v1/users/me", respond: { request in
+                (HTTPURLResponse(url: request.url!, statusCode: 200,
+                                 httpVersion: nil, headerFields: nil)!,
+                 Data())
+            })
+        ])
+        let session = URLSession(configuration: config)
+
+        var post = URLRequest(url: URL(string: "https://example.test/v1/users/me")!)
+        post.httpMethod = "POST"
+
+        do {
+            _ = try await session.data(for: post)
+            XCTFail("POST should not match a GET-only route")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertTrue(
+                nsError.localizedDescription.contains("no Route matched"),
+                "expected 'no Route matched' for method mismatch; got \(nsError.localizedDescription)"
+            )
+        }
+    }
+
+    func test_routes_unmatchedRequest_throwsDescriptiveURLError() async {
+        let config = URLProtocolStub.install(routes: [
+            .path("/v1/users/me", respond: { request in
+                (HTTPURLResponse(url: request.url!, statusCode: 200,
+                                 httpVersion: nil, headerFields: nil)!,
+                 Data())
+            })
+        ])
+        let session = URLSession(configuration: config)
+
+        do {
+            _ = try await session.data(
+                from: URL(string: "https://api.au1.cliniko.com/v1/patients")!
+            )
+            XCTFail("expected unmatched route to throw")
+        } catch {
+            // The thrown URLError is bridged to NSError before reaching the
+            // session boundary; the descriptive message lives on
+            // localizedDescription. Asserting both substrings (structural
+            // marker AND the requested URL) so a regression that drops
+            // either piece is caught.
+            let nsError = error as NSError
+            let message = nsError.localizedDescription
+            XCTAssertTrue(
+                message.contains("no Route matched") && message.contains("/v1/patients"),
+                "expected descriptive message containing 'no Route matched' and '/v1/patients'; got \(message)"
+            )
+        }
+    }
+
+    // MARK: - RAII (`installScoped`)
+
+    /// Exemplar for `URLProtocolStub.installScoped(_:)`. The returned handle's
+    /// `deinit` calls `reset()` (token-gated) when the handle goes out of
+    /// scope. We delegate to a separate async helper so the handle's lifetime
+    /// ends deterministically at the helper's return — `do { let x = … }`
+    /// blocks do NOT guarantee ARC release at the closing brace, so the
+    /// helper-function form is the reliable shape.
+    func test_installScoped_resetsOnHandleDeinit() async throws {
+        let request = URLRequest(url: URL(string: "https://example.test/")!)
+
+        try await runWithScopedInstallation(probeRequest: request)
+
+        // The helper has returned, its `installation` local has been released,
+        // deinit ran, the token-gated reset cleared the responder.
+        XCTAssertFalse(
+            URLProtocolStub.canInit(with: request),
+            "Installation deinit must call URLProtocolStub.reset()"
+        )
+    }
+
+    private func runWithScopedInstallation(probeRequest: URLRequest) async throws {
+        let installation = URLProtocolStub.installScoped { request in
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, Data())
+        }
+
+        // Stub is live while the handle is in scope.
+        XCTAssertTrue(URLProtocolStub.canInit(with: probeRequest))
+
+        let session = URLSession(configuration: installation.configuration)
+        let (_, response) = try await session.data(
+            from: URL(string: "https://example.test/")!
+        )
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+    }
+
+    /// Stale `Installation` deinit must NOT clobber a newer installation that
+    /// has already taken over the responder. The token-gating in
+    /// `Installation.deinit` is what makes `installScoped` safe even if a
+    /// caller accidentally keeps an old handle alive past the install of the
+    /// next one (e.g. captured in a Task).
+    func test_installScoped_staleHandleDeinit_doesNotClobberNewerInstall() async {
+        let probe = URLRequest(url: URL(string: "https://example.test/")!)
+
+        var firstHandle: URLProtocolStub.Installation? = URLProtocolStub.installScoped { _ in
+            (HTTPURLResponse(url: URL(string: "https://example.test")!,
+                             statusCode: 200,
+                             httpVersion: nil,
+                             headerFields: nil)!, Data())
+        }
+        XCTAssertNotNil(firstHandle)
+
+        // A second `installScoped` takes over (different token).
+        let secondHandle = URLProtocolStub.installScoped { _ in
+            (HTTPURLResponse(url: URL(string: "https://example.test")!,
+                             statusCode: 201,
+                             httpVersion: nil,
+                             headerFields: nil)!, Data())
+        }
+
+        // Drop the first handle — its deinit's reset is token-gated, so it
+        // should observe a token mismatch and no-op rather than clearing
+        // the second handle's responder.
+        firstHandle = nil
+
+        XCTAssertTrue(
+            URLProtocolStub.canInit(with: probe),
+            "Stale Installation.deinit must not reset a newer installation's responder"
+        )
+
+        // Touch the second handle so the optimizer cannot pre-deinit it.
+        _ = secondHandle.configuration
+    }
 }


### PR DESCRIPTION
Closes #30.

## What's new

Two purely-additive constructs on the test-only `URLProtocolStub` utility:

### 1. `Installation` RAII handle

`installScoped(_:) -> Installation` returns a handle whose `deinit` calls a token-gated reset. Tests that adopt this form drop the manual `tearDown { URLProtocolStub.reset() }` boilerplate.

```swift
// Before
override func tearDown() { URLProtocolStub.reset(); super.tearDown() }
let config = URLProtocolStub.install { … }
let session = URLSession(configuration: config)

// After
let installation = URLProtocolStub.installScoped { … }
let session = URLSession(configuration: installation.configuration)
// reset on deinit; no tearDown line needed
```

The token-gating in `Installation.deinit` means a stale handle that outlives a newer install no-ops rather than clobbering the active responder. This is what makes the RAII form safe even if a handle is captured into a `Task` / async let.

### 2. Routed install + `Route.path` builder

`install(routes:) -> URLSessionConfiguration` (and its scoped sibling) takes `[Route]`. Each request is dispatched to the first matching `Route`; an unmatched request throws `URLError(.unsupportedURL)` with a descriptive message so a typo in a test path fails loudly.

```swift
let config = URLProtocolStub.install(routes: [
    .path(\"/v1/users/me\", respond: { request in
        let body = try HTTPStubFixture.load(\"cliniko/responses/users_me.json\")
        return (HTTPURLResponse(url: request.url!, statusCode: 200, …)!, body)
    }),
    .path(\"/v1/patients\", respond: { request in … })
])
```

`Route.path(_:method:respond:)` defaults to `GET`. The raw `Route(matches:respond:)` initializer stays for matchers that need richer logic.

## Backward compatibility

The existing single-closure `install(_:) -> URLSessionConfiguration` is preserved unchanged. All 11 current call sites in `Tests/.../Services/Cliniko/`, `Tests/.../ViewModels/`, `Tests/.../Views/`, and `Tests/.../Services/ModelDownloaderTests.swift` continue to compile and pass without modification.

## Verification

- `swift test --filter URLProtocolStubTests` — **14/14 pass** (5 new exemplars + 9 existing).
- Full CI-shape `swift test --parallel --enable-code-coverage` with the standard skip set — 317 tests / 30 suites green.
- `swiftlint lint --strict` on both files — 0 violations.
- `pre-commit run --files …` — all hooks pass.

## Pre-PR review pipeline (per AGENTS.md)

Two Opus reviewers in parallel since new types were introduced:

**`pr-review-toolkit:code-reviewer` (GO conditional):**
1. ⚠️ Test relied on `do { let x = … }` ARC lifetime — undefined under `-O` / future toolchains.
2. ⚠️ Two live `Installation`s would let A's deinit nuke B's responder.
3. `URLError(.fileDoesNotExist)` is a misleading code for an unmatched route.
4. Test 2's `||` assertion was over-permissive.

**`pr-review-toolkit:type-design-analyzer` (needs revision):**
1. Double-install clobber (same as above).
2. `match` reads as a verb next to `respond` — predicate property should be `matches`.
3. Missing `Route.path(_:method:respond:)` convenience for the ~80% common HTTP method + path case.

**All concrete findings folded into the same commit** (no separate fixup):
- Token-based deinit safety for clobber resistance — covers both reviewers' concurrency concern.
- Helper-function form (`runWithScopedInstallation`) for the deinit test — deterministic ARC release at the helper return.
- `URLError(.unsupportedURL)` instead of `.fileDoesNotExist`.
- Test assertion tightened from `||` to `&&` so a regression that drops either the structural marker or the URL is caught.
- Renamed `Route.match` → `Route.matches`.
- Added `Route.path(_:method:respond:)` builder; raw initializer stays as the escape hatch.
- New `test_installScoped_staleHandleDeinit_doesNotClobberNewerInstall` proving the token-gate works as designed.

## Out of scope

- Migrating the 11 existing call sites to `installScoped`. They work unchanged; touching them would be churn.
- Sugar like `Route.any(respond:)` or `precondition(!routes.isEmpty)` — wait until a real test wants them.

Awaiting CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)