### PR TITLE
fix(ui): NSWindow.isReleasedWhenClosed = false on all four windows (#106 / #102)

### DIFF
--- a/.claude/references/concurrency.md
+++ b/.claude/references/concurrency.md
@@ -211,6 +211,44 @@ reference pattern.
 
 ---
 
+## 8. `NSWindow.isReleasedWhenClosed` (over-release UAF)
+
+**Issue #106 / #102.** Every `NSWindow()` you create in Swift code must
+set `isReleasedWhenClosed = false` immediately after construction. The
+AppKit default is `true` — when `close()` runs, AppKit autoreleases the
+window. If you also hold a strong Swift reference and any close path
+runs more than once (a re-entrant notification observer; SwiftUI's
+`.onDisappear` after `dismiss()`; `applicationWillTerminate` cleanup),
+the second `release` lands on a freed `NSKVONotifying_NSWindow`. The
+crash signature is `EXC_BAD_ACCESS` on `objc_autoreleasePoolPop` from
+`NSApplication.run`'s outer pool drain — sometimes minutes after the
+actual over-release, with no symbolicated frames pointing back at the
+caller because the offender is long off-stack.
+
+```swift
+// WRONG — default `isReleasedWhenClosed = true` + Swift strong ref
+let window = NSWindow(...)
+self.recordingWindow = window
+// Two close paths converging here = zombie release on the second.
+
+// CORRECT — Swift ARC owns the lifetime, close() is idempotent
+let window = NSWindow(...)
+window.isReleasedWhenClosed = false
+self.recordingWindow = window
+```
+
+This applies to `NSWindow` subclasses too (`ClickThroughWindow` in
+`Sources/Views/GlassOverlay/`). Set `isReleasedWhenClosed = false` on
+the instance — not via subclass override — so the behaviour is visible
+at the call site.
+
+The render-crash test recipe (§7) catches `@Observable`+actor crashes
+but NOT this one. NSZombies (`NSZombieEnabled=YES` env var, launch the
+binary directly, not via `open`) is the diagnostic — the
+`*** -[NSKVONotifying_NSWindow release]:` line names the offender.
+
+---
+
 ## Checklist: adding an actor-backed service
 
 - [ ] Conform to an `Actor`-constrained protocol (not the concrete type).
@@ -222,6 +260,18 @@ reference pattern.
 - [ ] Run `swift test --parallel` plus a local smoke test on real hardware
       before merging — `@Observable`+actor crashes don't always reproduce
       in unit tests.
+
+## Checklist: introducing a new NSWindow
+
+- [ ] Set `newWindow.isReleasedWhenClosed = false` immediately after
+      construction (rule §8). All four existing windows do this — match.
+- [ ] Hold the strong reference on a single owner (a window-controller
+      class, not also on AppDelegate).
+- [ ] If the window has a delegate that posts a "did-close" notification
+      observed by the controller, make sure the close handler's second
+      pass is a verified no-op (`window?.close()` is fine if
+      `isReleasedWhenClosed = false` is set, since it becomes
+      `orderOut:`).
 
 ---
 

--- a/.claude/references/mlx-lifecycle.md
+++ b/.claude/references/mlx-lifecycle.md
@@ -115,33 +115,16 @@ retry on schema failure.
   try to hop threads manually.
 - Stored on an `@Observable` class (e.g. `AppState`): requires
   `@ObservationIgnored`, per [`concurrency.md`](concurrency.md) rule 1.
-- **Autorelease-pool defence around MLX boundaries (issue #106 — under
-  verification, not a confirmed root-cause repair).**
-  Pre-fix, M1 Pro / mlx-swift-lm 3.31.3 / Gemma 4 E4B reproduces an
-  `EXC_BAD_ACCESS` on `objc_autoreleasePoolPop` after warmup completes
-  (no MLX/Metal frames on the faulting thread — only `NSApplication.run`'s
-  outer pool drain). The hypothesis is that a Metal/Obj-C bridge
-  temporary from `LLMModelFactory.shared.loadContainer(…)` outlives the
-  resume frame and is double-released. The defensive countermeasure is
-  to wrap any **synchronous post-resume code** that follows an MLX
-  `await` in `autoreleasepool { … }`, on either side of the actor hop,
-  so Obj-C bridge temporaries drain on the resume thread rather than
-  riding the continuation. **Mechanical scope is narrow:**
-  `autoreleasepool` is sync-only, so temporaries autoreleased **during**
-  the `await` itself can't be wrapped from outside. The wrap with the
-  strongest mechanical justification is the **per-chunk drain inside
-  `MLXGemmaProvider.runGeneration`**'s for-await loop, where chunk
-  processing is fully synchronous. Apply at three sites today:
-  `MLXGemmaProvider.warmup()` (post-resume state mutation + log
-  formatting), `MLXGemmaProvider.runGeneration()` (per-chunk drain
-  inside the for-await loop), and `AppState.runClinicalNotesPipeline()`
-  (post-warmup `@MainActor` state transition). When wrapping a for-await
-  loop, hoist `break`/`continue` to a flag set inside the closure and
-  consumed after; keep `try Task.checkCancellation()` *outside* the
-  closure (autoreleasepool is non-throwing).
-  **If a future crash report shows the same signature with these wraps
-  in place, escalate to NSZombies + Address Sanitizer — don't trust
-  this comment.**
+- **Per-chunk autorelease drain in `runGeneration`.** Long async
+  streams plus Obj-C bridge work accumulate temporaries on the actor's
+  executor between suspension points. The canonical Cocoa pattern is
+  to wrap each iteration body in `autoreleasepool { … }` so per-chunk
+  bridge temporaries (mlx-swift-lm chunk decoding, OSLog formatting,
+  the `yield` continuation) drain independently. When wrapping a
+  for-await loop, hoist `break` / `continue` to a flag set inside the
+  closure and consumed after, and keep `try Task.checkCancellation()`
+  *outside* the closure (autoreleasepool is non-throwing — cancellation
+  must propagate as a thrown `CancellationError`).
 
 ---
 

--- a/.claude/references/mlx-lifecycle.md
+++ b/.claude/references/mlx-lifecycle.md
@@ -115,6 +115,33 @@ retry on schema failure.
   try to hop threads manually.
 - Stored on an `@Observable` class (e.g. `AppState`): requires
   `@ObservationIgnored`, per [`concurrency.md`](concurrency.md) rule 1.
+- **Autorelease-pool defence around MLX boundaries (issue #106 — under
+  verification, not a confirmed root-cause repair).**
+  Pre-fix, M1 Pro / mlx-swift-lm 3.31.3 / Gemma 4 E4B reproduces an
+  `EXC_BAD_ACCESS` on `objc_autoreleasePoolPop` after warmup completes
+  (no MLX/Metal frames on the faulting thread — only `NSApplication.run`'s
+  outer pool drain). The hypothesis is that a Metal/Obj-C bridge
+  temporary from `LLMModelFactory.shared.loadContainer(…)` outlives the
+  resume frame and is double-released. The defensive countermeasure is
+  to wrap any **synchronous post-resume code** that follows an MLX
+  `await` in `autoreleasepool { … }`, on either side of the actor hop,
+  so Obj-C bridge temporaries drain on the resume thread rather than
+  riding the continuation. **Mechanical scope is narrow:**
+  `autoreleasepool` is sync-only, so temporaries autoreleased **during**
+  the `await` itself can't be wrapped from outside. The wrap with the
+  strongest mechanical justification is the **per-chunk drain inside
+  `MLXGemmaProvider.runGeneration`**'s for-await loop, where chunk
+  processing is fully synchronous. Apply at three sites today:
+  `MLXGemmaProvider.warmup()` (post-resume state mutation + log
+  formatting), `MLXGemmaProvider.runGeneration()` (per-chunk drain
+  inside the for-await loop), and `AppState.runClinicalNotesPipeline()`
+  (post-warmup `@MainActor` state transition). When wrapping a for-await
+  loop, hoist `break`/`continue` to a flag set inside the closure and
+  consumed after; keep `try Task.checkCancellation()` *outside* the
+  closure (autoreleasepool is non-throwing).
+  **If a future crash report shows the same signature with these wraps
+  in place, escalate to NSZombies + Address Sanitizer — don't trust
+  this comment.**
 
 ---
 

--- a/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
+++ b/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
@@ -81,23 +81,55 @@ public actor MLXGemmaProvider: LLMProvider {
     /// call is a no-op once `container` is set. Wired from the Clinical
     /// Notes Mode toggle in `AppState` so the practitioner pays the
     /// load cost up-front rather than on the first "Generate Notes" tap.
+    ///
+    /// **#106 — autorelease-pool defence (under verification).**
+    /// Hypothesis: `LLMModelFactory.shared.loadContainer` brings a
+    /// Metal/Obj-C bridge into the picture (command buffers, textures,
+    /// `MTLBuffer`s). On M1 Pro / macOS 26 with `mlx-swift-lm` 3.31.3 +
+    /// Gemma 4 E4B, the app crashes with `EXC_BAD_ACCESS` on
+    /// `objc_autoreleasePoolPop` after `warmup()` completes (no MLX or
+    /// Metal frames on the faulting thread — only `NSApplication.run`'s
+    /// outer pool drain). The wrap below is **defensive**, not a
+    /// confirmed root-cause repair: it forces a synchronous pool drain
+    /// over the post-resume tail (state mutation + log formatting,
+    /// which itself does Obj-C bridging). The mechanical lever is
+    /// limited — `autoreleasepool` is sync-only, so we can't wrap
+    /// `try await loadContainer(...)` itself. The stronger lever is the
+    /// per-chunk wrap inside `runGeneration` below. If a crash report
+    /// with this wrap in place still shows the same signature,
+    /// **escalate to NSZombies / Address Sanitizer** rather than
+    /// trusting this comment — see the recommended-next-steps section
+    /// of issue #106.
+    /// (`AppState.runClinicalNotesPipeline` carries the matching
+    /// post-resume `autoreleasepool` on the @MainActor side.) The "starting"
+    /// signpost is intentional — if a future regression is *not* fixed by
+    /// this wrap, the next crash report shows whether we got past
+    /// `loadContainer` or died inside it.
     public func warmup() async throws {
         if container != nil { return }
         let started = ContinuousClock.now
+        logger.info("MLX warmup starting")
         do {
             let loaded = try await LLMModelFactory.shared.loadContainer(
                 from: modelDirectory,
                 using: tokenizerLoader
             )
-            container = loaded
-            let elapsed = ContinuousClock.now - started
-            // Log millisecond-precision so sub-second warmups (the
-            // common warm-cache case) don't truncate to "0s".
-            let ms = (elapsed.components.seconds * 1_000)
-                + Int64(elapsed.components.attoseconds / 1_000_000_000_000_000)
-            logger.info(
-                "MLX warmup completed in \(ms, privacy: .public)ms"
-            )
+            // Wrap the entire post-resume synchronous tail (state mutation
+            // + the OSLog interpolation, which goes through `os_log_create`
+            // and brings Obj-C in) so anything autoreleased on this
+            // executor's thread between resume and return drains here
+            // rather than riding the @MainActor continuation.
+            autoreleasepool {
+                container = loaded
+                let elapsed = ContinuousClock.now - started
+                // Log millisecond-precision so sub-second warmups (the
+                // common warm-cache case) don't truncate to "0s".
+                let ms = (elapsed.components.seconds * 1_000)
+                    + Int64(elapsed.components.attoseconds / 1_000_000_000_000_000)
+                logger.info(
+                    "MLX warmup completed in \(ms, privacy: .public)ms"
+                )
+            }
         } catch {
             let kind = String(describing: type(of: error))
             logger.error("MLX warmup failed kind=\(kind, privacy: .public)")
@@ -184,31 +216,56 @@ public actor MLXGemmaProvider: LLMProvider {
             parameters: parameters
         )
 
+        // #106 — per-chunk autorelease drain. This is the wrap with the
+        // strongest mechanical justification of the three sites: chunk
+        // processing is fully synchronous, so any Obj-C bridge temporaries
+        // produced inside the closure (string slicing, `mlx-swift-lm`
+        // chunk decoding, OSLog formatting) are released to the pool we
+        // create here and drained at every iteration boundary — they
+        // can't accumulate across the run.
+        //
+        // Closure-body conventions:
+        //   - `try Task.checkCancellation()` lives **outside** the
+        //     `autoreleasepool` because Swift's `autoreleasepool` is
+        //     non-throwing; cancellation must propagate as a thrown
+        //     `CancellationError`, not be swallowed by the closure.
+        //   - The closure body is intentionally non-throwing — `yield`
+        //     and the string operations don't throw — so we can use the
+        //     non-`try` form and avoid wrapping a throwing closure that
+        //     would change error semantics.
+        //   - `break` is hoisted to the `shouldBreak` flag so the
+        //     post-stop-match emit ordering (yield prefix → break)
+        //     survives the closure boundary.
         var pendingTail = ""
+        var shouldBreak = false
         for await item in stream {
             try Task.checkCancellation()
-            guard case let .chunk(text) = item else { continue }
-            if stops.isEmpty {
-                yield(text)
-                continue
-            }
-            pendingTail += text
-            if let stopRange = Self.firstStopRange(in: pendingTail, stops: stops) {
-                let prefix = String(pendingTail[..<stopRange.lowerBound])
-                if !prefix.isEmpty {
-                    yield(prefix)
+            autoreleasepool {
+                guard case let .chunk(text) = item else { return }
+                if stops.isEmpty {
+                    yield(text)
+                    return
                 }
-                break
+                pendingTail += text
+                if let stopRange = Self.firstStopRange(in: pendingTail, stops: stops) {
+                    let prefix = String(pendingTail[..<stopRange.lowerBound])
+                    if !prefix.isEmpty {
+                        yield(prefix)
+                    }
+                    shouldBreak = true
+                    return
+                }
+                let safeBoundary = Self.safeFlushBoundary(
+                    in: pendingTail,
+                    stops: stops
+                )
+                if safeBoundary > pendingTail.startIndex {
+                    let flushable = String(pendingTail[..<safeBoundary])
+                    yield(flushable)
+                    pendingTail = String(pendingTail[safeBoundary...])
+                }
             }
-            let safeBoundary = Self.safeFlushBoundary(
-                in: pendingTail,
-                stops: stops
-            )
-            if safeBoundary > pendingTail.startIndex {
-                let flushable = String(pendingTail[..<safeBoundary])
-                yield(flushable)
-                pendingTail = String(pendingTail[safeBoundary...])
-            }
+            if shouldBreak { break }
         }
     }
 

--- a/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
+++ b/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
@@ -82,29 +82,10 @@ public actor MLXGemmaProvider: LLMProvider {
     /// Notes Mode toggle in `AppState` so the practitioner pays the
     /// load cost up-front rather than on the first "Generate Notes" tap.
     ///
-    /// **#106 — autorelease-pool defence (under verification).**
-    /// Hypothesis: `LLMModelFactory.shared.loadContainer` brings a
-    /// Metal/Obj-C bridge into the picture (command buffers, textures,
-    /// `MTLBuffer`s). On M1 Pro / macOS 26 with `mlx-swift-lm` 3.31.3 +
-    /// Gemma 4 E4B, the app crashes with `EXC_BAD_ACCESS` on
-    /// `objc_autoreleasePoolPop` after `warmup()` completes (no MLX or
-    /// Metal frames on the faulting thread — only `NSApplication.run`'s
-    /// outer pool drain). The wrap below is **defensive**, not a
-    /// confirmed root-cause repair: it forces a synchronous pool drain
-    /// over the post-resume tail (state mutation + log formatting,
-    /// which itself does Obj-C bridging). The mechanical lever is
-    /// limited — `autoreleasepool` is sync-only, so we can't wrap
-    /// `try await loadContainer(...)` itself. The stronger lever is the
-    /// per-chunk wrap inside `runGeneration` below. If a crash report
-    /// with this wrap in place still shows the same signature,
-    /// **escalate to NSZombies / Address Sanitizer** rather than
-    /// trusting this comment — see the recommended-next-steps section
-    /// of issue #106.
-    /// (`AppState.runClinicalNotesPipeline` carries the matching
-    /// post-resume `autoreleasepool` on the @MainActor side.) The "starting"
-    /// signpost is intentional — if a future regression is *not* fixed by
-    /// this wrap, the next crash report shows whether we got past
-    /// `loadContainer` or died inside it.
+    /// The "starting" / "completed" OSLog signposts are diagnostic
+    /// instrumentation introduced for #106: when the next MLX-related
+    /// crash report lands, the surrounding signposts localise whether
+    /// we crashed pre- or post-load. Cheap to leave in.
     public func warmup() async throws {
         if container != nil { return }
         let started = ContinuousClock.now
@@ -114,22 +95,15 @@ public actor MLXGemmaProvider: LLMProvider {
                 from: modelDirectory,
                 using: tokenizerLoader
             )
-            // Wrap the entire post-resume synchronous tail (state mutation
-            // + the OSLog interpolation, which goes through `os_log_create`
-            // and brings Obj-C in) so anything autoreleased on this
-            // executor's thread between resume and return drains here
-            // rather than riding the @MainActor continuation.
-            autoreleasepool {
-                container = loaded
-                let elapsed = ContinuousClock.now - started
-                // Log millisecond-precision so sub-second warmups (the
-                // common warm-cache case) don't truncate to "0s".
-                let ms = (elapsed.components.seconds * 1_000)
-                    + Int64(elapsed.components.attoseconds / 1_000_000_000_000_000)
-                logger.info(
-                    "MLX warmup completed in \(ms, privacy: .public)ms"
-                )
-            }
+            container = loaded
+            let elapsed = ContinuousClock.now - started
+            // Log millisecond-precision so sub-second warmups (the
+            // common warm-cache case) don't truncate to "0s".
+            let ms = (elapsed.components.seconds * 1_000)
+                + Int64(elapsed.components.attoseconds / 1_000_000_000_000_000)
+            logger.info(
+                "MLX warmup completed in \(ms, privacy: .public)ms"
+            )
         } catch {
             let kind = String(describing: type(of: error))
             logger.error("MLX warmup failed kind=\(kind, privacy: .public)")
@@ -216,23 +190,23 @@ public actor MLXGemmaProvider: LLMProvider {
             parameters: parameters
         )
 
-        // #106 — per-chunk autorelease drain. This is the wrap with the
-        // strongest mechanical justification of the three sites: chunk
-        // processing is fully synchronous, so any Obj-C bridge temporaries
-        // produced inside the closure (string slicing, `mlx-swift-lm`
-        // chunk decoding, OSLog formatting) are released to the pool we
-        // create here and drained at every iteration boundary — they
-        // can't accumulate across the run.
+        // Per-chunk autorelease drain. Long async streams + Obj-C bridge
+        // work (mlx-swift-lm chunk decoding, OSLog formatting, the
+        // `yield` continuation) accumulate temporaries on the actor's
+        // executor between suspension points. The canonical Cocoa
+        // pattern for any long sync loop containing bridged work is to
+        // wrap the body in `autoreleasepool` so each iteration drains
+        // independently — see `NSAutoreleasePool` "long-running loop"
+        // guidance.
         //
         // Closure-body conventions:
-        //   - `try Task.checkCancellation()` lives **outside** the
+        //   - `try Task.checkCancellation()` stays **outside** the
         //     `autoreleasepool` because Swift's `autoreleasepool` is
         //     non-throwing; cancellation must propagate as a thrown
         //     `CancellationError`, not be swallowed by the closure.
         //   - The closure body is intentionally non-throwing — `yield`
-        //     and the string operations don't throw — so we can use the
-        //     non-`try` form and avoid wrapping a throwing closure that
-        //     would change error semantics.
+        //     and the string operations don't throw — so we use the
+        //     non-`try` form.
         //   - `break` is hoisted to the `shouldBreak` flag so the
         //     post-stop-match emit ordering (yield prefix → break)
         //     survives the closure boundary.

--- a/Sources/Services/HotkeyManager.swift
+++ b/Sources/Services/HotkeyManager.swift
@@ -242,6 +242,24 @@ class HotkeyManager {
         await onClinicalNotesRecordingStart?()
     }
 
+    /// Notify HotkeyManager that the clinical-notes modal has closed so the
+    /// chord state flag stays in sync with reality. Called from the modal's
+    /// `.onDisappear` in `AppDelegate`. Required because the modal can close
+    /// for reasons that don't go through the chord-stop callback — most
+    /// commonly the in-modal **Done** button (which transcribes via the same
+    /// `viewModel.stopRecording()` path the chord uses, but bypasses
+    /// `handleClinicalNotesKeyPress`). Without this call, the next chord
+    /// press sees a stale `isRecordingClinicalNotes == true`, takes the
+    /// "stop" branch, fires a no-op stop callback (no active modal), and
+    /// the user perceives the chord as broken until they press it again.
+    /// Idempotent — safe to call from any close path.
+    func clinicalNotesSessionEnded() {
+        if isRecordingClinicalNotes {
+            isRecordingClinicalNotes = false
+            AppLogger.app.debug("HotkeyManager: clinicalNotesSessionEnded - state reset")
+        }
+    }
+
     // MARK: - Key Event Handlers (internal for testability)
 
     /// Handle key down event - starts recording if not already processing and not in cooldown

--- a/Sources/SpeechToTextApp/AppDelegate.swift
+++ b/Sources/SpeechToTextApp/AppDelegate.swift
@@ -1015,6 +1015,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 AppLogger.app.debug("showRecordingModal: LiquidGlassRecordingModal disappeared")
                 self?.recordingWindow?.close()
                 self?.recordingWindow = nil
+                // Reset the clinical-notes chord state so the next chord
+                // press starts a fresh session. Without this, Done in the
+                // modal closes the window but leaves
+                // `HotkeyManager.isRecordingClinicalNotes == true`, and
+                // the next chord press is wasted on the "stop" branch
+                // (no active modal → no-op). Idempotent — also fires for
+                // chord-initiated stop and Cancel paths.
+                self?.hotkeyManager?.clinicalNotesSessionEnded()
                 // weak `activeRecordingViewModel` auto-nils once the SwiftUI host releases the strong ref
             }
 

--- a/Sources/SpeechToTextApp/AppDelegate.swift
+++ b/Sources/SpeechToTextApp/AppDelegate.swift
@@ -1033,6 +1033,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             defer: false
         )
 
+        // #106 — disable AppKit's auto-release-on-close. This is the
+        // load-bearing mitigation for the EXC_BAD_ACCESS surfaced by
+        // NSZombies as `*** -[NSKVONotifying_NSWindow release]:` on the
+        // outer runloop pool drain. The recording modal has three close
+        // paths converging on the same NSWindow: SwiftUI's
+        // `dismissAction()`, the SwiftUI `.onDisappear` below
+        // (`self?.recordingWindow?.close()`), and `applicationWillTerminate`
+        // line 229. With the default `isReleasedWhenClosed = true`, the
+        // first close autoreleases the window; the second close on a
+        // freed object is the zombie. With `false`, the strong
+        // `recordingWindow` property is the sole ARC owner and `nil`
+        // assignment cleanly drops the last reference.
+        window.isReleasedWhenClosed = false
+
         window.contentView = NSHostingView(rootView: contentView)
         window.isOpaque = false
         window.backgroundColor = .clear

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -356,7 +356,19 @@ class AppState {
             }
             llmDownloadState = .verified(directory: modelDir)
             try await provider.warmup()
-            llmDownloadState = .ready
+            // #106 — main-thread side of the autorelease defence
+            // (under verification, not a confirmed root-cause repair).
+            // The warmup resume crosses MLXGemmaProvider's actor →
+            // @MainActor here. The wrap drains any Obj-C bridge
+            // temporaries autoreleased synchronously between resume and
+            // the next await, so they don't accumulate on
+            // `NSApplication.run`'s outer runloop pool (the site of the
+            // observed EXC_BAD_ACCESS). Mechanically narrow — won't
+            // catch temporaries autoreleased *during* the await — but
+            // free + paired with `MLXGemmaProvider.warmup`'s wrap.
+            autoreleasepool {
+                llmDownloadState = .ready
+            }
         } catch is CancellationError {
             // User-initiated cancel is a clean state transition, not a
             // failure. Don't overwrite to `.failed` — `applyDownloadProgress`

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -356,19 +356,7 @@ class AppState {
             }
             llmDownloadState = .verified(directory: modelDir)
             try await provider.warmup()
-            // #106 — main-thread side of the autorelease defence
-            // (under verification, not a confirmed root-cause repair).
-            // The warmup resume crosses MLXGemmaProvider's actor →
-            // @MainActor here. The wrap drains any Obj-C bridge
-            // temporaries autoreleased synchronously between resume and
-            // the next await, so they don't accumulate on
-            // `NSApplication.run`'s outer runloop pool (the site of the
-            // observed EXC_BAD_ACCESS). Mechanically narrow — won't
-            // catch temporaries autoreleased *during* the await — but
-            // free + paired with `MLXGemmaProvider.warmup`'s wrap.
-            autoreleasepool {
-                llmDownloadState = .ready
-            }
+            llmDownloadState = .ready
         } catch is CancellationError {
             // User-initiated cancel is a clean state transition, not a
             // failure. Don't overwrite to `.failed` — `applyDownloadProgress`

--- a/Sources/Views/ClinicalNotes/ReviewWindow.swift
+++ b/Sources/Views/ClinicalNotes/ReviewWindow.swift
@@ -99,6 +99,20 @@ final class ReviewWindow: NSObject, NSWindowDelegate {
             defer: false
         )
 
+        // #106 / #102 — disable AppKit's auto-release-on-close. Cancel
+        // posts `.reviewScreenDidDismiss`, the controller observer hops
+        // to MainActor and calls `window?.close()`, which fires
+        // `windowWillClose` here, which posts `.reviewScreenDidDismiss`
+        // a second time. The two MainActor Tasks queued from those two
+        // posts can both observe `controller.window` non-nil and both
+        // call `close()`. With the default `isReleasedWhenClosed = true`
+        // that's an over-release; with `false`, lifetime is purely Swift
+        // ARC and `close()` is just `orderOut:` — re-entry becomes safe.
+        // (#102's "Cancel terminates the entire app" symptom is the same
+        // over-release stomping `NSApplication`'s state on the next
+        // runloop pool drain.)
+        newWindow.isReleasedWhenClosed = false
+
         newWindow.delegate = self
         newWindow.title = Self.windowTitle
         newWindow.identifier = NSUserInterfaceItemIdentifier("reviewWindow")

--- a/Sources/Views/Components/ShortcutRecorderView.swift
+++ b/Sources/Views/Components/ShortcutRecorderView.swift
@@ -141,6 +141,17 @@ struct ShortcutRecorderView: View {
         isRecording = true
         validationError = nil // clear any prior rejection so the user sees the new attempt's outcome
 
+        // Suspend the bound Carbon hotkey while recording. Without this,
+        // pressing the currently-bound chord (or anything that overlaps
+        // with another bound shortcut) fires the Carbon hotkey **before**
+        // the local NSEvent monitor below sees the keystroke — the user
+        // would either see the bound action fire or hear the system
+        // "bonk" with no recorder feedback. `KeyboardShortcuts.Recorder`
+        // (the library's own recorder) does this internally; our custom
+        // SPM-safe replacement has to do it explicitly. Re-enabled in
+        // `stopRecording()` and defensively in `.onDisappear`.
+        KeyboardShortcuts.disable(shortcutName)
+
         // Start monitoring key events
         keyEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown, .flagsChanged]) { [self] event in
             if event.type == .keyDown {
@@ -179,6 +190,14 @@ struct ShortcutRecorderView: View {
             NSEvent.removeMonitor(monitor)
             mouseEventMonitor = nil
         }
+        // Re-bind the Carbon hotkey to whatever's now stored. If the
+        // recorder didn't actually persist a new chord (Esc / outside
+        // click / validator rejection), `enable` re-activates the
+        // previous binding. If it did persist, `enable` activates the
+        // new one. Either way, the chord is live again after the
+        // recorder closes — paired with the `disable` in
+        // `startRecording()`.
+        KeyboardShortcuts.enable(shortcutName)
     }
 
     private func handleKeyDown(_ event: NSEvent) {

--- a/Sources/Views/GlassOverlay/GlassOverlayWindow.swift
+++ b/Sources/Views/GlassOverlay/GlassOverlayWindow.swift
@@ -133,6 +133,17 @@ final class GlassOverlayWindow {
             defer: false
         )
 
+        // #106 — disable AppKit's auto-release-on-close. Same family as
+        // the recording-modal / Review / Main fixes: with the AppKit
+        // default `true`, `close()` autoreleases in addition to whatever
+        // Swift ARC does, and any second close (or strong-ref-drop racing
+        // the autorelease pool drain) hits the zombie. The overlay
+        // window is reused across show/hide via `orderOut:`, but
+        // `closeOverlay()` still calls `close()` and the singleton
+        // controller can be torn down on app termination — keep
+        // lifetime under Swift ARC alone.
+        window.isReleasedWhenClosed = false
+
         configureWindow(window)
         positionWindow(window)
 

--- a/Sources/Views/MainView/MainWindow.swift
+++ b/Sources/Views/MainView/MainWindow.swift
@@ -82,6 +82,16 @@ final class MainWindow: NSObject, NSWindowDelegate {
             defer: false
         )
 
+        // #106 / #102 — disable AppKit's auto-release-on-close. With the
+        // default `true`, `close()` autoreleases the NSWindow in addition
+        // to whatever Swift ARC does via our strong `window` property.
+        // Any second `close()` (from a re-entrant notification observer,
+        // SwiftUI `.onDisappear`, or termination cleanup) then sends
+        // `release` to a deallocated `NSKVONotifying_NSWindow` — the
+        // exact zombie NSZombies caught for #106. Setting `false` puts
+        // lifetime entirely under Swift ARC and makes `close()` idempotent.
+        newWindow.isReleasedWhenClosed = false
+
         // Configure window
         configureWindow(newWindow)
 

--- a/Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift
+++ b/Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift
@@ -90,6 +90,46 @@ struct MLXGemmaProviderUnitTests {
         // maxStopLen=0 → keepBack=0 → boundary at endIndex (full flush OK).
         #expect(boundary == text.endIndex)
     }
+
+    /// **#106 — warmup error mapping (shape, not specific error type).**
+    /// Verifies that `warmup()` catches *any* underlying error from
+    /// `LLMModelFactory.shared.loadContainer` and re-raises it as
+    /// `ProviderError.modelLoadFailed(kind:)` with a non-empty kind
+    /// string. The kind string carries only the type name — never
+    /// `localizedDescription` — so PHI in upstream error chains can't
+    /// leak. The test asserts the **mapping shape**: empty-dir input is
+    /// just a convenient way to provoke any throw from `loadContainer`
+    /// (it might be `URLError`, `POSIXError`, an `LLMError` variant,
+    /// etc. — we don't care which).
+    ///
+    /// Stays in the default CI path because no real model load happens —
+    /// `loadContainer` fails fast on an empty directory.
+    @Test("warmup re-raises load failure as ProviderError.modelLoadFailed")
+    func warmupMapsLoadFailure() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mlx-gemma-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempDir,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let provider = MLXGemmaProvider(modelDirectory: tempDir)
+
+        do {
+            try await provider.warmup()
+            Issue.record("warmup() should have thrown on missing weights")
+            return
+        } catch let error as MLXGemmaProvider.ProviderError {
+            guard case .modelLoadFailed(let kind) = error else {
+                Issue.record("expected .modelLoadFailed, got \(error)")
+                return
+            }
+            #expect(!kind.isEmpty, "kind must carry the upstream error type name")
+        } catch {
+            Issue.record("expected ProviderError.modelLoadFailed, got \(type(of: error))")
+        }
+    }
 }
 
 /// Real-inference tests against a downloaded `MLXGemmaProvider`.

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -877,13 +877,27 @@ elif [ -f "${PROJECT_ROOT}/app_logov2.png" ]; then
     print_success "Copied app logo to Resources"
 fi
 
-# Copy SPM resource bundle (contains Models for voice trigger, etc.)
-SPM_BUNDLE="${PROJECT_ROOT}/.build/${BUILD_CONFIG}/SpeechToText_SpeechToText.bundle"
-if [ -d "${SPM_BUNDLE}" ]; then
-    cp -R "${SPM_BUNDLE}" "${APP_BUNDLE}/Contents/Resources/"
-    print_success "Copied SPM resource bundle (voice trigger models)"
-else
-    print_warning "SPM resource bundle not found at ${SPM_BUNDLE}"
+# Copy ALL SPM resource bundles from xcodebuild's Products dir.
+# Issue #108 — previously only `SpeechToText_SpeechToText.bundle` was
+# copied, which left `mlx-swift_Cmlx.bundle` (the carrier for
+# `default.metallib`) out of the .app. Cmlx then hard-fails at startup
+# with `Failed to load the default metallib`, blocking #106 repro on
+# any clean build. Other transitive package bundles (KeyboardShortcuts,
+# swift-crypto, swift-transformers Hub) are likely also load-bearing
+# for some feature and were silently missing too.
+PRODUCTS_DIR="${DERIVED_DATA}/Build/Products/${XCODE_CONFIG}"
+COPIED_BUNDLE_COUNT=0
+shopt -s nullglob
+for BUNDLE in "${PRODUCTS_DIR}"/*.bundle; do
+    BUNDLE_NAME="$(basename "${BUNDLE}")"
+    cp -R "${BUNDLE}" "${APP_BUNDLE}/Contents/Resources/"
+    print_success "Copied resource bundle: ${BUNDLE_NAME}"
+    COPIED_BUNDLE_COUNT=$((COPIED_BUNDLE_COUNT + 1))
+done
+shopt -u nullglob
+
+if [ "${COPIED_BUNDLE_COUNT}" -eq 0 ]; then
+    print_warning "No resource bundles found at ${PRODUCTS_DIR}"
 fi
 
 # Set permissions

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -10,6 +10,11 @@
 #   --release       Build in release mode (default: debug)
 #   --dmg           Also create a DMG installer
 #   --open          Open the app after building
+#   --install       Replace /Applications/<APP_NAME>.app with the built bundle
+#                   (kills any running instance first, then rm -rf + cp -R).
+#                   Pairs naturally with --open: opens the installed copy
+#                   so macOS TCC tracks a stable signed identity instead of
+#                   re-prompting permissions on every build/.
 #   --clean         Clean build directory before building
 #   --sign NAME     Sign with specified identity (use "ad-hoc" for ad-hoc)
 #   --sync          Pull latest code from git before building
@@ -68,6 +73,8 @@ SIGN_IDENTITY=""
 SYNC_CODE=false
 CHECK_SIGNING_ONLY=false
 REQUIRE_SIGNING=false  # Set to true to mandate signing (no ad-hoc allowed)
+INSTALL_APP=false      # --install: replace /Applications/<APP_NAME>.app with the built bundle
+INSTALL_DIR="/Applications"
 
 # Check for .signing-identity file
 SIGNING_IDENTITY_FILE="${PROJECT_ROOT}/.signing-identity"
@@ -120,6 +127,7 @@ show_help() {
     echo "  --release       Build in release mode (default: debug)"
     echo "  --dmg           Also create a DMG installer"
     echo "  --open          Open the app after building"
+    echo "  --install       Replace /Applications/${APP_NAME}.app with the built bundle"
     echo "  --clean         Clean build directory before building"
     echo "  --sign NAME     Sign with specified identity (use 'ad-hoc' for ad-hoc)"
     echo "  --sync          Pull latest code from git before building"
@@ -127,10 +135,11 @@ show_help() {
     echo "  --help          Show this help message"
     echo ""
     echo "Examples:"
-    echo "  ./scripts/build-app.sh                # Debug build with configured signing"
-    echo "  ./scripts/build-app.sh --release      # Release build"
-    echo "  ./scripts/build-app.sh --release --dmg # Release + DMG"
-    echo "  ./scripts/build-app.sh --check-signing # Validate signing setup"
+    echo "  ./scripts/build-app.sh                  # Debug build with configured signing"
+    echo "  ./scripts/build-app.sh --install --open # Build, replace /Applications copy, launch it"
+    echo "  ./scripts/build-app.sh --release        # Release build"
+    echo "  ./scripts/build-app.sh --release --dmg  # Release + DMG"
+    echo "  ./scripts/build-app.sh --check-signing  # Validate signing setup"
     echo ""
     exit 0
 }
@@ -501,6 +510,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --open)
             OPEN_APP=true
+            shift
+            ;;
+        --install)
+            INSTALL_APP=true
             shift
             ;;
         --clean)
@@ -978,6 +991,67 @@ xattr -rd com.apple.quarantine "${APP_BUNDLE}" 2>/dev/null || true
 print_success "Gatekeeper bypass applied (local development only)"
 
 # =============================================================================
+# Install to /Applications (if requested)
+# =============================================================================
+# `--install` replaces the existing /Applications/<APP_NAME>.app with the
+# freshly built bundle. The earlier pre-build step already pkilled any
+# running instance (whether launched from build/ or /Applications/), so
+# the rm -rf below should not race with a live process. The install also
+# clears the Gatekeeper quarantine attribute that `cp -R` may copy across.
+
+INSTALLED_APP_PATH="${INSTALL_DIR}/${APP_NAME}.app"
+
+if [ "$INSTALL_APP" = true ]; then
+    print_header "Installing to ${INSTALL_DIR}"
+
+    if [ ! -d "${INSTALL_DIR}" ]; then
+        print_error "Install directory does not exist: ${INSTALL_DIR}"
+        exit 1
+    fi
+
+    if [ ! -w "${INSTALL_DIR}" ]; then
+        print_error "Install directory is not writable: ${INSTALL_DIR}"
+        echo ""
+        echo "  ${INSTALL_DIR} usually allows writes by the current user, but a"
+        echo "  recent macOS update or organisation MDM profile may have"
+        echo "  restricted it. Either install elsewhere or grant write access."
+        echo ""
+        exit 1
+    fi
+
+    if [ -d "${INSTALLED_APP_PATH}" ]; then
+        print_info "Removing existing ${INSTALLED_APP_PATH}..."
+        rm -rf "${INSTALLED_APP_PATH}" || {
+            print_error "Could not remove existing app at ${INSTALLED_APP_PATH}"
+            echo ""
+            echo "  Common causes:"
+            echo "    - The app is still running (pkill check before build was insufficient)"
+            echo "    - Finder has the bundle open in a Get-Info or Quick-Look window"
+            echo "    - Spotlight is mid-index of the bundle"
+            echo ""
+            echo "  Retry after closing Finder windows referencing the app, or run:"
+            echo "    pkill -f '${APP_NAME}.app/Contents/MacOS/${APP_NAME}'"
+            echo "    rm -rf ${INSTALLED_APP_PATH}"
+            echo ""
+            exit 1
+        }
+        print_success "Removed previous installed copy"
+    fi
+
+    print_info "Copying ${APP_BUNDLE} → ${INSTALLED_APP_PATH}..."
+    cp -R "${APP_BUNDLE}" "${INSTALLED_APP_PATH}" || {
+        print_error "Copy failed"
+        exit 1
+    }
+
+    # Re-clear quarantine on the installed copy. `cp -R` may carry the
+    # attribute across even though we cleared it on the build/ copy.
+    xattr -rd com.apple.quarantine "${INSTALLED_APP_PATH}" 2>/dev/null || true
+
+    print_success "Installed to ${INSTALLED_APP_PATH}"
+fi
+
+# =============================================================================
 # Create DMG (if requested)
 # =============================================================================
 
@@ -1020,12 +1094,19 @@ fi
 print_header "Build Complete"
 
 echo -e "${GREEN}[SUCCESS]${NC} App Bundle: ${APP_BUNDLE}"
+if [ "$INSTALL_APP" = true ]; then
+    echo -e "${GREEN}[SUCCESS]${NC} Installed:  ${INSTALLED_APP_PATH}"
+fi
 if [ "$CREATE_DMG" = true ]; then
     echo -e "${GREEN}[SUCCESS]${NC} DMG File:   ${BUILD_DIR}/${APP_NAME}.dmg"
 fi
 echo ""
 echo -e "${CYAN}To run the app:${NC}"
-echo "  open ${APP_BUNDLE}"
+if [ "$INSTALL_APP" = true ]; then
+    echo "  open ${INSTALLED_APP_PATH}"
+else
+    echo "  open ${APP_BUNDLE}"
+fi
 echo ""
 
 # Show appropriate note based on signing
@@ -1045,8 +1126,17 @@ else
     echo ""
 fi
 
-# Open app if requested
+# Open app if requested. Prefer the installed copy when --install was used
+# so macOS TCC tracks one stable signed identity and permission grants
+# survive across rebuilds (the build/ copy may be ad-hoc-signed and the
+# /Applications copy correctly signed, or vice versa — opening the
+# installed copy guarantees we exercise the path real users will hit).
 if [ "$OPEN_APP" = true ]; then
-    print_info "Opening app..."
-    open "${APP_BUNDLE}"
+    if [ "$INSTALL_APP" = true ]; then
+        print_info "Opening installed app..."
+        open "${INSTALLED_APP_PATH}"
+    else
+        print_info "Opening app..."
+        open "${APP_BUNDLE}"
+    fi
 fi


### PR DESCRIPTION
Closes #106. Closes #102. Closes #108. Partial mitigation only for #109 (filed for follow-up).

## What this fixes

### 1. NSWindow over-release (the original #106 / #102 root cause) — ✓ verified by user

NSZombies caught:

```
*** -[NSKVONotifying_NSWindow release]: message sent to deallocated instance 0xcaa299180
```

Every \`NSWindow\` in the codebase inherited AppKit's default \`isReleasedWhenClosed = true\` while Swift code held strong references. Multiple close paths converge per window (SwiftUI \`dismissAction()\` + \`.onDisappear\`; the controller's notification observer + \`windowWillClose\` re-posting the same notification; \`applicationWillTerminate\` cleanup). With the default, the first close auto-releases; the second is a zombie release on \`NSKVONotifying_NSWindow\`. Crash address varied per run because the freed memory got recycled by whatever Obj-C object the runtime allocated next. EXC_BAD_ACCESS at \`objc_autoreleasePoolPop\` from \`NSApplication.run\`'s outer drain — sometimes minutes after the actual over-release, with no symbolicated frames pointing back at the caller because the offender is long off-stack.

**Fix:** \`isReleasedWhenClosed = false\` on each \`NSWindow\` immediately after construction. Lifetime is now under Swift ARC alone; \`close()\` becomes idempotent (just \`orderOut:\`).

Four sites: \`MainWindow.makeWindow\`, \`ReviewWindow.makeWindow\`, \`AppDelegate.showRecordingModal\` (\`recordingWindow\`), \`GlassOverlayWindow.createWindow\` (\`ClickThroughWindow\`).

**Verified on M1 Pro / 32 GB / macOS 26.x:** SOAP notes generated, Review window opens + closes cleanly without terminating the app, no EXC_BAD_ACCESS.

### 2. Settings recorder field beeps when chord already bound — ✓ verified by user

\`ShortcutRecorderView.startRecording()\` installs an \`NSEvent.addLocalMonitorForEvents\` to capture the candidate chord but didn't suspend the bound Carbon hotkey for the same name. When the user tried to re-record over an existing binding, the Carbon hotkey fired **before** the NSEvent monitor saw the keystroke — recorder never captured, user heard the system "bonk". Custom \`ShortcutRecorderView\` exists because the library's own \`KeyboardShortcuts.Recorder\` hits a \`Bundle.module\` crash in SPM executable targets — but the custom version was missing the disable/enable bracket that the library version does internally.

**Fix:** \`KeyboardShortcuts.disable(shortcutName)\` on \`startRecording()\`, \`enable(shortcutName)\` on \`stopRecording()\`.

### 3. Clinical-notes chord locks out after first session — ⚠ partial mitigation only (see #109)

\`HotkeyManager.isRecordingClinicalNotes\` is set to \`true\` on chord-initiated start, but only the chord-stop path resets it. The in-modal **Done** button drives \`viewModel.stopRecording()\` directly, leaving the flag stuck at \`true\`.

**Partial fix:** new idempotent \`HotkeyManager.clinicalNotesSessionEnded()\`, called from the recording modal's \`.onDisappear\` in \`AppDelegate.showRecordingModal\`. State mutation is verified.

**Why this isn't enough:** user reports the chord still doesn't trigger after closing the Review window, even with the state reset in place. There's at least one additional bug in addition to the stale flag — most likely a \`KeyboardShortcuts.disable/.enable\` mismatch elsewhere, a Carbon hotkey re-registration failure, or a stale closure capture on \`HotkeyManager.onKeyDown\`. Filed as **#109** with full investigation hints for a fresh session.

## Cleanup of original (wrong-diagnosis) wraps

The first commit on this branch wrapped MLX boundaries in \`autoreleasepool { … }\` based on the hypothesis that the UAF was an Obj-C bridge temporary leaking out of the \`loadContainer\` call. NSZombies disproved that:

- **Reverted** \`AppState.runClinicalNotesPipeline\` post-warmup wrap (drained the wrong pool).
- **Reverted** \`MLXGemmaProvider.warmup\` post-resume wrap (same).
- **Reverted** the corresponding \`mlx-lifecycle.md\` "autorelease defence" section.
- **Kept** the per-chunk \`autoreleasepool\` inside \`MLXGemmaProvider.runGeneration\`'s for-await loop — the canonical Cocoa pattern for long sync loops with bridge work, justified independently of #106.
- **Kept** the \`MLX warmup starting\` OSLog signpost — generally useful crash-localisation, cheap.
- **Kept** the new \`.fast\` Swift Testing case for \`warmup()\` error mapping — independently valuable.

## Documentation

\`.claude/references/concurrency.md\` gets a new section §8 — "\`NSWindow.isReleasedWhenClosed\` (over-release UAF)" — with WRONG/CORRECT examples, the NSZombies diagnostic recipe, and a "checklist: introducing a new NSWindow" so future regressions get caught at PR review.

## Side-fixes (#108)

- \`scripts/build-app.sh\` now copies **all** \`*.bundle\` directories from xcodebuild's Products dir, not just the project's own. Previously \`mlx-swift_Cmlx.bundle\` (carrier of \`default.metallib\`) was missing from the .app, with the consequence that \`Cmlx\` hard-failed at startup with \`Failed to load the default metallib\` — blocking #106 repro on a clean build.
- New \`./scripts/build-app.sh --install\` flag rolls the manual \`rm -rf /Applications/SpeechToText.app && cp -R build/SpeechToText.app /Applications/\` into the build pipeline. Pairs naturally with \`--open\` to launch the installed copy so macOS TCC tracks one stable signed identity. Off by default — no behaviour change for any existing caller.

## Tests

- All 366 existing tests pass.
- New \`.fast\` test in \`MLXGemmaProviderTests.swift\` verifies \`warmup()\`'s error-mapping shape.
- The actual window/hotkey fixes aren't unit-testable without spawning real NSWindows / mocking the entire \`KeyboardShortcuts\` library; verified by manual NSZombies repro + user testing on M1 Pro.

## Test plan

- [x] **#106 root-cause fixed** — verified by user on M1 Pro / 32 GB / macOS 26.x. SOAP notes generated, Review window opened, no EXC_BAD_ACCESS.
- [x] **#102 Cancel-from-Review** — Review window closes cleanly, app stays running.
- [x] **#108 metallib bundling** — \`build-app.sh\` now produces a working .app with all package bundles.
- [x] **Recorder field fix** — Settings → Clinical Notes recorder captures keystrokes without "bonk".
- [ ] **Chord lockout** — partially mitigated only; tracked in #109 for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)