### PR TITLE
chore(concurrency): clear remaining [#SendingRisksDataRace] warnings (#83)

### DIFF
--- a/Sources/Services/VoiceTriggerMonitoringService.swift
+++ b/Sources/Services/VoiceTriggerMonitoringService.swift
@@ -178,12 +178,50 @@ final class VoiceTriggerMonitoringService {
 
             // Start audio capture for wake word processing
             // Pass both level callback (for visualization) and buffer callback (for wake word detection)
+            //
+            // Capture `serviceId` into a local so the audio-thread closure can interpolate it into
+            // the unsupported-format warning without reaching back across the @MainActor boundary
+            // for `self.serviceId`. Mirrors the `processorId` capture in AudioBufferProcessor.
+            let capturedServiceId = serviceId
             try await audioService.startCapture(
                 levelCallback: { @Sendable [weak self] level in
                     Task { @MainActor in self?.handleAudioLevel(level) }
                 },
                 bufferCallback: { @Sendable [weak self] buffer in
-                    Task { @MainActor in self?.handleAudioBuffer(buffer) }
+                    // Extract Sendable values on the audio thread before crossing into MainActor.
+                    // AVAudioPCMBuffer is non-Sendable; mirrors AudioBufferProcessor.process
+                    // (see AudioCaptureService.swift) and .claude/references/concurrency.md §3.
+                    //
+                    // Precision note: when the buffer arrives in floatChannelData form, the
+                    // wake-word path used to consume raw Float samples directly; it now goes
+                    // Float→Int16→Float (clamp ±1.0, ×Int16.max, ÷32768). Sherpa-onnx quantises
+                    // internally so the ~16-bit fidelity loss is benign in practice, and the
+                    // capture path was already Int16-quantising. Issue #83 explicitly required
+                    // reusing the AudioBufferProcessor pattern rather than inventing a new one.
+                    let frameLength = Int(buffer.frameLength)
+                    let sampleRate = buffer.format.sampleRate
+                    let samples: [Int16]
+                    if let floatData = buffer.floatChannelData {
+                        let floatSamples = UnsafeBufferPointer(start: floatData[0], count: frameLength)
+                        samples = floatSamples.map { sample in
+                            let clamped = max(-1.0, min(1.0, sample))
+                            return Int16(clamped * Float(Int16.max))
+                        }
+                    } else if let int16Data = buffer.int16ChannelData {
+                        samples = Array(UnsafeBufferPointer(start: int16Data[0], count: frameLength))
+                    } else {
+                        // Surface the dropped frame the same way AudioBufferProcessor.process does
+                        // (see AudioCaptureService.swift:71). Format value is structural metadata,
+                        // not PHI, so logging is safe; OSLog is thread-safe so we don't need a hop.
+                        AppLogger.warning(
+                            AppLogger.service,
+                            "[\(capturedServiceId)] Unsupported audio format in buffer — frame dropped"
+                        )
+                        return
+                    }
+                    Task { @MainActor in
+                        self?.handleAudioBuffer(samples: samples, sampleRate: sampleRate)
+                    }
                 }
             )
 
@@ -242,18 +280,22 @@ final class VoiceTriggerMonitoringService {
         AppLogger.debug(AppLogger.service, "[\(serviceId)] Voice trigger monitoring stopped")
     }
 
-    /// Handle incoming audio buffer
+    /// Handle incoming audio samples
     ///
     /// Routes audio data to the appropriate handler based on current state:
     /// - In monitoring mode: Sends to wake word service for keyword detection
     /// - In capturing mode: Accumulates samples for transcription
     ///
     /// Note: This method is already called from a MainActor Task dispatch in the audio callback.
-    /// We only use Task for the async wake word processing, not for the outer dispatch.
+    /// The non-Sendable `AVAudioPCMBuffer` is converted to `[Int16]` on the audio thread before
+    /// hopping into MainActor — see the `bufferCallback` closure in `startMonitoring()` and
+    /// `.claude/references/concurrency.md` §3.
     ///
-    /// - Parameter buffer: Audio buffer from capture service
+    /// - Parameters:
+    ///   - samples: Audio samples already extracted from the buffer on the audio thread
+    ///   - sampleRate: Native sample rate the buffer arrived at, in Hz
     private var audioBufferCount = 0
-    func handleAudioBuffer(_ buffer: AVAudioPCMBuffer) {
+    func handleAudioBuffer(samples: [Int16], sampleRate: Double) {
         audioBufferCount += 1
         if audioBufferCount % 100 == 1 {
             AppLogger.trace(AppLogger.service, "[\(serviceId)] handleAudioBuffer called \(audioBufferCount) times, state=\(state.description)")
@@ -261,8 +303,8 @@ final class VoiceTriggerMonitoringService {
         // Already on MainActor via caller's Task dispatch - no need for another Task wrapper
         switch self.state {
         case .monitoring:
-            // Convert buffer to Float samples for wake word detection
-            let floatSamples = self.convertBufferToFloatSamples(buffer)
+            // Convert Int16 samples to Float (resampled to 16 kHz) for wake-word detection
+            let floatSamples = self.convertInt16SamplesToFloat(samples, sourceRate: sampleRate)
             guard !floatSamples.isEmpty else { return }
 
             if audioBufferCount % 100 == 1 {
@@ -280,7 +322,7 @@ final class VoiceTriggerMonitoringService {
 
         case .capturing:
             // Accumulate samples for transcription
-            self.accumulateSamples(from: buffer)
+            self.accumulateSamples(samples, sampleRate: sampleRate)
 
         default:
             // Ignore audio in other states
@@ -288,35 +330,22 @@ final class VoiceTriggerMonitoringService {
         }
     }
 
-    /// Convert AVAudioPCMBuffer to Float samples normalized to [-1.0, 1.0] at 16kHz
+    /// Convert Int16 audio samples to Float samples normalized to [-1.0, 1.0] at 16kHz
     ///
-    /// This method converts audio from native hardware sample rate to the 16kHz rate
-    /// expected by sherpa-onnx keyword spotting.
+    /// Wake-word detection (sherpa-onnx keyword spotting) requires Float samples at exactly
+    /// 16 kHz. Resampling uses simple linear interpolation via `resampleToTarget`.
     ///
-    /// - Parameter buffer: Audio buffer to convert (at native sample rate)
+    /// - Parameters:
+    ///   - samples: Int16 samples extracted from the audio buffer on the audio thread
+    ///   - sourceRate: Native sample rate of the samples in Hz (e.g. 48000)
     /// - Returns: Float samples at 16kHz suitable for wake word processing
-    private func convertBufferToFloatSamples(_ buffer: AVAudioPCMBuffer) -> [Float] {
-        let frameLength = Int(buffer.frameLength)
-        let nativeSampleRate = buffer.format.sampleRate
+    private func convertInt16SamplesToFloat(_ samples: [Int16], sourceRate: Double) -> [Float] {
         let targetSampleRate = Double(Constants.VoiceTrigger.sampleRate)
-
-        // First convert to float samples at native rate
-        var floatSamples: [Float]
-        if let floatData = buffer.floatChannelData {
-            // Already float format
-            floatSamples = Array(UnsafeBufferPointer(start: floatData[0], count: frameLength))
-        } else if let int16Data = buffer.int16ChannelData {
-            // Convert Int16 to Float [-1.0, 1.0]
-            let int16Samples = UnsafeBufferPointer(start: int16Data[0], count: frameLength)
-            floatSamples = int16Samples.map { Float($0) / 32768.0 }
-        } else {
-            return []
-        }
+        var floatSamples = samples.map { Float($0) / 32768.0 }
 
         // Resample to 16kHz if native rate differs
-        // sherpa-onnx keyword spotting requires exactly 16kHz audio
-        if abs(nativeSampleRate - targetSampleRate) > 1.0 {
-            floatSamples = resampleToTarget(floatSamples, from: nativeSampleRate, to: targetSampleRate)
+        if abs(sourceRate - targetSampleRate) > 1.0 {
+            floatSamples = resampleToTarget(floatSamples, from: sourceRate, to: targetSampleRate)
         }
 
         return floatSamples
@@ -409,28 +438,12 @@ final class VoiceTriggerMonitoringService {
     }
 
     /// Accumulate audio samples during capture phase
-    private func accumulateSamples(from buffer: AVAudioPCMBuffer) {
-        let frameLength = Int(buffer.frameLength)
-
-        // Convert buffer to Int16 samples
-        let samples: [Int16]
-        if let floatData = buffer.floatChannelData {
-            let floatSamples = UnsafeBufferPointer(start: floatData[0], count: frameLength)
-            samples = floatSamples.map { sample in
-                let clamped = max(-1.0, min(1.0, sample))
-                return Int16(clamped * Float(Int16.max))
-            }
-        } else if let int16Data = buffer.int16ChannelData {
-            samples = Array(UnsafeBufferPointer(start: int16Data[0], count: frameLength))
-        } else {
-            AppLogger.warning(AppLogger.service, "[\(serviceId)] Unsupported audio format in buffer")
-            return
-        }
-
+    ///
+    /// Samples are already in Int16 form (extracted from `AVAudioPCMBuffer` on the audio thread
+    /// — see the `bufferCallback` closure in `startMonitoring()`).
+    private func accumulateSamples(_ samples: [Int16], sampleRate: Double) {
         capturedSamples.append(contentsOf: samples)
-
-        // Store sample rate from buffer format
-        capturedSampleRate = buffer.format.sampleRate
+        capturedSampleRate = sampleRate
 
         AppLogger.trace(
             AppLogger.service,

--- a/Sources/Views/WelcomeViewModel.swift
+++ b/Sources/Views/WelcomeViewModel.swift
@@ -319,18 +319,34 @@ final class WelcomeViewModel {
         let currentPhrase = samplePhrases[currentPhraseIndex]
         let totalChars = currentPhrase.count
 
-        // Type one character every 30ms for a natural typing feel
+        // Type one character every 30ms for a natural typing feel.
+        //
+        // The block is pinned to RunLoop.main because this method is
+        // @MainActor-isolated and Timer.scheduledTimer schedules on the current
+        // run loop. Two-step pattern:
+        //   1. Invalidate the captured non-Sendable `timer` parameter directly
+        //      from the @Sendable closure body when self has gone away — no
+        //      isolation crossed. Mirrors the early-return guard in
+        //      `RecordingViewModel.startInactivityTimer`.
+        //   2. For the "typing finished" branch, invalidate via the stored
+        //      MainActor property `self.typingTimer` (identity-equal to the
+        //      captured `timer`) so the parameter never crosses into the
+        //      MainActor.assumeIsolated block. Using `assumeIsolated` here
+        //      rather than a Task hop keeps the synchronous tick semantics —
+        //      a 30ms typing animation can't afford run-loop reorderings.
+        //      See `.claude/references/concurrency.md` §2.
         let timer = Timer.scheduledTimer(withTimeInterval: 0.03, repeats: true) { [weak self] timer in
-            Task { @MainActor [weak self] in
-                guard let self = self else {
-                    timer.invalidate()
-                    return
-                }
-
+            guard let self = self else {
+                timer.invalidate()
+                return
+            }
+            MainActor.assumeIsolated {
                 if self.displayedCharacterCount < totalChars {
                     self.displayedCharacterCount += 1
                 } else {
-                    timer.invalidate()
+                    self.typingTimer?.invalidate()
+                    self.typingTimer = nil
+                    self.deinitTypingTimer = nil
                 }
             }
         }

--- a/Tests/SpeechToTextTests/Views/WelcomeViewModelTypingAnimationTests.swift
+++ b/Tests/SpeechToTextTests/Views/WelcomeViewModelTypingAnimationTests.swift
@@ -1,0 +1,105 @@
+// WelcomeViewModelTypingAnimationTests.swift
+// macOS Local Speech-to-Text Application
+//
+// Pure-logic + lifecycle tests for the typing animation surface in
+// `WelcomeViewModel`. Companion to issue #83 — verifies the
+// `MainActor.assumeIsolated` codepath instantiates, ticks, and tears down
+// without crashing. The Sendable-warning fix itself is enforced at compile
+// time + by the `swift build -c release` zero-warning gate; these tests
+// provide a runtime regression backstop on the public surface area.
+//
+// Swift Testing per `.claude/CLAUDE.md` operating rule #2 (new pure-logic /
+// async tests use Swift Testing). Tagged `.fast` so they run on every CI PR.
+
+import Foundation
+import Testing
+@testable import SpeechToText
+
+@Suite("WelcomeViewModel typing animation surface", .tags(.fast))
+@MainActor
+struct WelcomeViewModelTypingAnimationTests {
+    // MARK: - displayedText (pure logic)
+
+    @Test("displayedText returns empty string when no characters typed yet")
+    func displayedText_isEmpty_whenCharacterCountIsZero() {
+        let viewModel = makeViewModel()
+        viewModel.currentPhraseIndex = 0
+        viewModel.displayedCharacterCount = 0
+
+        #expect(viewModel.displayedText == "")
+    }
+
+    @Test("displayedText returns full phrase when character count saturates")
+    func displayedText_isFullPhrase_whenCharacterCountAtMax() {
+        let viewModel = makeViewModel()
+        viewModel.currentPhraseIndex = 0
+        let phrase = viewModel.samplePhrases[0]
+        viewModel.displayedCharacterCount = phrase.count
+
+        #expect(viewModel.displayedText == phrase)
+    }
+
+    @Test("displayedText clamps at phrase length when count overshoots")
+    func displayedText_clamps_whenCharacterCountExceedsPhrase() {
+        let viewModel = makeViewModel()
+        viewModel.currentPhraseIndex = 0
+        let phrase = viewModel.samplePhrases[0]
+        viewModel.displayedCharacterCount = phrase.count + 1000
+
+        #expect(viewModel.displayedText == phrase)
+    }
+
+    @Test(
+        "displayedText returns the leading prefix at every character count",
+        arguments: 0...20
+    )
+    func displayedText_isPrefix_acrossCharacterCounts(count: Int) {
+        let viewModel = makeViewModel()
+        viewModel.currentPhraseIndex = 0
+        viewModel.displayedCharacterCount = count
+
+        let phrase = viewModel.samplePhrases[0]
+        let expected = String(phrase.prefix(count))
+        #expect(viewModel.displayedText == expected)
+    }
+
+    // MARK: - Animation lifecycle (regression backstop for #83)
+
+    /// Render-crash + tick test for the `MainActor.assumeIsolated` codepath
+    /// introduced by issue #83. If the new Timer block ever regresses to a
+    /// shape that crosses an isolation boundary unsafely, this test surfaces
+    /// it as a trap or a hung counter rather than a silent compile-time
+    /// warning. Real `Timer.scheduledTimer` ticks at 30 ms, so we wait long
+    /// enough for at least a couple of fires.
+    @Test("startPhraseAnimation advances displayed character count and stops cleanly")
+    func startPhraseAnimation_advancesAndStops_withoutCrash() async throws {
+        let viewModel = makeViewModel()
+
+        viewModel.startPhraseAnimation()
+        // Three ticks at 30ms each, plus a small slop margin for run-loop scheduling.
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        let countAfterTicking = viewModel.displayedCharacterCount
+        viewModel.stopPhraseAnimation()
+
+        // The closure incremented at least once, observable on the public surface.
+        #expect(countAfterTicking > 0)
+
+        // After stop, no further ticks should be in flight; sleep again and
+        // confirm the counter is stable. (If the timer survived stop, the
+        // count would keep climbing.)
+        try await Task.sleep(nanoseconds: 100_000_000)
+        #expect(viewModel.displayedCharacterCount == countAfterTicking)
+    }
+
+    // MARK: - Helpers
+
+    private func makeViewModel() -> WelcomeViewModel {
+        WelcomeViewModel(
+            permissionService: MockPermissionService(),
+            settingsService: SettingsService(
+                userDefaults: UserDefaults(suiteName: "test.welcome.\(UUID().uuidString)") ?? .standard
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Clears the two remaining `[#SendingRisksDataRace]` warnings flagged by `swift build -c release` after #40d. Both follow the patterns canonicalised in `.claude/references/concurrency.md` and the existing call sites it points at.

- **`VoiceTriggerMonitoringService.swift:186`** — `bufferCallback` extracts Sendable `[Int16]` samples + sample rate from the non-Sendable `AVAudioPCMBuffer` inside the `@Sendable` audio-thread closure *before* the `Task { @MainActor in }` hop. Mirrors [`AudioBufferProcessor.process`](https://github.com/CloudbrokerAz/mac-speech-to-text/blob/main/Sources/Services/AudioCaptureService.swift#L49-L73) verbatim per the issue's "do not invent a new pattern" guidance. `handleAudioBuffer` signature changes to `(samples: [Int16], sampleRate: Double)`; `convertBufferToFloatSamples` → `convertInt16SamplesToFloat`; `accumulateSamples(from:)` → `accumulateSamples(_:sampleRate:)`. The unsupported-format branch logs a warning that matches the reference at `AudioCaptureService.swift:71`.
  - **Behaviour change worth flagging**: when the buffer arrives in `floatChannelData` form, the wake-word path now does Float→Int16→Float (was Float direct). Sherpa-onnx quantises internally so the ~16-bit fidelity loss is benign in practice, and the capture path was already Int16-quantising. Documented inline. Real-hardware wake-word smoke is the regression backstop the issue calls for — `./scripts/smoke-test.sh` once we have a release candidate.

- **`WelcomeViewModel.swift:326`** — typing-animation `Timer` block replaces the `Task { @MainActor [weak self] in }` hop with `MainActor.assumeIsolated { }` for the synchronous tick body. The captured non-Sendable `timer` parameter is invalidated only in the `@Sendable` closure's `guard let self else` early-return (no isolation crossed); the "typing finished" branch invalidates via `self.typingTimer` (identity-equal to the captured `timer`, but reached through MainActor-isolated state). Mirrors the early-return guard from `RecordingViewModel.startInactivityTimer`.

## Test plan

- [x] `swift build -c release` — zero `[#SendingRisksDataRace]` warnings from `Sources/` (was 2 before).
- [x] `swift test --parallel` — 380 tests pass (5 new in `WelcomeViewModelTypingAnimationTests`).
- [x] `swiftlint lint --strict` on changed files — 0 violations.
- [x] `pre-commit run --files <changed>` — all hooks pass.
- [x] Pre-PR Opus review (`pr-review-toolkit:code-reviewer` + `pr-review-toolkit:silent-failure-hunter`) per the three-layer review pipeline in `AGENTS.md`. Feedback folded:
  - Restored unsupported-audio-format warning (silent-failure-hunter, confidence 82) by capturing `serviceId` into a local before the closure and matching `AudioBufferProcessor.process`'s log site.
  - Documented Float→Int16→Float wake-word fidelity trade-off inline (code-reviewer, confidence 85). Verification on hardware to follow before release.
  - Tightened the `MainActor.assumeIsolated` doc comment in `WelcomeViewModel` to accurately describe what's mirrored.
- [ ] Real-hardware smoke: voice-trigger wake-word still detects + captures (`./scripts/smoke-test.sh`).
- [ ] Real-hardware smoke: welcome-screen typing animation cycles cleanly through the four sample phrases.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)