### PR TITLE
refactor(security): KeychainSecureStore.Failure semantic cases (#29)

### DIFF
--- a/Sources/Services/KeychainSecureStore.swift
+++ b/Sources/Services/KeychainSecureStore.swift
@@ -14,24 +14,64 @@ import Security
 /// Item values are never logged. Error-path logs include the service and key
 /// name but never the value.
 public actor KeychainSecureStore: SecureStore {
+    /// Errors thrown by `KeychainSecureStore`.
+    ///
+    /// `Equatable` is intentionally asymmetric: two `.unexpected` values
+    /// compare unequal when their `OSStatus` differs, but two
+    /// `.authDenied` (or `.notAvailable`) values compare equal *regardless*
+    /// of the originating `OSStatus`. The whole point of the semantic
+    /// cases is information loss — collapsing `errSecAuthFailed` and
+    /// `errSecUserCanceled` into one bucket the UI layer can act on. Do
+    /// not write tests that try to "pin" a specific `OSStatus` via
+    /// equality on a semantic case; assert on the case itself.
     public enum Failure: Swift.Error, CustomStringConvertible, Equatable, Sendable {
-        /// The keychain returned an unexpected OSStatus for an operation.
-        case osStatus(OSStatus, Operation)
+        /// User denied / cancelled the keychain prompt, or auth failed.
+        /// Maps `errSecInteractionNotAllowed`, `errSecAuthFailed`,
+        /// `errSecUserCanceled`. Callers can surface a "we need keychain
+        /// access" affordance without re-deriving this from a raw OSStatus.
+        case authDenied(Operation)
+        /// The keychain itself isn't available to us. Maps
+        /// `errSecNotAvailable`, `errSecMissingEntitlement`. Distinguishes
+        /// "we can't reach the keychain at all" from a transient auth deny.
+        case notAvailable(Operation)
         /// `SecItemCopyMatching` succeeded but returned a value that was not
         /// `Data`. Indicates keychain corruption or a cross-class match and
         /// MUST NOT be silently mapped to "missing".
         case unexpectedItemType(Operation)
+        /// Any other `OSStatus` we don't have a semantic mapping for. Carries
+        /// the raw status purely for diagnostics — callers should not switch
+        /// on the integer value.
+        case unexpected(OSStatus, Operation)
 
         public enum Operation: String, Sendable {
             case set, get, delete, deleteAll
         }
 
+        /// Map a raw `OSStatus` from `SecItem*` to its semantic case.
+        /// Done at throw-time so callers never need to interpret raw status
+        /// codes — they switch on the case directly. Default access (internal)
+        /// so the mapping-table tests can reach it via `@testable import`.
+        static func from(status: OSStatus, op: Operation) -> Failure {
+            switch status {
+            case errSecInteractionNotAllowed, errSecAuthFailed, errSecUserCanceled:
+                return .authDenied(op)
+            case errSecNotAvailable, errSecMissingEntitlement:
+                return .notAvailable(op)
+            default:
+                return .unexpected(status, op)
+            }
+        }
+
         public var description: String {
             switch self {
-            case let .osStatus(status, op):
-                return "KeychainSecureStore: \(op.rawValue) failed (OSStatus \(status))"
+            case let .authDenied(op):
+                return "KeychainSecureStore: \(op.rawValue) failed (auth denied / cancelled)"
+            case let .notAvailable(op):
+                return "KeychainSecureStore: \(op.rawValue) failed (keychain not available)"
             case let .unexpectedItemType(op):
                 return "KeychainSecureStore: \(op.rawValue) returned a non-Data item"
+            case let .unexpected(status, op):
+                return "KeychainSecureStore: \(op.rawValue) failed (OSStatus \(status))"
             }
         }
     }
@@ -67,7 +107,7 @@ public actor KeychainSecureStore: SecureStore {
             try addItem(key: key, data: data, query: query, retryOnDuplicate: true)
         default:
             logger.error("set failed (update) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(updateStatus)")
-            throw Failure.osStatus(updateStatus, .set)
+            throw Failure.from(status: updateStatus, op: .set)
         }
     }
 
@@ -99,11 +139,11 @@ public actor KeychainSecureStore: SecureStore {
             )
             if updateStatus != errSecSuccess {
                 logger.error("set failed (retry-update) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(updateStatus)")
-                throw Failure.osStatus(updateStatus, .set)
+                throw Failure.from(status: updateStatus, op: .set)
             }
         default:
             logger.error("set failed (add) service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(addStatus)")
-            throw Failure.osStatus(addStatus, .set)
+            throw Failure.from(status: addStatus, op: .set)
         }
     }
 
@@ -132,7 +172,7 @@ public actor KeychainSecureStore: SecureStore {
             return nil
         default:
             logger.error("get failed service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(status)")
-            throw Failure.osStatus(status, .get)
+            throw Failure.from(status: status, op: .get)
         }
     }
 
@@ -145,7 +185,7 @@ public actor KeychainSecureStore: SecureStore {
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             logger.error("delete failed service=\(self.service, privacy: .public) key=\(key, privacy: .public) status=\(status)")
-            throw Failure.osStatus(status, .delete)
+            throw Failure.from(status: status, op: .delete)
         }
     }
 
@@ -177,10 +217,17 @@ public actor KeychainSecureStore: SecureStore {
                 return
             default:
                 logger.error("deleteAll failed service=\(self.service, privacy: .public) status=\(status)")
-                throw Failure.osStatus(status, .deleteAll)
+                throw Failure.from(status: status, op: .deleteAll)
             }
         }
         logger.error("deleteAll exceeded \(maxIterations) iterations service=\(self.service, privacy: .public)")
-        throw Failure.osStatus(errSecInternalError, .deleteAll)
+        // Synthetic sentinel: no real `OSStatus` came back from Keychain
+        // here — the loop hit its defensive iteration cap. We construct
+        // `.unexpected` directly (bypassing `Failure.from(...)`) because
+        // the integer is a fiction labelling "we exhausted retries", not
+        // a Keychain return code. Indistinguishable at the type level
+        // from a genuine `errSecInternalError`; if a future caller needs
+        // to differentiate, promote this to its own case.
+        throw Failure.unexpected(errSecInternalError, .deleteAll)
     }
 }

--- a/Tests/SpeechToTextTests/Services/KeychainSecureStoreFailureMappingTests.swift
+++ b/Tests/SpeechToTextTests/Services/KeychainSecureStoreFailureMappingTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Security
+import Testing
+@testable import SpeechToText
+
+// Pure-logic tests for `KeychainSecureStore.Failure.from(status:op:)`.
+//
+// The `.requiresHardware` round-trip suite in `KeychainSecureStoreTests`
+// can't reach this mapping without fault-injecting raw `SecItem*`
+// returns. Splitting the OSStatus → semantic-case table out into a
+// pure helper made it directly testable — these run in CI under the
+// `.fast` tag and pin the contract that callers rely on (switch on
+// the case, never on the raw status integer).
+
+@Suite("KeychainSecureStore.Failure.from(status:op:)", .tags(.fast))
+struct KeychainSecureStoreFailureMappingTests {
+
+    typealias Failure = KeychainSecureStore.Failure
+    typealias Operation = KeychainSecureStore.Failure.Operation
+
+    // MARK: - authDenied family
+
+    @Test(
+        "Auth-denied / cancelled OSStatuses map to .authDenied",
+        arguments: [
+            errSecInteractionNotAllowed,
+            errSecAuthFailed,
+            errSecUserCanceled
+        ]
+    )
+    func authDeniedFamily_mapsToAuthDenied(status: OSStatus) {
+        #expect(Failure.from(status: status, op: .get) == .authDenied(.get))
+    }
+
+    // MARK: - notAvailable family
+
+    @Test(
+        "Not-available OSStatuses map to .notAvailable",
+        arguments: [
+            errSecNotAvailable,
+            errSecMissingEntitlement
+        ]
+    )
+    func notAvailableFamily_mapsToNotAvailable(status: OSStatus) {
+        #expect(Failure.from(status: status, op: .set) == .notAvailable(.set))
+    }
+
+    // MARK: - unmapped → unexpected
+
+    /// Any OSStatus the helper doesn't recognise must surface as
+    /// `unexpected`, carrying the raw status for diagnostics. The point
+    /// of the encapsulation is that callers don't need to interpret
+    /// these — but the integer is still useful in `OSLog` for support.
+    @Test(
+        "Unmapped OSStatuses fall through to .unexpected, preserving the raw status",
+        arguments: [
+            errSecItemNotFound,           // intercepted at call site, but mapping must still be defined
+            errSecDuplicateItem,          // handled inline in addItem retry path
+            errSecInternalError,          // also our synthetic deleteAll-loop sentinel
+            errSecParam,                  // programmer-error class
+            errSecDecode,                 // Keychain corruption sentinel — promote to a `.corrupted` case if a caller ever needs to distinguish it
+            OSStatus(-99999)              // arbitrary unknown
+        ]
+    )
+    func unmappedStatus_mapsToUnexpected(status: OSStatus) {
+        let mapped = Failure.from(status: status, op: .delete)
+        #expect(mapped == .unexpected(status, .delete))
+    }
+
+    // MARK: - Operation propagation
+
+    /// The helper must thread the `Operation` argument through to the
+    /// resulting case unchanged across every branch. A regression here
+    /// would make every error claim `.set` regardless of where it was
+    /// thrown from.
+    @Test(
+        "Operation propagates through every mapping branch",
+        arguments: [
+            Operation.set, .get, .delete, .deleteAll
+        ]
+    )
+    func operationIsPropagated(op: Operation) {
+        #expect(Failure.from(status: errSecAuthFailed, op: op) == .authDenied(op))
+        #expect(Failure.from(status: errSecNotAvailable, op: op) == .notAvailable(op))
+        #expect(Failure.from(status: errSecParam, op: op) == .unexpected(errSecParam, op))
+    }
+
+    // MARK: - description
+
+    /// The four cases must each emit a distinct, op-tagged description
+    /// — useful in error logs and `Error.localizedDescription`. Pinning
+    /// the strings is intentional: a future "let's tidy these up" refactor
+    /// can update the goldens deliberately rather than silently shifting
+    /// support-team-facing copy.
+    @Test("Description text for each case")
+    func descriptionForEachCase() {
+        #expect(
+            Failure.authDenied(.get).description
+                == "KeychainSecureStore: get failed (auth denied / cancelled)"
+        )
+        #expect(
+            Failure.notAvailable(.set).description
+                == "KeychainSecureStore: set failed (keychain not available)"
+        )
+        #expect(
+            Failure.unexpectedItemType(.get).description
+                == "KeychainSecureStore: get returned a non-Data item"
+        )
+        #expect(
+            Failure.unexpected(errSecParam, .delete).description
+                == "KeychainSecureStore: delete failed (OSStatus -50)"
+        )
+    }
+}

--- a/Tests/SpeechToTextTests/Services/KeychainSecureStoreTests.swift
+++ b/Tests/SpeechToTextTests/Services/KeychainSecureStoreTests.swift
@@ -29,10 +29,11 @@ import Testing
 // justified for a single error branch — the mapping is reviewed by
 // inspection at `Sources/Services/KeychainSecureStore.swift:122-129`.
 //
-// `Failure.osStatus` mapping is similarly only reachable via
-// fault-injection at the `SecItem*` layer; SecureStore-level error
-// surfacing is already covered through the `ThrowingSecureStore` stub
-// in `ClinikoCredentialStoreTests`.
+// The `OSStatus` → semantic-case mapping (`Failure.from(status:op:)`)
+// is covered as a pure-logic table in
+// `KeychainSecureStoreFailureMappingTests` (`.fast`, runs in CI).
+// SecureStore-level error surfacing is already covered through the
+// `ThrowingSecureStore` stub in `ClinikoCredentialStoreTests`.
 
 @Suite("KeychainSecureStore (real Keychain)", .tags(.requiresHardware))
 struct KeychainSecureStoreTests {
@@ -78,7 +79,8 @@ struct KeychainSecureStoreTests {
 
     /// The SecureStore contract is "missing returns `nil`, anything
     /// else throws". Pin that an unset key returns `nil` and does not
-    /// surface as a thrown `Failure.osStatus(errSecItemNotFound, .get)`.
+    /// surface as a thrown `Failure` (i.e. neither `unexpected(errSecItemNotFound, .get)`
+    /// nor any of the semantic cases).
     @Test("get returns nil for a key that has never been set")
     func get_missingKey_returnsNil() async throws {
         let store = KeychainSecureStore(service: Self.uniqueService())


### PR DESCRIPTION
## Summary

Splits `KeychainSecureStore.Failure.osStatus(OSStatus, Operation)` into four semantic cases so callers stop re-deriving meaning from raw `OSStatus` integers — exactly the type-design follow-up flagged on F3 (#22).

```swift
public enum Failure: Swift.Error, CustomStringConvertible, Equatable, Sendable {
    case authDenied(Operation)        // errSecInteractionNotAllowed / AuthFailed / UserCanceled
    case notAvailable(Operation)      // errSecNotAvailable / MissingEntitlement
    case unexpectedItemType(Operation)
    case unexpected(OSStatus, Operation)
}
```

A static `Failure.from(status:op:)` does the `OSStatus → semantic-case` mapping at throw time. Throw sites in `set` / `addItem` / `get` / `delete` / `deleteAll` all funnel through it; the synthetic `errSecInternalError` from `deleteAll`'s defensive iteration cap stays as a direct `.unexpected(...)` construction with a code comment explaining why.

## Caller-impact audit

`grep -rn 'Failure\.osStatus\|Failure\.unexpectedItemType'` → all 8 throw sites lived inside `KeychainSecureStore.swift` itself. No consumer (incl. `ClinikoCredentialStore`) switched on cases. Only an inert comment in the existing `.requiresHardware` test file references the old name; updated.

## Tests added

- `Tests/SpeechToTextTests/Services/KeychainSecureStoreFailureMappingTests.swift` — Swift Testing, `.fast`, parameterised. Pins every documented OSStatus family (`authDenied` × 3, `notAvailable` × 2, `unexpected` × 6 incl. `errSecDecode` corruption sentinel), `Operation` propagation across the three mapping branches × 4 ops, and the four `description` strings. Runs in CI — closes the gap called out in `KeychainSecureStoreTests` ("Failure.osStatus mapping is similarly only reachable via fault-injection").

The existing `KeychainSecureStoreTests` (real-keychain, `.requiresHardware`, comment-only updates) is untouched at the behavioural level.

## Test plan

- [x] `swift build` — clean (unrelated `ISO8601DateFormatter` warning in `ClinikoEndpoint.swift` is pre-existing)
- [x] `swift test --parallel --filter KeychainSecureStoreFailureMappingTests` — 5 tests / 17 cases pass in 0.001s
- [x] `swift test --parallel` (full non-hardware suite, matching CI shape) — 322 tests pass
- [x] `swiftlint lint --strict` on changed files — clean
- [x] `pre-commit run --files <changed>` — all hooks pass
- [x] Pre-PR Opus pipeline (`pr-review-toolkit:code-reviewer` + `pr-review-toolkit:type-design-analyzer` + `pr-review-toolkit:silent-failure-hunter`) — all GO; in-scope nits applied (Equatable-asymmetry doc, synthetic-deleteAll comment, `from` doc tightening, `errSecDecode` test arg)

## Documented intentional asymmetry

`Equatable` semantics: two `.unexpected` values compare unequal when their `OSStatus` differs; two `.authDenied` (or `.notAvailable`) values compare equal **regardless** of underlying `OSStatus`. The collapse is the point — the UI layer needs "auth denied" not "errSecAuthFailed vs errSecUserCanceled". Documented on the enum so a future test author doesn't try to "pin" a specific `OSStatus` via case equality.

## Out of scope — to file as follow-ups

Surfaced by reviewers; deliberately not in this PR to keep the diff aligned with #29's spec:

- **`.corrupted(Operation)` for `errSecDecode`** (silent-failure-hunter MEDIUM) — keychain payload corruption is a "user must re-enter the API key" condition deserving its own case; the current `.unexpected` bucket conflates it with programmer errors.
- **`.loopCapExceeded(.deleteAll)`** — the `deleteAll` defensive sentinel currently reuses `errSecInternalError`, which is type-indistinguishable from a real Keychain return.
- **`LocalizedError` conformance** — `description` is set, but `(failure as Error).localizedDescription` falls through to Apple's generic "operation couldn't be completed" string. Cheap UX win.

I'll open a single follow-up issue covering all three after this merges.

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)