### PR TITLE
fix(cliniko): patient search uses q[] array filter — clears "server error" in picker (#101)

### DIFF
--- a/Sources/Services/Cliniko/ClinikoEndpoint.swift
+++ b/Sources/Services/Cliniko/ClinikoEndpoint.swift
@@ -20,7 +20,10 @@ public enum ClinikoEndpoint: Sendable, Equatable {
     /// (`/users/me` does not exist — it 404s, see #88).
     case usersMe
 
-    /// `GET /patients?q={query}` — debounced patient search for #9.
+    /// `GET /patients?q[]=field:~term` — debounced patient search for #9.
+    /// Cliniko's `/patients` filter takes Ransack-style array filters;
+    /// a bare `q=value` 5xx'd in production. See #101 +
+    /// `patientSearchQueryItems` for the splitting strategy.
     case patientSearch(query: String)
 
     /// `GET /patients/{id}/appointments?from={ISO8601}&to={ISO8601}` —

--- a/Sources/Services/Cliniko/ClinikoEndpoint.swift
+++ b/Sources/Services/Cliniko/ClinikoEndpoint.swift
@@ -197,8 +197,12 @@ public enum ClinikoEndpoint: Sendable, Equatable {
     private static func patientSearchQueryItems(query: String) -> [URLQueryItem] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return [] }
+        // Use `.whitespacesAndNewlines` (vs the reference impl's `.whitespaces`)
+        // so a pasted multi-line clipboard like "John\nDoe" still tokenises
+        // into first/last name pair rather than landing as one weird value
+        // with an embedded `%0A` on the wire (Gemini Code Assist review on #112).
         let parts = trimmed
-            .components(separatedBy: .whitespaces)
+            .components(separatedBy: .whitespacesAndNewlines)
             .filter { !$0.isEmpty }
         if parts.count >= 2 {
             let first = parts[0]

--- a/Sources/Services/Cliniko/ClinikoEndpoint.swift
+++ b/Sources/Services/Cliniko/ClinikoEndpoint.swift
@@ -152,7 +152,13 @@ public enum ClinikoEndpoint: Sendable, Equatable {
         case .usersMe, .createTreatmentNote:
             return nil
         case .patientSearch(let query):
-            return ClinikoEndpoint.patientSearchQueryItems(query: query)
+            // Collapse `[]` to `nil` so `buildURL` doesn't emit a stray
+            // trailing `?` for empty/whitespace input. The actual
+            // PHI-exposure guard against an unfiltered list-all is in
+            // `ClinikoPatientService.searchPatients` — this is just URL
+            // hygiene.
+            let items = ClinikoEndpoint.patientSearchQueryItems(query: query)
+            return items.isEmpty ? nil : items
         case .patientAppointments(_, let from, let to):
             return [
                 URLQueryItem(name: "from", value: ClinikoEndpoint.iso8601(from)),
@@ -172,8 +178,12 @@ public enum ClinikoEndpoint: Sendable, Equatable {
     /// in `CloudbrokerAz/epc-letter-generation/Sources/Services/Cliniko/`.
     ///
     /// Splitting strategy (mirrors the reference exactly):
-    /// - Empty / whitespace-only → no query items. The picker VM already
-    ///   trims and short-circuits on empty, so this is defence-in-depth.
+    /// - Empty / whitespace-only → no query items. **This is URL-shape
+    ///   hygiene only** — it does NOT defend against a list-all of every
+    ///   patient (Cliniko serves the unfiltered list in either case). The
+    ///   PHI-exposure guard for that lives in
+    ///   `ClinikoPatientService.searchPatients`, which short-circuits to
+    ///   an empty array before issuing the request.
     /// - 1 token → `q[]=last_name:~<token>`. Single-term searches in
     ///   clinical UI are usually a surname.
     /// - ≥2 tokens → `q[]=first_name:~<head>` + `q[]=last_name:~<tail>`,

--- a/Sources/Services/Cliniko/ClinikoEndpoint.swift
+++ b/Sources/Services/Cliniko/ClinikoEndpoint.swift
@@ -54,7 +54,7 @@ public enum ClinikoEndpoint: Sendable, Equatable {
     public var pathTemplate: String {
         switch self {
         case .usersMe: return "/user"
-        case .patientSearch: return "/patients?q={query}"
+        case .patientSearch: return "/patients?q[]={filter}"
         case .patientAppointments: return "/patients/:id/appointments"
         case .createTreatmentNote: return "/treatment_notes"
         }
@@ -149,13 +149,53 @@ public enum ClinikoEndpoint: Sendable, Equatable {
         case .usersMe, .createTreatmentNote:
             return nil
         case .patientSearch(let query):
-            return [URLQueryItem(name: "q", value: query)]
+            return ClinikoEndpoint.patientSearchQueryItems(query: query)
         case .patientAppointments(_, let from, let to):
             return [
                 URLQueryItem(name: "from", value: ClinikoEndpoint.iso8601(from)),
                 URLQueryItem(name: "to", value: ClinikoEndpoint.iso8601(to))
             ]
         }
+    }
+
+    /// Build Cliniko's filter syntax for `GET /patients?q[]=field:~term`.
+    ///
+    /// Cliniko's `/patients` endpoint expects array-shaped `q[]` filters
+    /// with the form `field:~value` (the `~` being Cliniko's contains
+    /// operator). Sending a bare `q=value` triggered issue #101 — Cliniko
+    /// 5xx'd on the malformed filter, which the client mapped to
+    /// `.server(status:)`, surfacing as "Cliniko had a server error" in
+    /// the patient picker. Verified against the working reference impl
+    /// in `CloudbrokerAz/epc-letter-generation/Sources/Services/Cliniko/`.
+    ///
+    /// Splitting strategy (mirrors the reference exactly):
+    /// - Empty / whitespace-only → no query items. The picker VM already
+    ///   trims and short-circuits on empty, so this is defence-in-depth.
+    /// - 1 token → `q[]=last_name:~<token>`. Single-term searches in
+    ///   clinical UI are usually a surname.
+    /// - ≥2 tokens → `q[]=first_name:~<head>` + `q[]=last_name:~<tail>`,
+    ///   tail = remaining tokens joined by space (handles "Mary Jane Smith"
+    ///   as first="Mary", last="Jane Smith").
+    ///
+    /// `URLQueryItem` value-half percent-encoding is handled by
+    /// `URLComponents`; `:` and `~` pass through unencoded as URL-safe
+    /// characters in the query component, and any user-supplied bytes
+    /// (including `&`, `=`, spaces) are escaped automatically.
+    private static func patientSearchQueryItems(query: String) -> [URLQueryItem] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let parts = trimmed
+            .components(separatedBy: .whitespaces)
+            .filter { !$0.isEmpty }
+        if parts.count >= 2 {
+            let first = parts[0]
+            let last = parts.dropFirst().joined(separator: " ")
+            return [
+                URLQueryItem(name: "q[]", value: "first_name:~\(first)"),
+                URLQueryItem(name: "q[]", value: "last_name:~\(last)")
+            ]
+        }
+        return [URLQueryItem(name: "q[]", value: "last_name:~\(trimmed)")]
     }
 
     /// ISO8601 with seconds + UTC. Cliniko accepts this canonical shape for

--- a/Sources/Services/Cliniko/ClinikoPatientService.swift
+++ b/Sources/Services/Cliniko/ClinikoPatientService.swift
@@ -38,7 +38,16 @@ public actor ClinikoPatientService: ClinikoPatientSearching {
     }
 
     public func searchPatients(query: String) async throws -> [Patient] {
-        let response: PatientSearchResponse = try await client.send(.patientSearch(query: query))
+        // Guard against empty / whitespace-only queries: without this, a
+        // bare `GET /v1/patients` lists EVERY patient in the tenant —
+        // unfiltered PHI exfiltration if a future caller bypasses the
+        // picker VM's empty-check (today only `PatientPickerViewModel`
+        // calls this, and it short-circuits empty input, but the
+        // service-layer contract should be safe in isolation). Matches
+        // the reference impl in `epc-letter-generation`.
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        let response: PatientSearchResponse = try await client.send(.patientSearch(query: trimmed))
         return response.patients
     }
 }

--- a/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patients_search.json
+++ b/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patients_search.json
@@ -24,6 +24,6 @@
   ],
   "total_entries": 3,
   "links": {
-    "self": "https://api.au1.cliniko.com/v1/patients?q=sample"
+    "self": "https://api.au1.cliniko.com/v1/patients?q%5B%5D=last_name%3A~sample"
   }
 }

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
@@ -117,26 +117,22 @@ struct ClinikoEndpointTests {
                 "expected encoded `&` and `=`, got: \(absolute)")
     }
 
-    @Test("patientSearch with empty / whitespace-only query emits no filter items")
-    func patientSearchURL_emptyQuery_emitsNoQueryItems() {
-        // Defence-in-depth: PatientPickerViewModel already short-circuits
-        // empty input, but the endpoint shouldn't send a malformed filter
-        // if a different caller passes whitespace-only.
-        let emptyURL = ClinikoEndpoint.patientSearch(query: "").buildURL(against: baseURL)
-        let emptyComponents = emptyURL.flatMap {
-            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+    @Test("patientSearch with empty / whitespace-only query emits a clean URL with no trailing `?`")
+    func patientSearchURL_emptyQuery_hasNoTrailingQuestionMark() {
+        // URL hygiene only — `URLComponents.queryItems = []` would still
+        // emit `…/patients?` (trailing `?`). Returning `nil` from the
+        // endpoint's `queryItems` accessor keeps the URL clean. Note this
+        // is NOT the PHI guard against an unfiltered list-all of every
+        // patient — that lives in `ClinikoPatientService.searchPatients`.
+        for input in ["", "   \t\n  "] {
+            let url = ClinikoEndpoint.patientSearch(query: input).buildURL(against: baseURL)
+            let absolute = url?.absoluteString ?? ""
+            #expect(absolute == "https://api.au1.cliniko.com/v1/patients",
+                    "expected clean URL for query \"\(input)\", got: \(absolute)")
+            #expect(!absolute.hasSuffix("?"), "trailing `?` for query \"\(input)\"")
+            let components = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+            #expect(components?.queryItems == nil)
         }
-        #expect(emptyComponents?.queryItems == nil || emptyComponents?.queryItems?.isEmpty == true)
-
-        let whitespaceURL = ClinikoEndpoint.patientSearch(query: "   \t\n  ")
-            .buildURL(against: baseURL)
-        let whitespaceComponents = whitespaceURL.flatMap {
-            URLComponents(url: $0, resolvingAgainstBaseURL: false)
-        }
-        #expect(
-            whitespaceComponents?.queryItems == nil
-            || whitespaceComponents?.queryItems?.isEmpty == true
-        )
     }
 
     @Test("patientAppointments URL embeds id + ISO8601 dates")

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
@@ -27,7 +27,9 @@ struct ClinikoEndpointTests {
     func patientSearchShape() {
         let endpoint = ClinikoEndpoint.patientSearch(query: "smith")
         #expect(endpoint.method == .get)
-        #expect(endpoint.pathTemplate == "/patients?q={query}")
+        // Template now reflects Cliniko's array-shaped filter syntax (#101).
+        // Bound query value still excluded — `{filter}` is the placeholder.
+        #expect(endpoint.pathTemplate == "/patients?q[]={filter}")
         #expect(endpoint.body == nil)
         #expect(endpoint.isIdempotent)
         #expect(endpoint.resource == .patient)
@@ -69,16 +71,72 @@ struct ClinikoEndpointTests {
         #expect(url?.absoluteString == "https://api.au1.cliniko.com/v1/user")
     }
 
-    @Test("patientSearch URL encodes the query")
-    func patientSearchURL() {
-        let url = ClinikoEndpoint.patientSearch(query: "John & Jane").buildURL(against: baseURL)
-        // The query must be percent-encoded; `&` becomes `%26`, space becomes `%20`.
+    @Test("patientSearch URL emits Cliniko's q[]=field:~term filter syntax (single token)")
+    func patientSearchURL_singleToken_emitsLastNameFilter() {
+        let url = ClinikoEndpoint.patientSearch(query: "smith").buildURL(against: baseURL)
         #expect(url != nil)
+        let components = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+        let queryItems = components?.queryItems ?? []
+        // Single token → q[]=last_name:~smith. Reference: epc-letter-generation
+        // ClinikoPatientService.searchPatients(query:) — last_name is the most
+        // common surname-only search pattern in the picker UI.
+        #expect(queryItems.count == 1, "got \(queryItems)")
+        #expect(queryItems.first?.name == "q[]")
+        #expect(queryItems.first?.value == "last_name:~smith")
+        #expect(components?.path == "/v1/patients")
+    }
+
+    @Test("patientSearch URL emits q[]=first_name + q[]=last_name for multi-token query")
+    func patientSearchURL_multiToken_emitsFirstAndLastNameFilters() {
+        let url = ClinikoEndpoint.patientSearch(query: "Mary Jane Smith")
+            .buildURL(against: baseURL)
+        let components = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+        let queryItems = components?.queryItems ?? []
+        #expect(queryItems.count == 2, "got \(queryItems)")
+        #expect(queryItems[0].name == "q[]")
+        #expect(queryItems[0].value == "first_name:~Mary")
+        #expect(queryItems[1].name == "q[]")
+        // Trailing tokens are joined back together so "Jane Smith" stays a
+        // single last-name filter value (handles compound surnames).
+        #expect(queryItems[1].value == "last_name:~Jane Smith")
+    }
+
+    @Test("patientSearch URL percent-escapes user-supplied special chars in the value")
+    func patientSearchURL_percentEscapesSpecialChars() {
+        // `&` and `=` would break the query string if unescaped; URLComponents
+        // must encode them inside the value half of the URLQueryItem so they
+        // can't terminate the filter or introduce a sibling query parameter.
+        let url = ClinikoEndpoint.patientSearch(query: "O&Brien=test")
+            .buildURL(against: baseURL)
         let absolute = url?.absoluteString ?? ""
         #expect(absolute.contains("/v1/patients"))
-        #expect(absolute.contains("q="))
-        // URLComponents standard encoding turns space into "%20"
-        #expect(absolute.contains("John%20%26%20Jane") || absolute.contains("John+%26+Jane"))
+        // Single-token branch (no whitespace) → last_name filter. The user
+        // input portion is encoded; `:` and `~` in the structural prefix
+        // pass through as URL-safe.
+        #expect(absolute.contains("q%5B%5D=last_name:~O%26Brien%3Dtest"),
+                "expected encoded `&` and `=`, got: \(absolute)")
+    }
+
+    @Test("patientSearch with empty / whitespace-only query emits no filter items")
+    func patientSearchURL_emptyQuery_emitsNoQueryItems() {
+        // Defence-in-depth: PatientPickerViewModel already short-circuits
+        // empty input, but the endpoint shouldn't send a malformed filter
+        // if a different caller passes whitespace-only.
+        let emptyURL = ClinikoEndpoint.patientSearch(query: "").buildURL(against: baseURL)
+        let emptyComponents = emptyURL.flatMap {
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }
+        #expect(emptyComponents?.queryItems == nil || emptyComponents?.queryItems?.isEmpty == true)
+
+        let whitespaceURL = ClinikoEndpoint.patientSearch(query: "   \t\n  ")
+            .buildURL(against: baseURL)
+        let whitespaceComponents = whitespaceURL.flatMap {
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }
+        #expect(
+            whitespaceComponents?.queryItems == nil
+            || whitespaceComponents?.queryItems?.isEmpty == true
+        )
     }
 
     @Test("patientAppointments URL embeds id + ISO8601 dates")

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
@@ -86,6 +86,22 @@ struct ClinikoEndpointTests {
         #expect(components?.path == "/v1/patients")
     }
 
+    @Test("patientSearch URL splits on embedded newlines as well as spaces")
+    func patientSearchURL_multiToken_splitsOnEmbeddedNewlines() {
+        // A pasted multi-line clipboard ("John\nDoe") used to tokenise as a
+        // single value (because `.whitespaces` excludes line terminators),
+        // landing on the wire as `last_name:~John%0ADoe`. The split now uses
+        // `.whitespacesAndNewlines` so it splits on `\n` / `\r` too — Gemini
+        // Code Assist review on PR #112.
+        let url = ClinikoEndpoint.patientSearch(query: "John\nDoe")
+            .buildURL(against: baseURL)
+        let components = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+        let items = components?.queryItems ?? []
+        #expect(items.count == 2, "got \(items)")
+        #expect(items[0].value == "first_name:~John")
+        #expect(items[1].value == "last_name:~Doe")
+    }
+
     @Test("patientSearch URL emits q[]=first_name + q[]=last_name for multi-token query")
     func patientSearchURL_multiToken_emitsFirstAndLastNameFilters() {
         let url = ClinikoEndpoint.patientSearch(query: "Mary Jane Smith")

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoPatientServiceTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoPatientServiceTests.swift
@@ -162,6 +162,40 @@ final class ClinikoPatientServiceTests: XCTestCase {
         try await assertSearchError(status: 503, expected: .server(status: 503))
     }
 
+    // MARK: - Empty / whitespace queries (PHI list-all guard)
+
+    /// Without the service-layer empty-query guard, a bare `searchPatients(query: "")`
+    /// would issue `GET /v1/patients` with no filter and Cliniko would
+    /// return EVERY patient in the tenant — a silent PHI exfiltration if
+    /// any future caller bypasses the picker VM's empty-check. The guard
+    /// short-circuits to `[]` and never touches the network.
+    func test_searchPatients_emptyQuery_returnsEmptyArray_withoutNetworkCall() async throws {
+        let invocationCount = CallCounter()
+        let service = try makeService { _ in
+            _ = invocationCount.increment()
+            // Still return a well-formed response so a regression in the
+            // guard fails the count assertion below rather than crashing
+            // somewhere downstream — the test is about whether the request
+            // happens, not what comes back.
+            let body = try HTTPStubFixture.load("cliniko/responses/patients_search_empty.json")
+            let response = HTTPURLResponse(
+                url: URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (response, body)
+        }
+
+        let empty = try await service.searchPatients(query: "")
+        let whitespace = try await service.searchPatients(query: "   \t\n  ")
+
+        XCTAssertTrue(empty.isEmpty)
+        XCTAssertTrue(whitespace.isEmpty)
+        XCTAssertEqual(invocationCount.value, 0,
+                       "empty / whitespace queries must not hit the network")
+    }
+
     /// 429 with `Retry-After: 0` exhausts the immediate-retry policy budget
     /// and surfaces as `.rateLimited(retryAfter: 0)`. The picker UI maps
     /// this to "Cliniko is throttling requests. Try again shortly." — a
@@ -258,6 +292,26 @@ final class ClinikoPatientServiceTests: XCTestCase {
         } catch {
             XCTFail("expected ClinikoError, got \(error)", file: file, line: line)
         }
+    }
+}
+
+/// Counts how many times a URLProtocolStub responder is invoked. Mirrors
+/// the helper of the same name in `ClinikoClientTests` (kept private per
+/// file to dodge `URLProtocolStub` cross-suite races — see #30).
+private final class CallCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    @discardableResult
+    func increment() -> Int {
+        lock.lock(); defer { lock.unlock() }
+        count += 1
+        return count
+    }
+
+    var value: Int {
+        lock.lock(); defer { lock.unlock() }
+        return count
     }
 }
 

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoPatientServiceTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoPatientServiceTests.swift
@@ -63,7 +63,13 @@ final class ClinikoPatientServiceTests: XCTestCase {
         XCTAssertNil(patients.last?.email)
     }
 
-    func test_searchPatients_emitsQueryItem() async throws {
+    /// End-to-end pin (#101): a single-word query produces Cliniko's
+    /// array-shaped `q[]=last_name:~term` filter on the wire. The
+    /// duplication with `ClinikoEndpointTests.patientSearchURL_…` is
+    /// intentional — this asserts the *whole* call path from
+    /// `searchPatients(query:)` through `ClinikoClient.send(_:)` lands
+    /// the right bytes in the URL, not just the endpoint enum in isolation.
+    func test_searchPatients_singleToken_emitsLastNameFilter() async throws {
         let captured = CapturedRequestBox()
         let service = try makeService { request in
             captured.set(request)
@@ -77,12 +83,45 @@ final class ClinikoPatientServiceTests: XCTestCase {
             return (response, body)
         }
 
-        _ = try await service.searchPatients(query: "doe smith")
+        _ = try await service.searchPatients(query: "smith")
 
         let url = try XCTUnwrap(captured.value?.url)
         let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-        let queryValue = components.queryItems?.first { $0.name == "q" }?.value
-        XCTAssertEqual(queryValue, "doe smith")
+        let items = components.queryItems ?? []
+        XCTAssertEqual(items.count, 1, "got \(items)")
+        XCTAssertEqual(items.first?.name, "q[]")
+        XCTAssertEqual(items.first?.value, "last_name:~smith")
+        XCTAssertEqual(components.path, "/v1/patients")
+    }
+
+    /// Multi-token queries split on whitespace: first token → first_name
+    /// filter, remainder joined back together → last_name filter. Mirrors
+    /// the reference impl in `epc-letter-generation`.
+    func test_searchPatients_multiToken_emitsFirstAndLastNameFilters() async throws {
+        let captured = CapturedRequestBox()
+        let service = try makeService { request in
+            captured.set(request)
+            let body = try HTTPStubFixture.load("cliniko/responses/patients_search_empty.json")
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+
+        // Compound surname: "Mary Jane Smith" → first_name=Mary, last_name="Jane Smith".
+        _ = try await service.searchPatients(query: "Mary Jane Smith")
+
+        let url = try XCTUnwrap(captured.value?.url)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let items = components.queryItems ?? []
+        XCTAssertEqual(items.count, 2, "got \(items)")
+        XCTAssertEqual(items[0].name, "q[]")
+        XCTAssertEqual(items[0].value, "first_name:~Mary")
+        XCTAssertEqual(items[1].name, "q[]")
+        XCTAssertEqual(items[1].value, "last_name:~Jane Smith")
         XCTAssertEqual(components.path, "/v1/patients")
     }
 
@@ -121,6 +160,61 @@ final class ClinikoPatientServiceTests: XCTestCase {
 
     func test_searchPatients_503_afterRetriesExhausted_mapsToServer() async throws {
         try await assertSearchError(status: 503, expected: .server(status: 503))
+    }
+
+    /// 429 with `Retry-After: 0` exhausts the immediate-retry policy budget
+    /// and surfaces as `.rateLimited(retryAfter: 0)`. The picker UI maps
+    /// this to "Cliniko is throttling requests. Try again shortly." — a
+    /// distinct error path from the generic `.server` we used to fall into.
+    func test_searchPatients_429_exhaustsBudget_mapsToRateLimited() async throws {
+        let service = try makeService { request in
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 429,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Retry-After": "0"]
+            )!
+            return (response, Data())
+        }
+        do {
+            _ = try await service.searchPatients(query: "anything")
+            XCTFail("expected ClinikoError.rateLimited")
+        } catch ClinikoError.rateLimited(let retryAfter) {
+            XCTAssertEqual(retryAfter, 0)
+        } catch {
+            XCTFail("expected .rateLimited, got \(error)")
+        }
+    }
+
+    /// 200 with a body that does not decode into `PatientSearchResponse`
+    /// surfaces as `.decoding(typeName:)`. Cliniko has occasionally shipped
+    /// envelope changes (e.g. renaming `total_entries`) and we want the
+    /// picker to render an unambiguous "report this" path rather than a
+    /// generic "server error" fallthrough.
+    func test_searchPatients_malformedJSON_mapsToDecoding() async throws {
+        // Body parses as JSON but lacks the required `patients` array, so
+        // PatientSearchResponse cannot decode. PHI: synthetic, no patient data.
+        let body = Data(#"{"unexpected_envelope": true}"#.utf8)
+        let service = try makeService { request in
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+        do {
+            _ = try await service.searchPatients(query: "anything")
+            XCTFail("expected ClinikoError.decoding")
+        } catch ClinikoError.decoding(let typeName) {
+            XCTAssertTrue(
+                typeName.contains("PatientSearchResponse"),
+                "typeName should identify the decoding target; got \(typeName)"
+            )
+        } catch {
+            XCTFail("expected .decoding, got \(error)")
+        }
     }
 
     // MARK: - Cancellation


### PR DESCRIPTION
Closes #101.

## Symptom

Typing a name into the patient-picker sheet (Clinical Notes Mode → Generate Notes → Patient picker) returned **"Cliniko had a server error. Try again."** even with valid credentials (the #88 auth probe passed).

## Root cause

`ClinikoEndpoint.patientSearch` was emitting `?q={value}` (single string), but Cliniko's `/patients` endpoint takes [Ransack-style](https://docs.api.cliniko.com/) array filters: `q[]=field:~term`. The malformed filter triggered a 5xx (or unclassified-status) response that `ClinikoClient.classifyResponse` mapped to `.server`, which `PatientPickerView.humanReadable(_:)` renders as the user-facing "server error" string.

Verified against the working reference impl in [`CloudbrokerAz/epc-letter-generation/Sources/Services/Cliniko/ClinikoPatientService.swift:110-138`](https://github.com/CloudbrokerAz/epc-letter-generation/blob/main/Sources/Services/Cliniko/ClinikoPatientService.swift#L110-L138).

## Fix (smallest surgical change)

`ClinikoEndpoint.patientSearchQueryItems(query:)` (new private helper) builds the array-shape filter, mirroring the reference's splitting strategy:

| Input | Wire shape |
|---|---|
| `""` / whitespace-only | `GET /v1/patients` (no query items — service guard short-circuits before the request fires) |
| `"smith"` | `q[]=last_name:~smith` |
| `"Mary Jane Smith"` | `q[]=first_name:~Mary` + `q[]=last_name:~Jane Smith` |

`URLComponents` handles percent-encoding of user-supplied bytes (`&`, `=`, space, etc.); the structural `:~` prefix passes through URL-safe per RFC 3986 §3.4. Pinned by `patientSearchURL_percentEscapesSpecialChars`.

## Reference diff (what the reference does that we now also do)

| Reference (epc-letter-generation) | Before | After (this PR) |
|---|---|---|
| `q[]=last_name:~term` (single token) / `q[]=first_name:~A&q[]=last_name:~B` (multi) | `q=value` | ✅ matches |
| `addingPercentEncoding` on user input only | URLComponents-default | URLComponents-default (sufficient for typical names — see "Open question" below) |
| `User-Agent` includes contact email | URL-only UA | **Deferred** — auth probe passes today, hardening only |
| Pagination via `links.next` | Decoded but not followed | **Deferred** — picker renders first page; sufficient for typical clinic sizes |

## AC checklist (from #101)

- [x] **Reproduce + capture status structurally** — root cause confirmed via reference diff; status logged at `ClinikoClient.runAttempt` per `phi-handling.md` (status code only, no body).
- [x] **Smallest surgical change** — single helper rewrite in `ClinikoEndpoint`; doc'd alongside.
- [x] **5xx transient/permanent split** — *not needed*. Once the request shape is correct, Cliniko returns 2xx for valid queries; the existing 5xx → `.server(status:)` mapping is correct (5xx is genuinely transient on a real outage). Re-evaluate if real Cliniko traffic shows otherwise.
- [x] **`URLProtocolStub` test matrix**: 200 results, 200 empty, 401, 403, 404, 429 (Retry-After), 5xx (after retries), malformed JSON, cancellation, **and** the new no-network empty-query guard (12 tests in `ClinikoPatientServiceTests`).
- [ ] **Latency measurement** — not measured in this PR (no real Cliniko in CI / dev container). Existing optimisations: 300 ms keystroke debounce in `PatientPickerViewModel.updateQuery(_:)`, in-flight `searchTask?.cancel()` between keystrokes, and now a service-layer empty-query short-circuit. **Action**: please verify round-trip against your tenant before merge; if it's still "a bit slow" we'll open a follow-up issue (candidates: smaller `per_page`, parallel first-page-while-paginating, picker-side debounce tuning).
- [x] **PHI rule** — no logs touched; `pathTemplate` updated to `"/patients?q[]={filter}"` (placeholder, no bound term); fixtures use synthetic data; no PHI in test assertions.

## Pre-PR review pipeline

Per [AGENTS.md §"Subagents & code review"](https://github.com/CloudbrokerAz/mac-speech-to-text/blob/main/AGENTS.md):

- **`pr-review-toolkit:code-reviewer` (opus)** — green light. No blockers. Confirmed URL-encoding correctness via Foundation probe; PHI hygiene clean; AC matrix covered.
- **`pr-review-toolkit:silent-failure-hunter` (opus)** — caught a P1: empty/whitespace query at `ClinikoPatientService` boundary would have silently issued an unfiltered `GET /v1/patients` (Cliniko serves the **entire patient list** — silent PHI exfiltration). The picker VM short-circuits empty input today, but a future caller (export retry, re-search after auth refresh) would have hit it. **Folded the fix into commit `8c896db`**: service-layer guard returns `[]` before issuing the request; endpoint also collapses `[]` queryItems to `nil` for clean URL shape.

## Commits

- `f62db56` source fix + endpoint test updates
- `43352dc` patient-service test additions (q[] shape, 429, malformed JSON)
- `b8afb4f` case-doc + fixture self-link cleanup
- `8c896db` P1: empty-query list-all guard + URL hygiene (post-review)

## Test plan

- [x] `swift test --filter ClinikoEndpointTests/` — 15/15 pass
- [x] `swift test --filter ClinikoPatientServiceTests/` — 12/12 pass
- [x] `swift test --filter ClinikoClientTests/` — 27/27 pass (no regression in shared layer)
- [x] `swiftlint --strict` clean on all changed files
- [x] `pre-commit run --files <changed>` clean
- [ ] Manual smoke: open the picker, type a single surname → expect results (not "server error")
- [ ] Manual smoke: type a "First Last" → expect results
- [ ] Manual smoke: clear the field → expect picker resets to idle, no network spinner
🤖 Generated with [Claude Code](https://claude.com/claude-code)