### PR TITLE
feat(clinical-notes): "Start Clinical Note" menu-bar item (#92)

### DIFF
--- a/.claude/references/menubar-integration.md
+++ b/.claude/references/menubar-integration.md
@@ -77,21 +77,29 @@ KeyboardShortcuts.onKeyDown(for: .startRecording) { [weak self] in
   automatically; the settings UI uses `KeyboardShortcuts.Recorder`.
 
 For Clinical Notes Mode the `#11` toggle is paired with a **second**
-dedicated hotkey, `clinicalNotesRecord` (#91). The default
+dedicated hotkey, `clinicalNotesRecord` (#91), and a sibling
+**menu-bar item** "Start Clinical Note" (#92). The default
 `holdToRecord` / `toggleRecording` chord stays untouched: pure STT,
-glass overlay, text insertion. The clinical chord opens
-`LiquidGlassRecordingModal` directly (auto-starts recording on present
-via the modal's existing `.task(id:)`), so the Generate Notes / Done
-buttons surface automatically when the mode is on.
+glass overlay, text insertion. Both clinical surfaces post the same
+`.showRecordingModal` notification, which AppDelegate's existing
+observer handles by presenting `LiquidGlassRecordingModal`
+(auto-starts recording on present via the modal's `.task(id:)`).
 
 The clinical chord is **unbound by default** to avoid OS / browser /
-IDE conflicts on install. It is gated by the toggle and Cliniko
-credential presence: when either gate flips off,
-`KeyboardShortcuts.disable(.clinicalNotesRecord)` runs so a stale
-binding never fires. The Settings → Clinical Notes section's
-"Recording shortcut" row uses `ShortcutRecorderView`'s `validate:`
-closure to reject any chord already bound to `.holdToRecord` or
-`.toggleRecording`.
+IDE conflicts on install; the menu-bar item provides a tap-target
+for discoverability and for hands-off-keyboard moments. Both are
+gated by the toggle and Cliniko credential presence: when either
+gate flips off,
+`KeyboardShortcuts.disable(.clinicalNotesRecord)` runs (chord side)
+and `MenuBarViewModel.canStartClinicalNote` returns false (menu
+side), so neither surface fires when prerequisites are missing. The
+Settings → Clinical Notes "Recording shortcut" row uses
+`ShortcutRecorderView`'s `validate:` closure to reject any chord
+already bound to `.holdToRecord` or `.toggleRecording`.
+
+`MenuBarViewModel.refreshState()` is called from `MenuBarView`'s
+`.task` on each menu open, so toggle / credential changes made
+elsewhere in the session are picked up without an app restart.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,15 +253,20 @@ on-device, session-only PHI, opt-in via Settings.
    wires the dependencies — see `Sources/SpeechToTextApp/AppState.swift`).
    Once on + Cliniko credentials present, Settings → Clinical Notes
    exposes a **dedicated "Recording shortcut"** row (`#91`) bound to
-   `KeyboardShortcuts.Name.clinicalNotesRecord` (unbound by default).
-   The default `holdToRecord` / `toggleRecording` chord stays pure STT
-   for general dictation; the new chord is the only production trigger
-   for the clinical pipeline — both gates flip the shortcut off so a
-   stale binding never fires.
+   `KeyboardShortcuts.Name.clinicalNotesRecord` (unbound by default),
+   and the menu bar grows a **"Start Clinical Note"** item (`#92`) as
+   the discoverability sibling. The default
+   `holdToRecord` / `toggleRecording` chord stays pure STT for general
+   dictation; the new chord and menu item are the only production
+   triggers for the clinical pipeline — both gates flip the shortcut
+   off (`KeyboardShortcuts.disable(.clinicalNotesRecord)`) and hide
+   the menu item (`MenuBarViewModel.canStartClinicalNote` returns
+   false) so neither surface fires when prerequisites are missing.
 2. **Recording** runs unchanged (FluidAudio → `RecordingSession`).
    General dictation uses the existing chord. Clinical sessions use
-   `clinicalNotesRecord` → `LiquidGlassRecordingModal` (auto-starts
-   recording on present via the modal's existing `.task(id:)`).
+   `clinicalNotesRecord` or the "Start Clinical Note" menu item →
+   `LiquidGlassRecordingModal` (auto-starts recording on present via
+   the modal's existing `.task(id:)`).
 3. **Generate Notes** action on the recording modal hands the transcript to
    `SessionStore` → `ClinicalNotesProcessor` → `LLMProvider`
    (`MLXGemmaProvider` / `MockLLMProvider`). Retry-once on schema-invalid

--- a/Sources/Views/MenuBarView.swift
+++ b/Sources/Views/MenuBarView.swift
@@ -9,7 +9,14 @@ import SwiftUI
 /// Ultra-minimal menu bar dropdown
 struct MenuBarView: View {
     @Environment(AppState.self) private var appState
-    @State private var viewModel = MenuBarViewModel()
+    @State private var viewModel: MenuBarViewModel
+
+    /// Production callers use the parameterless default; tests inject a VM
+    /// pre-seeded with a custom `SettingsService` / `ClinikoCredentialStore`
+    /// to exercise the gate states for the "Start Clinical Note" item (#92).
+    init(viewModel: MenuBarViewModel? = nil) {
+        self._viewModel = State(initialValue: viewModel ?? MenuBarViewModel())
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -45,6 +52,33 @@ struct MenuBarView: View {
 
             Divider()
 
+            // Start Clinical Note (#92)
+            // Visible only when Clinical Notes Mode is on AND Cliniko
+            // credentials are present. Hidden in all other states (no
+            // greyed-out entries) — the doctor either has the feature or
+            // doesn't. Tap posts the same `.showRecordingModal` notification
+            // the dedicated hotkey (#91) uses, so the existing AppDelegate
+            // observer presents `LiquidGlassRecordingModal`.
+            if viewModel.canStartClinicalNote {
+                Button {
+                    viewModel.startClinicalNote()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "stethoscope")
+                            .foregroundStyle(Color("AmberPrimary", bundle: nil))
+                        Text("Start Clinical Note")
+                        Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("menuBarStartClinicalNote")
+
+                Divider()
+            }
+
             // Quit
             Button {
                 viewModel.quit()
@@ -70,6 +104,12 @@ struct MenuBarView: View {
             .keyboardShortcut("q", modifiers: .command)
         }
         .frame(width: 220)
+        .task {
+            // Re-read settings + credential presence on each menu open so the
+            // "Start Clinical Note" gate reflects changes made elsewhere in
+            // the session without requiring an app restart (#92).
+            await viewModel.refreshState()
+        }
     }
 }
 

--- a/Sources/Views/MenuBarViewModel.swift
+++ b/Sources/Views/MenuBarViewModel.swift
@@ -18,16 +18,47 @@ final class MenuBarViewModel {
     /// Whether microphone permission is granted
     var hasPermission: Bool = false
 
+    /// Whether Clinical Notes Mode is currently enabled in Settings (#92).
+    /// Combined with `hasStoredCredentials` to gate the "Start Clinical Note"
+    /// menu item — both must be true.
+    private(set) var clinicalNotesModeEnabled: Bool = false
+
+    /// Mirrors `ClinicalNotesSectionViewModel.CredentialLoadState` semantics so
+    /// a transient Keychain read failure doesn't silently flip the gate to
+    /// "absent". `.readFailed` is treated as "credentials may exist" for
+    /// gating, matching the Settings UI.
+    enum CredentialLoadState: Equatable {
+        case unknown
+        case present
+        case absent
+        case readFailed
+    }
+
+    /// What `hasAPIKey()` last reported. Updated by `refreshState()`.
+    private(set) var credentialState: CredentialLoadState = .unknown
+
     // MARK: - Dependencies
 
     @ObservationIgnored private let permissionService: PermissionService
+    @ObservationIgnored private let settingsService: SettingsService
+    @ObservationIgnored private let credentialStore: ClinikoCredentialStore
 
     // MARK: - Initialization
 
-    init(permissionService: PermissionService = PermissionService()) {
+    init(
+        permissionService: PermissionService = PermissionService(),
+        settingsService: SettingsService = SettingsService(),
+        credentialStore: ClinikoCredentialStore = ClinikoCredentialStore()
+    ) {
         self.permissionService = permissionService
+        self.settingsService = settingsService
+        self.credentialStore = credentialStore
 
-        // Check permission status on init
+        // Check microphone permission on init so the status icon is correct on
+        // first paint. The clinical-notes gate (`refreshState()`) is left to
+        // `MenuBarView`'s `.task` modifier so the same state-hydration path is
+        // used on every menu open and there's no race between this init Task
+        // and an explicit `refreshState()` call from a test or caller.
         Task { [weak self] in
             await self?.refreshPermission()
         }
@@ -51,6 +82,24 @@ final class MenuBarViewModel {
         return isRecording ? .red : Color("AmberPrimary", bundle: nil)
     }
 
+    // MARK: - Computed Gates
+
+    /// Whether the Cliniko credential store currently reports a key. Mirrors
+    /// `ClinicalNotesSectionViewModel.hasStoredCredentials`: returns true on
+    /// `.readFailed` so a transient Keychain failure doesn't silently disable
+    /// the gate (the user can still recover via Settings).
+    var hasStoredCredentials: Bool {
+        credentialState == .present || credentialState == .readFailed
+    }
+
+    /// Gate for the "Start Clinical Note" menu item (#92). Both Clinical Notes
+    /// Mode AND Cliniko credentials must be present — same rule as the
+    /// hotkey row in Settings (#91), and the menu item posts the same
+    /// `.showRecordingModal` notification the hotkey does.
+    var canStartClinicalNote: Bool {
+        clinicalNotesModeEnabled && hasStoredCredentials
+    }
+
     // MARK: - Actions
 
     /// Open the main application view
@@ -58,9 +107,38 @@ final class MenuBarViewModel {
         NotificationCenter.default.post(name: .showMainView, object: nil)
     }
 
+    /// Trigger the clinical-notes recording modal (#92). Posts the same
+    /// `.showRecordingModal` notification the dedicated hotkey (#91) uses, so
+    /// the existing AppDelegate observer presents `LiquidGlassRecordingModal`
+    /// (which auto-starts recording on present via its `.task(id:)`).
+    func startClinicalNote() {
+        NotificationCenter.default.post(name: .showRecordingModal, object: nil)
+    }
+
     /// Quit the application
     func quit() {
         NSApplication.shared.terminate(nil)
+    }
+
+    // MARK: - Refresh
+
+    /// Re-read settings + Cliniko credential presence to update
+    /// `clinicalNotesModeEnabled` and `credentialState`. Called from the view's
+    /// `.task` on each appearance so changes made elsewhere (Settings →
+    /// toggle, credential save/remove) are reflected next time the menu opens.
+    func refreshState() async {
+        clinicalNotesModeEnabled = settingsService.load().general.clinicalNotesModeEnabled
+        do {
+            let present = try await credentialStore.hasAPIKey()
+            credentialState = present ? .present : .absent
+        } catch {
+            // Treat read failure as "may exist" so the gate stays consistent
+            // with the Settings UI; user can recover by re-entering the key.
+            credentialState = .readFailed
+            AppLogger.app.warning(
+                "MenuBarViewModel: credential read failed (\(String(describing: type(of: error)), privacy: .public))"
+            )
+        }
     }
 
     // MARK: - Private Methods

--- a/Tests/SpeechToTextTests/Views/MenuBarViewModelTests.swift
+++ b/Tests/SpeechToTextTests/Views/MenuBarViewModelTests.swift
@@ -108,4 +108,105 @@ final class MenuBarViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(notificationReceived)
     }
+
+    // MARK: - #92 Clinical Notes gate
+
+    /// Builds a VM with isolated SettingsService + ClinikoCredentialStore so
+    /// each test starts from a clean gate.
+    private func makeIsolatedViewModel() -> MenuBarViewModel {
+        let suiteName = "MenuBarViewModelTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("UserDefaults(suiteName:) returned nil")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        let settingsService = SettingsService(userDefaults: defaults)
+        let credentialStore = ClinikoCredentialStore(
+            secureStore: InMemorySecureStore(),
+            userDefaults: defaults
+        )
+        return MenuBarViewModel(
+            permissionService: PermissionService(),
+            settingsService: settingsService,
+            credentialStore: credentialStore
+        )
+    }
+
+    func test_canStartClinicalNote_falseWhenModeOffAndCredsAbsent() async {
+        let vm = makeIsolatedViewModel()
+        await vm.refreshState()
+        XCTAssertFalse(vm.clinicalNotesModeEnabled)
+        XCTAssertFalse(vm.hasStoredCredentials)
+        XCTAssertFalse(vm.canStartClinicalNote)
+    }
+
+    func test_canStartClinicalNote_falseWhenCredsPresentButModeOff() async throws {
+        let suiteName = "MenuBarViewModelTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("UserDefaults(suiteName:) returned nil")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        let settingsService = SettingsService(userDefaults: defaults)
+        let credentialStore = ClinikoCredentialStore(
+            secureStore: InMemorySecureStore(),
+            userDefaults: defaults
+        )
+        try await credentialStore.saveCredentials(apiKey: "MS-test-au1", shard: .au1)
+
+        let vm = MenuBarViewModel(
+            permissionService: PermissionService(),
+            settingsService: settingsService,
+            credentialStore: credentialStore
+        )
+        await vm.refreshState()
+
+        XCTAssertTrue(vm.hasStoredCredentials)
+        XCTAssertFalse(vm.clinicalNotesModeEnabled)
+        XCTAssertFalse(vm.canStartClinicalNote, "Mode-off should hide the menu item even with creds")
+    }
+
+    func test_canStartClinicalNote_trueWhenModeOnAndCredsPresent() async throws {
+        let suiteName = "MenuBarViewModelTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("UserDefaults(suiteName:) returned nil")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        let settingsService = SettingsService(userDefaults: defaults)
+        let credentialStore = ClinikoCredentialStore(
+            secureStore: InMemorySecureStore(),
+            userDefaults: defaults
+        )
+        try await credentialStore.saveCredentials(apiKey: "MS-test-au1", shard: .au1)
+        var settings = settingsService.load()
+        settings.general.applyClinicalNotesMode(true)
+        try settingsService.save(settings)
+
+        let vm = MenuBarViewModel(
+            permissionService: PermissionService(),
+            settingsService: settingsService,
+            credentialStore: credentialStore
+        )
+        await vm.refreshState()
+
+        XCTAssertTrue(vm.clinicalNotesModeEnabled)
+        XCTAssertTrue(vm.hasStoredCredentials)
+        XCTAssertTrue(vm.canStartClinicalNote)
+    }
+
+    func test_startClinicalNote_postsShowRecordingModalNotification() {
+        // Given
+        var notificationReceived = false
+        notificationObserver = NotificationCenter.default.addObserver(
+            forName: .showRecordingModal,
+            object: nil,
+            queue: .main
+        ) { _ in
+            notificationReceived = true
+        }
+
+        // When
+        sut.startClinicalNote()
+
+        // Then
+        XCTAssertTrue(notificationReceived)
+    }
 }

--- a/Tests/SpeechToTextTests/Views/MenuBarViewRenderTests.swift
+++ b/Tests/SpeechToTextTests/Views/MenuBarViewRenderTests.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+import XCTest
+@testable import SpeechToText
+
+/// Render-crash tests for `MenuBarView` (#92). The production menu bar is
+/// presented via `MenuBarExtra(.window)`; these tests assert the view + its
+/// `@Observable @MainActor` view model can be constructed without crashing
+/// under each Clinical-Notes gate state. Body traversal via ViewInspector is
+/// intentionally avoided: `MenuBarView` reads `AppState` via
+/// `@Environment(AppState.self)`, and ViewInspector's `find()` triggers
+/// SwiftUI body evaluation outside a real host hierarchy where the
+/// `@Observable` environment lookup traps. The visibility gate is exercised
+/// at the view-model layer in `MenuBarViewModelTests` (`canStartClinicalNote`
+/// under each combination of mode toggle + credential presence).
+@MainActor
+final class MenuBarViewRenderTests: XCTestCase {
+
+    private func makeUserDefaults() -> UserDefaults {
+        let suiteName = "MenuBarViewRenderTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("UserDefaults(suiteName:) returned nil")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    private func makeViewModel(
+        modeEnabled: Bool,
+        seedCredentials: Bool
+    ) async throws -> MenuBarViewModel {
+        let defaults = makeUserDefaults()
+        let settingsService = SettingsService(userDefaults: defaults)
+        let credentialStore = ClinikoCredentialStore(
+            secureStore: InMemorySecureStore(),
+            userDefaults: defaults
+        )
+        if seedCredentials {
+            try await credentialStore.saveCredentials(apiKey: "MS-test-au1", shard: .au1)
+        }
+        if modeEnabled {
+            var settings = settingsService.load()
+            settings.general.applyClinicalNotesMode(true)
+            try settingsService.save(settings)
+        }
+        let vm = MenuBarViewModel(
+            permissionService: PermissionService(),
+            settingsService: settingsService,
+            credentialStore: credentialStore
+        )
+        await vm.refreshState()
+        return vm
+    }
+
+    func test_menuBarView_instantiatesWithoutCrash_modeOffNoCreds() async throws {
+        let vm = try await makeViewModel(modeEnabled: false, seedCredentials: false)
+        // Construction itself is the assertion: `MenuBarView.init` runs the
+        // SwiftUI `@State` wrapping for the injected VM. If the VM's
+        // `@Observable` macro + actor existential layout is broken, this
+        // traps before we ever read the view back.
+        _ = MenuBarView(viewModel: vm)
+        XCTAssertFalse(vm.canStartClinicalNote, "Gate must be closed in default state")
+    }
+
+    func test_menuBarView_instantiatesWithoutCrash_credsOnlyModeOff() async throws {
+        let vm = try await makeViewModel(modeEnabled: false, seedCredentials: true)
+        // Construction itself is the assertion: `MenuBarView.init` runs the
+        // SwiftUI `@State` wrapping for the injected VM. If the VM's
+        // `@Observable` macro + actor existential layout is broken, this
+        // traps before we ever read the view back.
+        _ = MenuBarView(viewModel: vm)
+        XCTAssertFalse(vm.canStartClinicalNote, "Mode-off must close the gate even with creds")
+    }
+
+    func test_menuBarView_instantiatesWithoutCrash_modeOnNoCreds() async throws {
+        let vm = try await makeViewModel(modeEnabled: true, seedCredentials: false)
+        // Construction itself is the assertion: `MenuBarView.init` runs the
+        // SwiftUI `@State` wrapping for the injected VM. If the VM's
+        // `@Observable` macro + actor existential layout is broken, this
+        // traps before we ever read the view back.
+        _ = MenuBarView(viewModel: vm)
+        XCTAssertFalse(vm.canStartClinicalNote, "Creds-absent must close the gate even with mode on")
+    }
+
+    func test_menuBarView_instantiatesWithoutCrash_bothGatesOpen() async throws {
+        let vm = try await makeViewModel(modeEnabled: true, seedCredentials: true)
+        // Construction itself is the assertion: `MenuBarView.init` runs the
+        // SwiftUI `@State` wrapping for the injected VM. If the VM's
+        // `@Observable` macro + actor existential layout is broken, this
+        // traps before we ever read the view back.
+        _ = MenuBarView(viewModel: vm)
+        XCTAssertTrue(vm.canStartClinicalNote, "Gate must be open with mode on + creds present")
+    }
+}


### PR DESCRIPTION
Closes #92.

## Summary

Sibling to #91/#93 (just merged): the dedicated hotkey gets a discoverability fallback in the menu bar. New "Start Clinical Note" item appears between "Open Speech to Text" and "Quit", visible only when Clinical Notes Mode is on AND Cliniko credentials are present (mirrors the hotkey row's gating). Tap → posts the same `.showRecordingModal` notification → AppDelegate presents `LiquidGlassRecordingModal` → recording auto-starts via the modal's existing `.task(id:)` → existing Generate Notes / Done / Review / Patient picker / Cliniko export pipeline runs.

## What changed

- **`Sources/Views/MenuBarViewModel.swift`** — extended with `SettingsService` + `ClinikoCredentialStore` deps (default-init in production, injectable for tests). New observable state: `clinicalNotesModeEnabled`, `credentialState: CredentialLoadState` (enum mirroring `ClinicalNotesSectionViewModel`). New computed `hasStoredCredentials` + `canStartClinicalNote`. New `refreshState() async` (Keychain throw → `.readFailed`, treated as "may exist" to match Settings UI recovery semantics) and `startClinicalNote()` (posts `.showRecordingModal`).
- **`Sources/Views/MenuBarView.swift`** — added optional `viewModel:` init param so tests can pre-seed state. Slotted the new gated `Button` between the existing `Divider()` and the Quit button. Both the button and its trailing divider live inside `if viewModel.canStartClinicalNote { … }` so no greyed-out residue when the gate is closed. Added `.task { await viewModel.refreshState() }` on the root VStack so the gate re-evaluates on each menu open (MenuBarExtra(.window) re-mounts).
- **No init-time `refreshState()` call** — runs solely from the view's `.task` so there's no race between launch-time hydration and explicit refresh calls from tests or future callers.

## Tests

- 4 new `MenuBarViewModelTests`: gate state under each (mode, creds) combination + `startClinicalNote()` posts `.showRecordingModal`.
- 4 new `MenuBarViewRenderTests`: construction-doesn't-trap under each gate state.
- ⚠️ Render tests intentionally **don't** use ViewInspector body traversal: `MenuBarView` reads `AppState` via `@Environment(AppState.self)`, and ViewInspector's `find()` traps on the missing Observable lookup outside a real host hierarchy. The visibility gate is exercised at the VM layer; the view's conditional is a one-line `if viewModel.canStartClinicalNote`. Test-infra follow-up filed as **#95** (a `withTestAppState` helper or similar) for when this pattern recurs.

`swift test --parallel` (CI shape, skipping the documented hardware-dependent classes) → **all green**, 15/15 in the MenuBar suites. `pre-commit run --files <touched>` clean.

## Pre-PR review

Pre-PR `pr-review-toolkit:code-reviewer` (opus) flagged one Important issue (init/explicit-refresh race) — folded in by removing `refreshState()` from the init Task. PHI logging compliance confirmed (error type names only, `privacy: .public` for structural state only, no key body, no patient data).

## Related

- **#91 / #93** — dedicated `clinicalNotesRecord` hotkey (merged into main as `0573591`). This PR rides on top.
- **#95** — test-infra follow-up: ViewInspector helper for `@Environment(Observable)` views. Filed during this PR's review.
- **#94** — pre-existing `ModelDownloaderTests` flake (unrelated; non-blocking).

## Test plan

- [ ] Local `swift test --parallel` (CI skip-list applied) green.
- [ ] CI green on PR.
- [ ] Manual smoke: enable Clinical Notes Mode + add Cliniko creds → menu item appears. Tap it → modal opens with recording active. Toggle off → menu item disappears. Remove creds → menu item disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)