### PR TITLE
ci: skip Build Release job on PRs (only run on push to main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,14 @@ jobs:
     name: Build Release
     runs-on: macos-15
     needs: test
+    # Skip on PRs — `test` already runs `swift build -c release` (line 151),
+    # so `Build Release` only adds value when we actually want to publish a
+    # downloadable release-build artifact. That use case is a `push: main` /
+    # `workflow_dispatch` operation, not a per-PR gate. Saves ~4 min per PR
+    # run (~33% of total CI wall-clock) and stops generating ~140
+    # release-build artifacts a month that nobody downloads. PR runs still
+    # get full lint + pre-commit + Build and Test gates.
+    if: github.event_name != 'pull_request'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Skip `Build Release` job on PR runs by gating with `if: github.event_name != 'pull_request'`.
- Saves ~4 min per PR run (~33% of total CI wall-clock — last 10 main runs averaged 12 min, of which Build Release was ~4 min).
- Stops generating ~140 release-build artifacts a month that nobody downloads from PRs.

## Why this is safe

- `Build Release` was a strict subset of `Build and Test`'s work. The `test` job runs the same `swift build -c release` at `ci.yml:151` before running tests against it. Skipping the standalone `build` job on PRs doesn't lose any compile-time coverage.
- PRs still gate on **SwiftLint + pre-commit + Build and Test** (which itself runs `swift build -c release` + `swift test --parallel --enable-code-coverage`). Same correctness signal as before.
- `Build Release` keeps running on `push: main` and `workflow_dispatch` — the legitimate publishing surfaces where the downloadable `release-build` artifact actually matters.

## Numbers (from PR #110's CI run)

| Job | Duration | Now runs on PRs? |
|---|---|---|
| SwiftLint | 24s | yes |
| pre-commit | 35s (parallel) | yes |
| Build and Test | 7m 0s | yes |
| Build Release | 4m 5s | **no** (skipped on PR) |

PR CI: ~12 min → ~8 min. Main CI: unchanged.

## Test plan

- [ ] CI green on this PR. The `Build Release` check should now show as `skipped` (or not run at all) rather than `pass`.
- [ ] After merge, verify the post-merge `main` CI run still includes `Build Release` and uploads the `release-build` artifact (`gh run list --branch main --limit 1`).

## Companion cleanup

A one-shot deletion of the 137 stale `release-build` artifacts is being run alongside this PR (purely cosmetic — public repo, Actions storage is free). The 5 most recent artifacts are retained for any in-flight debugging needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)