### PR TITLE
refactor(security): KeychainSecureStore.Failure three-piece polish (#79)

### DIFF
--- a/Sources/Services/KeychainSecureStore.swift
+++ b/Sources/Services/KeychainSecureStore.swift
@@ -18,12 +18,13 @@ public actor KeychainSecureStore: SecureStore {
     ///
     /// `Equatable` is intentionally asymmetric: two `.unexpected` values
     /// compare unequal when their `OSStatus` differs, but two
-    /// `.authDenied` (or `.notAvailable`) values compare equal *regardless*
-    /// of the originating `OSStatus`. The whole point of the semantic
-    /// cases is information loss — collapsing `errSecAuthFailed` and
-    /// `errSecUserCanceled` into one bucket the UI layer can act on. Do
-    /// not write tests that try to "pin" a specific `OSStatus` via
-    /// equality on a semantic case; assert on the case itself.
+    /// `.authDenied` (or `.notAvailable`, `.corrupted`, `.loopCapExceeded`)
+    /// values compare equal *regardless* of the originating `OSStatus`.
+    /// The whole point of the semantic cases is information loss —
+    /// collapsing `errSecAuthFailed` and `errSecUserCanceled` into one
+    /// bucket the UI layer can act on. Do not write tests that try to
+    /// "pin" a specific `OSStatus` via equality on a semantic case;
+    /// assert on the case itself.
     public enum Failure: Swift.Error, CustomStringConvertible, Equatable, Sendable {
         /// User denied / cancelled the keychain prompt, or auth failed.
         /// Maps `errSecInteractionNotAllowed`, `errSecAuthFailed`,
@@ -38,6 +39,21 @@ public actor KeychainSecureStore: SecureStore {
         /// `Data`. Indicates keychain corruption or a cross-class match and
         /// MUST NOT be silently mapped to "missing".
         case unexpectedItemType(Operation)
+        /// Keychain reported the stored item exists but cannot be decoded
+        /// — `errSecDecode`. For a HIPAA-adjacent credential store this is
+        /// probable corruption of the secret payload itself, distinct from
+        /// `unexpectedItemType` (which is a class-mismatch / cross-class
+        /// retrieval). Callers can surface "your stored credentials look
+        /// corrupt; please re-enter the API key" rather than the generic
+        /// `OSStatus -26275` description.
+        case corrupted(Operation)
+        /// `deleteAll` exceeded its defensive `10_000`-iteration cap.
+        /// Distinct from `.unexpected(errSecInternalError, .deleteAll)`
+        /// — no real `OSStatus` came back from Keychain here; the loop
+        /// just wedged. The `Operation` payload is `.deleteAll` today
+        /// (the only loop-capped path) but the case keeps the door open
+        /// for future bounded-retry sites.
+        case loopCapExceeded(Operation)
         /// Any other `OSStatus` we don't have a semantic mapping for. Carries
         /// the raw status purely for diagnostics — callers should not switch
         /// on the integer value.
@@ -57,6 +73,8 @@ public actor KeychainSecureStore: SecureStore {
                 return .authDenied(op)
             case errSecNotAvailable, errSecMissingEntitlement:
                 return .notAvailable(op)
+            case errSecDecode:
+                return .corrupted(op)
             default:
                 return .unexpected(status, op)
             }
@@ -70,6 +88,13 @@ public actor KeychainSecureStore: SecureStore {
                 return "KeychainSecureStore: \(op.rawValue) failed (keychain not available)"
             case let .unexpectedItemType(op):
                 return "KeychainSecureStore: \(op.rawValue) returned a non-Data item"
+            case let .corrupted(op):
+                return "KeychainSecureStore: \(op.rawValue) failed (stored item is corrupt — re-enter credentials)"
+            case let .loopCapExceeded(op):
+                // User-facing copy via `LocalizedError`: a doctor seeing
+                // this should know what to try next. Restart-and-retry is
+                // the only sane recovery for the deleteAll-wedge state.
+                return "KeychainSecureStore: \(op.rawValue) couldn't finish — please restart the app and try again"
             case let .unexpected(status, op):
                 return "KeychainSecureStore: \(op.rawValue) failed (OSStatus \(status))"
             }
@@ -221,13 +246,31 @@ public actor KeychainSecureStore: SecureStore {
             }
         }
         logger.error("deleteAll exceeded \(maxIterations) iterations service=\(self.service, privacy: .public)")
-        // Synthetic sentinel: no real `OSStatus` came back from Keychain
-        // here — the loop hit its defensive iteration cap. We construct
-        // `.unexpected` directly (bypassing `Failure.from(...)`) because
-        // the integer is a fiction labelling "we exhausted retries", not
-        // a Keychain return code. Indistinguishable at the type level
-        // from a genuine `errSecInternalError`; if a future caller needs
-        // to differentiate, promote this to its own case.
-        throw Failure.unexpected(errSecInternalError, .deleteAll)
+        // No real `OSStatus` came back from Keychain here — the loop hit
+        // its defensive iteration cap. `Failure.loopCapExceeded` is the
+        // type-distinct sentinel for "we exhausted retries" so a caller
+        // can branch on it directly without inspecting an integer that
+        // would otherwise be indistinguishable from a genuine
+        // `errSecInternalError`. Constructed directly (not via
+        // `Failure.from`) because no `OSStatus` is in flight.
+        throw Failure.loopCapExceeded(.deleteAll)
     }
+}
+
+// MARK: - LocalizedError
+
+/// Surface the typed `description` through `Error.localizedDescription`.
+///
+/// Without this, casting a `Failure` back through the existential
+/// `any Error` (which the call site does whenever it bubbles up via
+/// `throws`) gives Apple's generic
+/// `"The operation couldn't be completed. (... error 1.)"` — losing the
+/// specific copy that told the doctor *why* their Cliniko credential
+/// store rejected the operation.
+///
+/// `errorDescription` is preferred over `failureReason` here because UI
+/// surfaces (`Alert`, `NSAlert`) read `localizedDescription`, which is
+/// itself fed by `errorDescription` for `LocalizedError` conformers.
+extension KeychainSecureStore.Failure: LocalizedError {
+    public var errorDescription: String? { description }
 }

--- a/Sources/Services/KeychainSecureStore.swift
+++ b/Sources/Services/KeychainSecureStore.swift
@@ -18,8 +18,9 @@ public actor KeychainSecureStore: SecureStore {
     ///
     /// `Equatable` is intentionally asymmetric: two `.unexpected` values
     /// compare unequal when their `OSStatus` differs, but two
-    /// `.authDenied` (or `.notAvailable`, `.corrupted`, `.loopCapExceeded`)
-    /// values compare equal *regardless* of the originating `OSStatus`.
+    /// `.authDenied` (or `.notAvailable`, `.unexpectedItemType`,
+    /// `.corrupted`, `.loopCapExceeded`) values compare equal
+    /// *regardless* of the originating `OSStatus`.
     /// The whole point of the semantic cases is information loss —
     /// collapsing `errSecAuthFailed` and `errSecUserCanceled` into one
     /// bucket the UI layer can act on. Do not write tests that try to

--- a/Tests/SpeechToTextTests/Services/KeychainSecureStoreFailureMappingTests.swift
+++ b/Tests/SpeechToTextTests/Services/KeychainSecureStoreFailureMappingTests.swift
@@ -45,20 +45,43 @@ struct KeychainSecureStoreFailureMappingTests {
         #expect(Failure.from(status: status, op: .set) == .notAvailable(.set))
     }
 
+    // MARK: - corrupted family
+
+    /// `errSecDecode` indicates the keychain item exists but cannot be
+    /// decoded — for a credential store this is probable corruption of
+    /// the secret payload. Maps to `.corrupted` so the UI can surface
+    /// "your stored credentials look corrupt; please re-enter the API
+    /// key" rather than the generic `OSStatus -26275` description.
+    @Test(
+        "Decode-failure OSStatus maps to .corrupted",
+        arguments: [
+            errSecDecode
+        ]
+    )
+    func corruptedFamily_mapsToCorrupted(status: OSStatus) {
+        #expect(Failure.from(status: status, op: .get) == .corrupted(.get))
+    }
+
     // MARK: - unmapped → unexpected
 
     /// Any OSStatus the helper doesn't recognise must surface as
     /// `unexpected`, carrying the raw status for diagnostics. The point
     /// of the encapsulation is that callers don't need to interpret
     /// these — but the integer is still useful in `OSLog` for support.
+    ///
+    /// `errSecDecode` was previously in this list — it now has its own
+    /// `.corrupted` case (see the family suite above). `errSecInternalError`
+    /// is no longer a deleteAll-cap-exceeded sentinel either: that path
+    /// throws `.loopCapExceeded(.deleteAll)` directly without going
+    /// through `Failure.from(...)`, so the mapping is back to a clean
+    /// "we genuinely got this status from Keychain" semantics.
     @Test(
         "Unmapped OSStatuses fall through to .unexpected, preserving the raw status",
         arguments: [
             errSecItemNotFound,           // intercepted at call site, but mapping must still be defined
             errSecDuplicateItem,          // handled inline in addItem retry path
-            errSecInternalError,          // also our synthetic deleteAll-loop sentinel
+            errSecInternalError,          // a real Keychain return — no longer doubles as a deleteAll-cap sentinel
             errSecParam,                  // programmer-error class
-            errSecDecode,                 // Keychain corruption sentinel — promote to a `.corrupted` case if a caller ever needs to distinguish it
             OSStatus(-99999)              // arbitrary unknown
         ]
     )
@@ -85,13 +108,28 @@ struct KeychainSecureStoreFailureMappingTests {
         #expect(Failure.from(status: errSecParam, op: op) == .unexpected(errSecParam, op))
     }
 
+    // MARK: - Operation propagation, corrupted branch
+
+    /// Same propagation contract as `operationIsPropagated` above — but
+    /// for the `.corrupted` branch, which the original test predates.
+    @Test(
+        "Operation propagates through .corrupted branch",
+        arguments: [
+            Operation.set, .get, .delete, .deleteAll
+        ]
+    )
+    func operationIsPropagated_corrupted(op: Operation) {
+        #expect(Failure.from(status: errSecDecode, op: op) == .corrupted(op))
+    }
+
     // MARK: - description
 
-    /// The four cases must each emit a distinct, op-tagged description
-    /// — useful in error logs and `Error.localizedDescription`. Pinning
-    /// the strings is intentional: a future "let's tidy these up" refactor
-    /// can update the goldens deliberately rather than silently shifting
-    /// support-team-facing copy.
+    /// Every case must emit a distinct, op-tagged description — useful
+    /// in error logs and `Error.localizedDescription` (now that
+    /// `LocalizedError` conformance routes through `description`).
+    /// Pinning the strings is intentional: a future "let's tidy these
+    /// up" refactor can update the goldens deliberately rather than
+    /// silently shifting support-team-facing copy.
     @Test("Description text for each case")
     func descriptionForEachCase() {
         #expect(
@@ -107,8 +145,71 @@ struct KeychainSecureStoreFailureMappingTests {
                 == "KeychainSecureStore: get returned a non-Data item"
         )
         #expect(
+            Failure.corrupted(.get).description
+                == "KeychainSecureStore: get failed (stored item is corrupt — re-enter credentials)"
+        )
+        #expect(
+            Failure.loopCapExceeded(.deleteAll).description
+                == "KeychainSecureStore: deleteAll couldn't finish — please restart the app and try again"
+        )
+        #expect(
             Failure.unexpected(errSecParam, .delete).description
                 == "KeychainSecureStore: delete failed (OSStatus -50)"
         )
+    }
+
+    // MARK: - loopCapExceeded is constructed at the call site, not via .from
+
+    /// `.loopCapExceeded` is the one case that bypasses
+    /// `Failure.from(status:op:)` — it's constructed directly in
+    /// `KeychainSecureStore.deleteAll()` when the 10 000-iteration cap
+    /// is hit, and no real `OSStatus` is in flight. This negative test
+    /// pins that invariant: no input to `.from(...)` should ever yield
+    /// `.loopCapExceeded`. A regression here would mean someone slipped
+    /// an `OSStatus → .loopCapExceeded` mapping into the helper, which
+    /// would muddy the case's "we wedged" semantics with a Keychain
+    /// status that has its own meaning.
+    @Test(
+        "Failure.from never produces .loopCapExceeded",
+        arguments: [
+            errSecSuccess,
+            errSecItemNotFound,
+            errSecDuplicateItem,
+            errSecInternalError,                     // the integer the synthetic sentinel previously borrowed
+            errSecAuthFailed,
+            errSecNotAvailable,
+            errSecDecode,
+            errSecParam,
+            OSStatus(-99999)
+        ]
+    )
+    func loopCapExceededIsNeverProducedByFrom(status: OSStatus) {
+        for op: Operation in [.set, .get, .delete, .deleteAll] {
+            let mapped = Failure.from(status: status, op: op)
+            #expect(
+                mapped != .loopCapExceeded(op),
+                ".from(status: \(status), op: \(op)) must not produce .loopCapExceeded"
+            )
+        }
+    }
+
+    // MARK: - LocalizedError
+
+    /// `LocalizedError` conformance routes `errorDescription` through
+    /// `description`. Without this, casting a `Failure` back to the
+    /// existential `any Error` (which `throws` propagation does) loses
+    /// the typed copy and SwiftUI / AppKit alert UIs surface Apple's
+    /// generic "The operation couldn't be completed. (... error 1.)"
+    /// fallback. One representative case is enough — the conformance
+    /// is a single-line passthrough.
+    @Test("LocalizedError.errorDescription matches description")
+    func localizedErrorDescriptionMatchesDescription() {
+        let failure = Failure.corrupted(.get)
+        #expect(failure.errorDescription == failure.description)
+        // Belt-and-braces: also check the existential cast that real
+        // call sites take. `localizedDescription` is the property that
+        // `Alert(error:)` / `NSAlert` actually read.
+        let asError: any Error = failure
+        #expect(asError.localizedDescription == failure.description)
     }
 }


### PR DESCRIPTION
Closes #79. Bundles three quality follow-ups from #29 / PR #78's three-reviewer Opus pipeline. All three live on the same enum, all three ship as one PR per the issue body's reasoning.

## Summary

- **`.corrupted(Operation)`** — `errSecDecode` now routes through `.corrupted(op)` instead of falling through to `.unexpected(errSecDecode, op)`. For a HIPAA-adjacent credential store, `errSecDecode` means *probable corruption of the secret payload*. UI can render a "re-enter credentials" affordance.
- **`.loopCapExceeded(Operation)`** — replaces the synthetic `Failure.unexpected(errSecInternalError, .deleteAll)` thrown when `deleteAll`'s 10 000-iteration cap is hit. Constructed directly at the cap site (no `OSStatus` is in flight). User-facing copy reads "couldn't finish — please restart the app and try again" via `LocalizedError`.
- **`LocalizedError`** conformance — `errorDescription` returns `description`, so `(failure as Error).localizedDescription` surfaces the typed copy in `Alert(error:)` / `NSAlert` instead of Apple's generic fallback.

## Tests

9 Swift Testing cases under `.fast`:
- Parametrised `errSecDecode → .corrupted` mapping
- Op-propagation across the new `.corrupted` branch
- Description goldens for both new cases
- `LocalizedError` direct + existential-cast assertion
- **Negative test:** `Failure.from(...)` never produces `.loopCapExceeded` (locks the "constructed at the call site only" invariant)

`KeychainSecureStoreTests` (the `.requiresHardware` round-trip suite) untouched.

## Pre-PR Opus pipeline

Three reviewers aligned on **ship-it**:

- **`pr-review-toolkit:code-reviewer`** — no blockers, no important. Nit: equatable-asymmetry doc didn't mention the new cases. Folded in.
- **`pr-review-toolkit:silent-failure-hunter`** — both prior MEDIUM/LOW silent-failure findings (#78 review) closed. No new ones. No caller breakage (exhaustive-switch grep clean — only `AuditStore.Failure` catches a same-named type, not this one). PHI scan clean (no `service`/`key`/value interpolated). Nit: "exceeded its iteration cap" was jargon-y for a doctor reading an `Alert`. Softened to restart-and-retry copy.
- **`pr-review-toolkit:type-design-analyzer`** — 5/5 encapsulation, 5/5 invariant expression, 4/5 usefulness, 4/5 enforcement. Recommendation: add a negative test that `.from(...)` never produces `.loopCapExceeded`. Folded in. (Other recommendations declined: dropping `Operation` from `.loopCapExceeded` conflicts with the issue body's "keeps the door open for future bounded-retry sites"; softening `.unexpected` errorDescription is a separate UX-polish follow-up.)

## Validation

- [x] `swift test --filter KeychainSecureStoreFailureMappingTests` — 9/9 green
- [x] `swift test --parallel` (full CI-shaped command) — 325 tests green; no caller broken
- [x] `swiftlint lint --strict` clean on both files
- [x] `pre-commit run --files <changed>` clean
- [ ] CI (auto)
- [ ] Gemini Code Assist (auto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)