### PR TITLE
chore(scripts): LLM hardware-eval CLI tooling (#75)

### DIFF
--- a/.claude/references/mlx-lifecycle.md
+++ b/.claude/references/mlx-lifecycle.md
@@ -157,6 +157,59 @@ Per #5 acceptance:
 
 ---
 
+## Hardware testing
+
+`MLXGemmaProviderGoldenTests`
+(`Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift`) is the
+real-inference suite — gated on `RUN_MLX_GOLDEN=1` and tagged
+`.requiresHardware` so CI's macOS-15 path skips it. It runs on the
+remote Mac (pre-push or nightly) and locally during dev. Three CLI
+helpers under `scripts/` round out the gap that surfaced during the
+v2 cutover (#75) — they avoid the "launch the .app or hand-curate a
+directory" dance every time someone wants to run a golden pass.
+
+| Script | Purpose |
+|---|---|
+| [`scripts/llm-prefetch.sh`](../../scripts/llm-prefetch.sh) | Populate the model directory from `Sources/Resources/Models/<dir>/manifest.json`. Mirrors `ModelDownloader.swift`'s size-check + sha256-verify + atomic `<file>.partial` rename. Idempotent — re-runs are no-ops once every file matches. Honours `MLX_GEMMA_DIR` (full-path override) and `MAC_STT_BUNDLE_ID`. |
+| [`scripts/llm-eval.sh`](../../scripts/llm-eval.sh) | Calls `llm-prefetch.sh`, exports `RUN_MLX_GOLDEN=1`, runs `swift test --filter MLXGemmaProviderGoldenTests`, and reports wall time + peak resident memory via `/usr/bin/time -l`. `--release` and `--no-parallel` mirror `swift test` flags. |
+| [`scripts/llm-reset.sh`](../../scripts/llm-reset.sh) | Removes the on-disk model directory so the next prefetch / first-run starts clean. Interactive by default — prints every path with `du -sh` size before the y/N. `--yes` for scripted use; `--dry-run` for inspection; `--legacy` to also drop the v1 `gemma-3-text-4b-it-4bit/` if it survives outside the .app's auto-purge. |
+
+### Bundle id divergence
+
+`Bundle.main.bundleIdentifier` is `com.speechtotext.app` when the .app
+runs (per `Info.plist` from `scripts/build-app.sh`) and falls back to
+`com.cloudbroker.mac-speech-to-text` when invoked from `swift test` /
+`swift run` (because the test runner's bundle id wins, then the actor's
+fallback at `ModelDownloader.swift:105/116` kicks in). The two paths
+therefore use different `Application Support/<id>/Models/`
+directories. The scripts default to the **test** path so a golden pass
+works out of the box; pass `--bundle-id com.speechtotext.app` (or set
+`MAC_STT_BUNDLE_ID`) when you want the .app's directory instead. A
+bare `llm-reset.sh` clears both.
+
+### Workflow
+
+```bash
+# Clean run from scratch
+./scripts/llm-reset.sh --yes
+./scripts/llm-eval.sh                     # prefetch + golden tests
+
+# Iterate against an existing model (skip the prefetch round-trip)
+./scripts/llm-eval.sh --skip-prefetch
+
+# Point at a model living elsewhere (e.g. mirror / shared volume)
+./scripts/llm-prefetch.sh --dest /Volumes/llm-cache/gemma-4-e4b-it-4bit
+MLX_GEMMA_DIR=/Volumes/llm-cache/gemma-4-e4b-it-4bit \
+  ./scripts/llm-eval.sh --skip-prefetch
+```
+
+Per-token latency, deterministic-generation parity, and warmup-time
+budgets are surfaced inside the test's own `#expect` blocks — the
+script's role is only to wrap the env + IO concerns and report
+wall-time / RSS at the seam.
+
+---
+
 ## Privacy
 
 - The LLM is in-process; no weights or prompts leave the device.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,12 @@ pre-commit run --files <specific-file>         # scoped
 ./scripts/build-app.sh --sync                  # rsync to remote Mac
 ./scripts/run-ui-tests.sh
 
+# LLM hardware-eval (golden tests, gated on RUN_MLX_GOLDEN=1)
+./scripts/llm-prefetch.sh                      # populate model dir from manifest
+./scripts/llm-eval.sh                          # prefetch + run golden tests + RSS
+./scripts/llm-reset.sh --dry-run               # inspect what would be wiped
+./scripts/llm-reset.sh --yes                   # clean re-download for first-run UX
+
 # GitHub
 gh issue list --state open --label epic
 gh issue view <N> --comments

--- a/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
+++ b/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
@@ -424,35 +424,53 @@ struct ModelDownloaderTests {
         #expect(size == 0)
     }
 
-    @Test("waitForFileBytes returns the file's freshly-stat'd size at the deadline (no stale lastSize)")
-    func waitForFileBytes_returnsFreshSizeAtDeadline() async throws {
+    @Test("waitForFileBytes observes a writer that lands during the wait (no stale lastSize)")
+    func waitForFileBytes_observesWriterDuringWait() async throws {
         let base = try Self.makeTempBase()
         defer { try? FileManager.default.removeItem(at: base) }
         let file = base.appendingPathComponent("late-grower.bin")
         try Data().write(to: file)
 
-        // Schedule a writer that fires close to the helper's deadline.
         // The pre-Gemini shape returned `lastSize` recorded *before* the
-        // final sleep — so a writer that landed during the sleep was
+        // final sleep, so a writer that landed during the sleep was
         // invisible. The post-Gemini stat-then-check shape always sees
-        // the freshly-stat'd size, even at the deadline. We assert "the
-        // helper returned the file's actual on-disk size at exit",
-        // which is true under the new shape regardless of whether the
-        // writer landed in time, and would FAIL deterministically on
-        // the old shape if scheduling lined up.
+        // the freshly-stat'd size when the loop next iterates.
+        //
+        // **#115 fix.** The previous shape raced a 95 ms writer against
+        // a 100 ms timeout: under macOS-15 runner load the writer
+        // sometimes landed in the gap between the helper returning 0
+        // and the test stat'ing the file (observed `size → 0` /
+        // `actualSize → 4`). The race was inherent to measuring the
+        // writer's effect *after* the helper exited.
+        //
+        // New shape: schedule the writer well inside a generous timeout
+        // so the helper's `size >= expectedBytes` early-exit branch
+        // fires, then `await` the writer task before stat'ing so the
+        // post-helper stat is deterministic. This still catches a stale
+        // lastSize regression — if the helper returned a cached 0 when
+        // the writer had clearly landed, `size != actualSize` and
+        // `size != payload.count` both fail.
         let payload = Self.helloPayload
         let target = file
-        Task.detached {
-            try? await Task.sleep(for: .milliseconds(95))
+        let writer: Task<Void, Never> = Task.detached {
+            try? await Task.sleep(for: .milliseconds(50))
             try? payload.write(to: target)
         }
 
         let size = try await ModelDownloader.waitForFileBytes(
             at: file,
             expectedBytes: Int64(payload.count),
-            timeoutSeconds: 0.1
+            timeoutSeconds: 1.0
         )
+
+        // Drain the writer so the post-helper stat is stable regardless
+        // of when the helper returned. Without this `await`, the test
+        // could re-introduce the same race the new shape fixed (writer
+        // task fires between helper exit and test stat).
+        await writer.value
+
         let actualSize = (try FileManager.default.attributesOfItem(atPath: file.path)[.size] as? Int64) ?? -1
+        #expect(size == Int64(payload.count))
         #expect(size == actualSize)
     }
 

--- a/scripts/llm-eval.sh
+++ b/scripts/llm-eval.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# =============================================================================
+# llm-eval.sh
+# =============================================================================
+# Run the hardware-gated MLXGemmaProviderGoldenTests end-to-end on
+# M-series Apple Silicon. Calls llm-prefetch.sh first to ensure the
+# model directory is present, then runs the gated suite with timing +
+# peak-RSS instrumentation via /usr/bin/time.
+#
+# Usage: ./scripts/llm-eval.sh [options]
+#
+# Options:
+#   --dest <path>       Forward to llm-prefetch.sh (override model directory).
+#                       Equivalent to MLX_GEMMA_DIR.
+#   --bundle-id <id>    Forward to llm-prefetch.sh (override bundle id used
+#                       for Application-Support layout).
+#   --skip-prefetch     Skip the prefetch step (assume model already present).
+#                       Useful when the model lives at a custom location
+#                       managed outside this script.
+#   --filter <name>     Test filter passed to swift test --filter
+#                       (default: MLXGemmaProviderGoldenTests)
+#   --release           Run tests in release configuration (faster MLX
+#                       inference; also exposes any release-only build issue).
+#   --no-parallel       Drop --parallel from swift test invocation.
+#                       Default keeps it for parity with `swift test --parallel`.
+#   --help              Show this help message
+#
+# Environment:
+#   MLX_GEMMA_DIR       Same as --dest. Forwarded to swift test.
+#   MAC_STT_BUNDLE_ID   Same as --bundle-id. Forwarded to llm-prefetch.
+#   RUN_MLX_GOLDEN      Force-set to 1 by this script. Required by the
+#                       MLXGemmaProviderGoldenTests gate.
+#
+# Exit codes:
+#   0  golden tests passed
+#   1  prefetch failure
+#   2  test failure
+#   3  not on macOS / Apple Silicon
+#
+# Notes:
+#   - Wall-clock + peak resident memory are reported via /usr/bin/time -l.
+#     Per-token latency is surfaced inside the test's own #expect block;
+#     #18 acceptance for "before/after benchmarks" lives there.
+#   - Tests are tagged .requiresHardware, so this script is for local
+#     hardware runs or the nightly remote-Mac job — not the default
+#     CI path.
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration
+# =============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "${SCRIPT_DIR}")"
+
+# Terminal colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+# Defaults
+DEST_OVERRIDE="${MLX_GEMMA_DIR:-}"
+BUNDLE_ID_OVERRIDE="${MAC_STT_BUNDLE_ID:-}"
+SKIP_PREFETCH=false
+TEST_FILTER="MLXGemmaProviderGoldenTests"
+BUILD_CONFIG="debug"
+USE_PARALLEL=true
+
+# =============================================================================
+# Output helpers
+# =============================================================================
+
+print_header() {
+    echo -e "\n${BLUE}============================================================================${NC}"
+    echo -e "${BOLD}${CYAN}  $1${NC}"
+    echo -e "${BLUE}============================================================================${NC}\n"
+}
+
+print_info() {
+    echo -e "${CYAN}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1" >&2
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+show_help() {
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+    exit 0
+}
+
+# =============================================================================
+# Platform check
+# =============================================================================
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    print_error "llm-eval.sh requires macOS (MLX is Apple-Silicon-only)"
+    exit 3
+fi
+
+if [[ "$(uname -m)" != "arm64" ]]; then
+    print_warning "host is not arm64 (uname -m = $(uname -m)); MLX inference will not run"
+fi
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dest)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--dest requires a path"; exit 1; }
+            DEST_OVERRIDE="$2"
+            shift 2
+            ;;
+        --bundle-id)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--bundle-id requires a value"; exit 1; }
+            BUNDLE_ID_OVERRIDE="$2"
+            shift 2
+            ;;
+        --skip-prefetch)
+            SKIP_PREFETCH=true
+            shift
+            ;;
+        --filter)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--filter requires a value"; exit 1; }
+            TEST_FILTER="$2"
+            shift 2
+            ;;
+        --release)
+            BUILD_CONFIG="release"
+            shift
+            ;;
+        --no-parallel)
+            USE_PARALLEL=false
+            shift
+            ;;
+        --help|-h)
+            show_help
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            echo "Use --help for usage information" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# =============================================================================
+# Prefetch
+# =============================================================================
+
+cd "${PROJECT_ROOT}"
+
+if [ "${SKIP_PREFETCH}" = true ]; then
+    print_info "Skipping prefetch (--skip-prefetch)"
+else
+    print_header "Prefetching Gemma 4 weights"
+    # Build args incrementally. macOS `/bin/bash` 3.2 errors under `set -u`
+    # when expanding an empty array via "${arr[@]}", so we length-guard the
+    # invocation rather than relying on `${arr[@]+…}` syntax (which works
+    # but reads as a workaround on every call site).
+    PREFETCH_ARGS=()
+    [ -n "${DEST_OVERRIDE}" ] && PREFETCH_ARGS+=("--dest" "${DEST_OVERRIDE}")
+    [ -n "${BUNDLE_ID_OVERRIDE}" ] && PREFETCH_ARGS+=("--bundle-id" "${BUNDLE_ID_OVERRIDE}")
+    if [ ${#PREFETCH_ARGS[@]} -gt 0 ]; then
+        "${SCRIPT_DIR}/llm-prefetch.sh" "${PREFETCH_ARGS[@]}" || { print_error "Prefetch failed"; exit 1; }
+    else
+        "${SCRIPT_DIR}/llm-prefetch.sh" || { print_error "Prefetch failed"; exit 1; }
+    fi
+fi
+
+# =============================================================================
+# Environment for swift test
+# =============================================================================
+# RUN_MLX_GOLDEN=1 unlocks the @Suite gate in MLXGemmaProviderGoldenTests
+# (Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift:148-150).
+# MLX_GEMMA_DIR (when --dest is set) overrides the default
+# Application-Support lookup at line 153.
+
+export RUN_MLX_GOLDEN=1
+if [ -n "${DEST_OVERRIDE}" ]; then
+    export MLX_GEMMA_DIR="${DEST_OVERRIDE}"
+fi
+
+print_header "Running ${TEST_FILTER}"
+print_info "RUN_MLX_GOLDEN=1"
+[ -n "${MLX_GEMMA_DIR:-}" ] && print_info "MLX_GEMMA_DIR=${MLX_GEMMA_DIR}"
+print_info "Configuration: ${BUILD_CONFIG}"
+
+# =============================================================================
+# swift test invocation, wrapped in /usr/bin/time -l for peak RSS
+# =============================================================================
+# /usr/bin/time -l is the BSD time on macOS; trailing block includes
+# `maximum resident set size` in bytes plus user/sys/wall seconds.
+# Output goes to stderr — we tee it to a log file for easy inspection.
+
+LOG_DIR="${PROJECT_ROOT}/build/llm-eval"
+mkdir -p "${LOG_DIR}"
+TIME_LOG="${LOG_DIR}/eval-$(date +%Y%m%d-%H%M%S).log"
+
+SWIFT_TEST_ARGS=("test" "--filter" "${TEST_FILTER}")
+if [ "${USE_PARALLEL}" = true ]; then
+    SWIFT_TEST_ARGS+=("--parallel")
+fi
+if [ "${BUILD_CONFIG}" = "release" ]; then
+    SWIFT_TEST_ARGS+=("-c" "release")
+fi
+
+print_info "Logging timing to: ${TIME_LOG}"
+echo
+
+# Stream `time -l`'s combined stderr (swift's test output + the trailing
+# rusage block) directly to TIME_LOG, then `cat` it back to the user's
+# console after the run. Bash does not wait on `>(tee …)` process-sub
+# children — without this, the subsequent awk reads at the bottom of
+# this script could race against an unflushed log file.
+set +e
+/usr/bin/time -l swift "${SWIFT_TEST_ARGS[@]}" 2> "${TIME_LOG}"
+TEST_EXIT=$?
+set -e
+# Echo the captured stderr back so the user sees swift test output even
+# though we redirected it. (Removing the `2>` would lose the rusage trailer.)
+[ -f "${TIME_LOG}" ] && cat "${TIME_LOG}" >&2
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+print_header "Eval summary"
+
+if [ ${TEST_EXIT} -ne 0 ]; then
+    print_error "swift test exited ${TEST_EXIT}"
+fi
+
+# Pull the salient values from /usr/bin/time -l output. macOS emits the
+# triple `<real> real    <user> user    <sys> sys` on a single line, so a
+# bare `/real/` regex would match the same row that `/user/` and `/sys/`
+# match — silently reporting the wall-clock value under three labels. We
+# walk the fields and grab the value preceding each label.
+if [ -f "${TIME_LOG}" ]; then
+    REAL_S="$(awk '{ for(i=1;i<=NF;i++) if($i=="real") { print $(i-1); exit } }' "${TIME_LOG}" 2>/dev/null || true)"
+    USER_S="$(awk '{ for(i=1;i<=NF;i++) if($i=="user") { print $(i-1); exit } }' "${TIME_LOG}" 2>/dev/null || true)"
+    SYS_S="$(awk  '{ for(i=1;i<=NF;i++) if($i=="sys")  { print $(i-1); exit } }' "${TIME_LOG}" 2>/dev/null || true)"
+    PEAK_RSS_B="$(awk '/maximum resident set size/ {print $1; exit}' "${TIME_LOG}" 2>/dev/null || true)"
+    PEAK_FOOTPRINT_B="$(awk '/peak memory footprint/ {print $1; exit}' "${TIME_LOG}" 2>/dev/null || true)"
+
+    [ -n "${REAL_S}" ] && print_info "Wall:       ${REAL_S} s"
+    [ -n "${USER_S}" ] && print_info "User CPU:   ${USER_S} s"
+    [ -n "${SYS_S}" ]  && print_info "Sys CPU:    ${SYS_S} s"
+    if [ -n "${PEAK_RSS_B}" ]; then
+        # macOS reports peak RSS in bytes; print in MB for readability.
+        PEAK_RSS_MB="$(python3 -c 'import sys; print(f"{int(sys.argv[1]) / (1024 * 1024):.1f}")' "${PEAK_RSS_B}" 2>/dev/null || echo "?")"
+        print_info "Peak RSS:   ${PEAK_RSS_MB} MB (${PEAK_RSS_B} B)"
+    fi
+    if [ -n "${PEAK_FOOTPRINT_B}" ]; then
+        PEAK_FOOTPRINT_MB="$(python3 -c 'import sys; print(f"{int(sys.argv[1]) / (1024 * 1024):.1f}")' "${PEAK_FOOTPRINT_B}" 2>/dev/null || echo "?")"
+        print_info "Peak mem:   ${PEAK_FOOTPRINT_MB} MB (${PEAK_FOOTPRINT_B} B)"
+    fi
+fi
+
+if [ ${TEST_EXIT} -eq 0 ]; then
+    print_success "Golden tests passed"
+else
+    print_error "Golden tests failed"
+fi
+
+exit ${TEST_EXIT}

--- a/scripts/llm-prefetch.sh
+++ b/scripts/llm-prefetch.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+# =============================================================================
+# llm-prefetch.sh
+# =============================================================================
+# Populate the local Gemma 4 E4B-IT model directory from the bundled
+# manifest, without launching the .app. Mirrors ModelDownloader.swift:
+# size-check + sha256-verify + atomic rename via `<file>.partial`.
+#
+# Usage: ./scripts/llm-prefetch.sh [options]
+#
+# Options:
+#   --manifest <path>   Path to manifest.json
+#                       (default: Sources/Resources/Models/gemma-4-e4b-it-4bit/manifest.json)
+#   --dest <path>       Destination model directory. If set, overrides the
+#                       Application-Support layout entirely. Equivalent to
+#                       the MLX_GEMMA_DIR env var consumed by
+#                       MLXGemmaProviderGoldenTests.
+#   --bundle-id <id>    Bundle identifier for the Application-Support
+#                       layout. Default = com.cloudbroker.mac-speech-to-text
+#                       (matches the test fallback when Bundle.main is a
+#                       test runner; see ModelDownloader.swift:105/116).
+#                       Can also be set via MAC_STT_BUNDLE_ID env var.
+#   --quiet             Suppress per-file progress output (errors still emit)
+#   --help              Show this help message
+#
+# Environment:
+#   MLX_GEMMA_DIR       Same effect as --dest. Wins over --bundle-id.
+#   MAC_STT_BUNDLE_ID   Same effect as --bundle-id.
+#
+# Exit codes:
+#   0  success (or no-op — every file already verified)
+#   1  manifest unreadable / malformed
+#   2  download failure (network, HTTP non-2xx)
+#   3  verification failure (size or sha256 mismatch)
+#   4  missing prerequisite (curl / shasum / python3)
+#
+# Notes:
+#   - Idempotent: re-runs are no-ops once every file matches the manifest.
+#   - The script does NOT validate the manifest's revision pin against
+#     Hugging Face — verification is local-only against the bundled
+#     manifest's per-file sha256s.
+#   - Source of truth for the URL pattern is ModelDownloader.swift:441-475.
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration
+# =============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "${SCRIPT_DIR}")"
+DEFAULT_MANIFEST="${PROJECT_ROOT}/Sources/Resources/Models/gemma-4-e4b-it-4bit/manifest.json"
+DEFAULT_BUNDLE_ID="com.cloudbroker.mac-speech-to-text"
+HF_BASE="https://huggingface.co"
+
+# Terminal colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+# Options
+MANIFEST_PATH="${DEFAULT_MANIFEST}"
+DEST_OVERRIDE="${MLX_GEMMA_DIR:-}"
+BUNDLE_ID="${MAC_STT_BUNDLE_ID:-${DEFAULT_BUNDLE_ID}}"
+QUIET=false
+
+# =============================================================================
+# Output helpers
+# =============================================================================
+
+print_header() {
+    [ "$QUIET" = true ] && return
+    echo -e "\n${BLUE}============================================================================${NC}"
+    echo -e "${BOLD}${CYAN}  $1${NC}"
+    echo -e "${BLUE}============================================================================${NC}\n"
+}
+
+print_info() {
+    [ "$QUIET" = true ] && return
+    echo -e "${CYAN}[INFO]${NC} $1"
+}
+
+print_success() {
+    [ "$QUIET" = true ] && return
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1" >&2
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+show_help() {
+    # Print the leading comment block: every line starting with `#`,
+    # stopping at the first blank line that follows the shebang. Strip
+    # the leading `# ` (or just `#`) so the help text reads cleanly.
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+    exit 0
+}
+
+# =============================================================================
+# Prerequisites
+# =============================================================================
+
+require_command() {
+    local cmd="$1"
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        print_error "Required command not found: ${cmd}"
+        exit 4
+    fi
+}
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --manifest)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--manifest requires a path"; exit 1; }
+            MANIFEST_PATH="$2"
+            shift 2
+            ;;
+        --dest)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--dest requires a path"; exit 1; }
+            DEST_OVERRIDE="$2"
+            shift 2
+            ;;
+        --bundle-id)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--bundle-id requires a value"; exit 1; }
+            BUNDLE_ID="$2"
+            shift 2
+            ;;
+        --quiet)
+            QUIET=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            echo "Use --help for usage information" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+require_command curl
+require_command shasum
+require_command python3
+
+if [ ! -f "${MANIFEST_PATH}" ]; then
+    print_error "Manifest not found: ${MANIFEST_PATH}"
+    exit 1
+fi
+
+# =============================================================================
+# Manifest parsing
+#
+# Use python3 to extract structural fields — model_id, revision, and the
+# per-file (path, size, sha256) tuples. Output a tab-separated stream so
+# bash can iterate with `while read`. A null sha256 (manifest entries
+# without a hash) is emitted as an empty field.
+# =============================================================================
+
+read_manifest_field() {
+    # Read a top-level string field from the manifest. Pass the path and
+    # field name as argv to keep the Python source free of shell-interpolated
+    # values (a path containing a single quote, newline, or backslash would
+    # otherwise break the source rather than the resolution).
+    local field="$1"
+    python3 -c '
+import json, sys
+path, field = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    m = json.load(f)
+v = m.get(field)
+if v is None:
+    sys.exit(f"manifest missing field: {field}")
+print(v)
+' "${MANIFEST_PATH}" "${field}"
+}
+
+MODEL_ID="$(read_manifest_field model_id)"
+REVISION="$(read_manifest_field revision)"
+
+# Derive the model directory name from model_id (last path component, after
+# the final `/`). Mirrors ModelManifest.modelDirectoryName in Sources.
+MODEL_DIR_NAME="${MODEL_ID##*/}"
+if [ -z "${MODEL_DIR_NAME}" ] || [ "${MODEL_DIR_NAME}" = "${MODEL_ID}" ]; then
+    print_error "Malformed model_id (expected 'org/name'): ${MODEL_ID}"
+    exit 1
+fi
+
+# Resolve destination
+if [ -n "${DEST_OVERRIDE}" ]; then
+    DEST_DIR="${DEST_OVERRIDE}"
+else
+    DEST_DIR="${HOME}/Library/Application Support/${BUNDLE_ID}/Models/${MODEL_DIR_NAME}"
+fi
+
+print_header "Prefetching ${MODEL_ID} @ ${REVISION:0:8}…"
+print_info "Manifest:  ${MANIFEST_PATH}"
+print_info "Dest dir:  ${DEST_DIR}"
+
+mkdir -p "${DEST_DIR}"
+
+# =============================================================================
+# Per-file iteration
+# =============================================================================
+
+# Stream tab-separated `path<TAB>size<TAB>sha256` rows. Empty sha256 means
+# size-only verification (matches ModelDownloader.fileSatisfiesManifest).
+# Same argv-not-interpolated discipline as read_manifest_field above.
+FILE_STREAM="$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    m = json.load(f)
+for entry in m.get("files", []):
+    path = entry["path"]
+    size = entry["size"]
+    sha = entry.get("sha256") or ""
+    print(f"{path}\t{size}\t{sha}")
+' "${MANIFEST_PATH}")"
+
+verify_size() {
+    # $1 = path, $2 = expected size in bytes
+    local path="$1"
+    local expected="$2"
+    local got
+    got="$(stat -f %z "${path}" 2>/dev/null || echo 0)"
+    [ "${got}" = "${expected}" ]
+}
+
+verify_sha256() {
+    # $1 = path, $2 = expected hex
+    local path="$1"
+    local expected="$2"
+    local actual_lc expected_lc
+    actual_lc="$(shasum -a 256 "${path}" | awk '{print $1}' | tr 'A-Z' 'a-z')"
+    expected_lc="$(echo "${expected}" | tr 'A-Z' 'a-z')"
+    [ "${actual_lc}" = "${expected_lc}" ]
+}
+
+download_file() {
+    # $1 = relative path, $2 = expected size, $3 = expected sha256 (may be empty)
+    local rel_path="$1"
+    local expected_size="$2"
+    local expected_sha="$3"
+
+    local dest="${DEST_DIR}/${rel_path}"
+    local partial="${dest}.partial"
+    local url="${HF_BASE}/${MODEL_ID}/resolve/${REVISION}/${rel_path}"
+
+    mkdir -p "$(dirname "${dest}")"
+
+    # Idempotency: file already complete + verified.
+    if [ -f "${dest}" ] && verify_size "${dest}" "${expected_size}"; then
+        if [ -z "${expected_sha}" ]; then
+            print_success "verified (size only): ${rel_path}"
+            return 0
+        fi
+        if verify_sha256 "${dest}" "${expected_sha}"; then
+            print_success "verified: ${rel_path}"
+            return 0
+        fi
+        print_warning "sha256 mismatch on existing ${rel_path}; re-downloading"
+        rm -f "${dest}"
+    fi
+
+    # Clean any stale partial.
+    rm -f "${partial}"
+
+    print_info "downloading ${rel_path} ($(human_bytes "${expected_size}"))…"
+
+    # `curl -L` follows the HF 302 → CDN redirect. `-f` makes non-2xx fail.
+    # `--retry 3` for transient hiccups; `--retry-connrefused` covers DNS
+    # blips. `-#` is a brief progress bar; suppress in quiet mode.
+    local curl_progress=("-#")
+    if [ "$QUIET" = true ]; then
+        curl_progress=("-s" "-S")
+    fi
+    if ! curl -L -f "${curl_progress[@]}" --retry 3 --retry-connrefused \
+            -o "${partial}" "${url}"; then
+        print_error "download failed: ${rel_path}"
+        rm -f "${partial}"
+        exit 2
+    fi
+
+    if ! verify_size "${partial}" "${expected_size}"; then
+        local got
+        got="$(stat -f %z "${partial}" 2>/dev/null || echo 0)"
+        print_error "size mismatch for ${rel_path}: expected ${expected_size}, got ${got}"
+        rm -f "${partial}"
+        exit 3
+    fi
+
+    if [ -n "${expected_sha}" ]; then
+        if ! verify_sha256 "${partial}" "${expected_sha}"; then
+            print_error "sha256 mismatch for ${rel_path}"
+            rm -f "${partial}"
+            exit 3
+        fi
+    fi
+
+    mv -f "${partial}" "${dest}"
+    print_success "verified: ${rel_path}"
+}
+
+human_bytes() {
+    python3 -c '
+import sys
+b = float(sys.argv[1])
+for unit in ["B", "KB", "MB", "GB", "TB"]:
+    if b < 1024:
+        print(f"{b:.1f} {unit}")
+        break
+    b /= 1024
+' "$1"
+}
+
+# =============================================================================
+# Main loop
+# =============================================================================
+
+TOTAL_FILES=0
+while IFS=$'\t' read -r rel_path expected_size expected_sha; do
+    [ -z "${rel_path}" ] && continue
+    TOTAL_FILES=$((TOTAL_FILES + 1))
+    download_file "${rel_path}" "${expected_size}" "${expected_sha}"
+done <<< "${FILE_STREAM}"
+
+print_success "All ${TOTAL_FILES} files verified at ${DEST_DIR}"

--- a/scripts/llm-reset.sh
+++ b/scripts/llm-reset.sh
@@ -1,0 +1,250 @@
+#!/bin/bash
+# =============================================================================
+# llm-reset.sh
+# =============================================================================
+# Wipe local Gemma model directories under ~/Library/Application Support/
+# so the next launch (or `llm-prefetch.sh` run) re-downloads from a clean
+# state. Useful for testing the first-run UX, the cutover migration, or
+# recovering from a corrupt download.
+#
+# Usage: ./scripts/llm-reset.sh [options]
+#
+# Options:
+#   --bundle-id <id>    Wipe Models/ under this bundle id only.
+#                       (default: wipe both com.cloudbroker.mac-speech-to-text
+#                       AND com.speechtotext.app — the test fallback and the
+#                       .app's runtime bundle id respectively. See
+#                       ModelDownloader.swift:105 / build-app.sh:45.)
+#   --path <path>       Wipe an arbitrary path (e.g. an MLX_GEMMA_DIR target).
+#                       Bypasses the bundle-id resolution entirely.
+#   --legacy            Also remove the v1 gemma-3-text-4b-it-4bit/ directory.
+#                       (AppState.purgeLegacyGemma3ModelDirectory() handles
+#                       this on launch in the .app, but the standalone
+#                       golden-test path may leave it behind.)
+#   --yes               Skip the confirmation prompt. Required for CI / scripts.
+#   --dry-run           Print what would be removed; remove nothing.
+#   --help              Show this help message
+#
+# Environment:
+#   MAC_STT_BUNDLE_ID   Overrides --bundle-id default.
+#
+# Exit codes:
+#   0  removed (or nothing to remove)
+#   1  invalid options
+#   2  user declined the confirmation prompt
+#   3  removal failed
+#
+# Safety:
+#   The script lists every path it intends to remove and (without --yes)
+#   prompts for an explicit y/N before touching anything. --yes skips the
+#   prompt; --dry-run prints and exits without removing.
+# =============================================================================
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration
+# =============================================================================
+APP_SUPPORT="${HOME}/Library/Application Support"
+DEFAULT_TEST_BUNDLE_ID="com.cloudbroker.mac-speech-to-text"
+DEFAULT_APP_BUNDLE_ID="com.speechtotext.app"
+LEGACY_MODEL_DIR_NAME="gemma-3-text-4b-it-4bit"
+
+# Terminal colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+BOLD='\033[1m'
+
+# Options
+BUNDLE_ID_OVERRIDE="${MAC_STT_BUNDLE_ID:-}"
+EXPLICIT_PATH=""
+INCLUDE_LEGACY=false
+ASSUME_YES=false
+DRY_RUN=false
+
+# =============================================================================
+# Output helpers
+# =============================================================================
+
+print_header() {
+    echo -e "\n${BLUE}============================================================================${NC}"
+    echo -e "${BOLD}${CYAN}  $1${NC}"
+    echo -e "${BLUE}============================================================================${NC}\n"
+}
+
+print_info() {
+    echo -e "${CYAN}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1" >&2
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1" >&2
+}
+
+show_help() {
+    awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "${BASH_SOURCE[0]}"
+    exit 0
+}
+
+# =============================================================================
+# Argument parsing
+# =============================================================================
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --bundle-id)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--bundle-id requires a value"; exit 1; }
+            BUNDLE_ID_OVERRIDE="$2"
+            shift 2
+            ;;
+        --path)
+            [[ -z "${2:-}" || "${2}" == --* ]] && { print_error "--path requires a value"; exit 1; }
+            EXPLICIT_PATH="$2"
+            shift 2
+            ;;
+        --legacy)
+            INCLUDE_LEGACY=true
+            shift
+            ;;
+        --yes|-y)
+            ASSUME_YES=true
+            shift
+            ;;
+        --dry-run|-n)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            echo "Use --help for usage information" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# =============================================================================
+# Resolve targets
+# =============================================================================
+
+TARGETS=()
+
+if [ -n "${EXPLICIT_PATH}" ]; then
+    TARGETS+=("${EXPLICIT_PATH}")
+elif [ -n "${BUNDLE_ID_OVERRIDE}" ]; then
+    TARGETS+=("${APP_SUPPORT}/${BUNDLE_ID_OVERRIDE}/Models")
+else
+    # Default: wipe both bundle-id paths. The .app and `swift test` use
+    # different bundle ids, so a clean reset wants to clear both.
+    TARGETS+=("${APP_SUPPORT}/${DEFAULT_TEST_BUNDLE_ID}/Models")
+    TARGETS+=("${APP_SUPPORT}/${DEFAULT_APP_BUNDLE_ID}/Models")
+fi
+
+# Filter to only existing paths so the prompt does not list ghosts.
+# Always scope removal to the per-model subdirectory (`gemma-4-e4b-it-4bit/`,
+# and with --legacy also `gemma-3-text-4b-it-4bit/`) — never the parent
+# `Models/` root. A doctor's `Application Support/<bundle>/Models/` may
+# also contain unrelated caches (FluidAudio ASR weights, etc.); a `Models/`
+# rm -rf would be a data-loss vector.
+EXISTING_TARGETS=()
+LEGACY_HITS=()
+for t in "${TARGETS[@]}"; do
+    [ -e "${t}" ] || continue
+    CURRENT_DIR="${t}/gemma-4-e4b-it-4bit"
+    [ -e "${CURRENT_DIR}" ] && EXISTING_TARGETS+=("${CURRENT_DIR}")
+    if [ "${INCLUDE_LEGACY}" = true ]; then
+        LEGACY_DIR="${t}/${LEGACY_MODEL_DIR_NAME}"
+        [ -e "${LEGACY_DIR}" ] && LEGACY_HITS+=("${LEGACY_DIR}")
+    fi
+done
+
+# When --path is used, treat it as a literal target (no per-model carve-out).
+# Honours the user's explicit choice; protection is on them.
+if [ -n "${EXPLICIT_PATH}" ]; then
+    EXISTING_TARGETS=()
+    LEGACY_HITS=()
+    [ -e "${EXPLICIT_PATH}" ] && EXISTING_TARGETS+=("${EXPLICIT_PATH}")
+fi
+
+if [ ${#EXISTING_TARGETS[@]} -eq 0 ] && [ ${#LEGACY_HITS[@]} -eq 0 ]; then
+    print_info "Nothing to remove."
+    exit 0
+fi
+
+# =============================================================================
+# Confirmation
+# =============================================================================
+
+print_header "llm-reset"
+
+print_warning "About to remove the following:"
+# bash 3.2 errors under `set -u` when expanding "${arr[@]}" on an empty
+# array, so we length-guard each iteration. (See also llm-eval.sh.)
+if [ ${#EXISTING_TARGETS[@]} -gt 0 ]; then
+    for t in "${EXISTING_TARGETS[@]}"; do
+        SIZE="$(du -sh "${t}" 2>/dev/null | awk '{print $1}')"
+        echo "  - ${t}  (${SIZE:-?})"
+    done
+fi
+if [ "${INCLUDE_LEGACY}" = true ] && [ ${#LEGACY_HITS[@]} -gt 0 ]; then
+    for t in "${LEGACY_HITS[@]}"; do
+        SIZE="$(du -sh "${t}" 2>/dev/null | awk '{print $1}')"
+        echo "  - ${t}  (${SIZE:-?}) [legacy]"
+    done
+fi
+echo
+
+if [ "${DRY_RUN}" = true ]; then
+    print_info "Dry run — no files removed."
+    exit 0
+fi
+
+if [ "${ASSUME_YES}" = false ]; then
+    if [ ! -t 0 ]; then
+        print_error "Refusing to delete without --yes in non-interactive mode"
+        exit 2
+    fi
+    echo -n "Continue? (y/N): "
+    read -r response
+    if [[ ! "${response}" =~ ^[Yy]$ ]]; then
+        print_info "Cancelled."
+        exit 2
+    fi
+fi
+
+# =============================================================================
+# Removal
+# =============================================================================
+
+# Build the removal list with length guards (bash 3.2 + set -u). The
+# pre-checks at the top of the script guarantee at least one of the two
+# arrays is non-empty by the time we get here.
+REMOVE_LIST=()
+[ ${#EXISTING_TARGETS[@]} -gt 0 ] && REMOVE_LIST+=("${EXISTING_TARGETS[@]}")
+if [ "${INCLUDE_LEGACY}" = true ] && [ ${#LEGACY_HITS[@]} -gt 0 ]; then
+    REMOVE_LIST+=("${LEGACY_HITS[@]}")
+fi
+
+for t in "${REMOVE_LIST[@]}"; do
+    if rm -rf -- "${t}"; then
+        print_success "removed ${t}"
+    else
+        print_error "rm -rf failed for ${t}"
+        exit 3
+    fi
+done
+
+print_success "llm-reset complete"


### PR DESCRIPTION
## Summary

Closes **#75** and bundles a fix for **#115** (test flake hitting reliably in the last few hours under macOS-15 runner load — was blocking this PR's CI).

### #75 — Three new bash scripts under `scripts/`

- **`scripts/llm-prefetch.sh`** — populate the on-disk model dir from the bundled manifest without launching the .app. Mirrors `ModelDownloader.swift`'s size + sha256 verify + atomic `<file>.partial` rename. Idempotent.
- **`scripts/llm-eval.sh`** — calls prefetch, exports `RUN_MLX_GOLDEN=1`, runs `swift test --filter MLXGemmaProviderGoldenTests` under `/usr/bin/time -l`. Reports wall + user + sys + peak RSS + peak memory footprint.
- **`scripts/llm-reset.sh`** — interactive `rm -rf` of the on-disk model dir. Wipes under both `com.cloudbroker.mac-speech-to-text` (test fallback) and `com.speechtotext.app` (.app runtime), scoped to the per-model subdir. `--yes` / `--dry-run` / `--legacy` / `--path`.

Plus `.claude/references/mlx-lifecycle.md` gains a **"Hardware testing"** section with a script table, the bundle-id divergence note, and a workflow recipe; `AGENTS.md` "Common commands" gets three new lines.

### #115 — `waitForFileBytes` test de-flake

The previous shape raced a 95 ms writer against a 100 ms helper timeout, then asserted `size == actualSize` where `actualSize` was stat'd *after* the helper exited. The race was inherent to measuring writer effects *after* helper exit. Restructured: writer at 50 ms / timeout at 1 s targets the helper's early-exit branch, `await writer.value` before stat, and assertion is now `size == payload.count && size == actualSize` — still catches a stale-lastSize regression. **5/5 deterministic local passes** under `swift test --parallel --filter ModelDownloaderTests`.

### Pre-PR Opus reviewer (`pr-review-toolkit:code-reviewer`)

Caught and folded into this PR before push:
- bash 3.2 + `set -u` empty-array crash in `llm-eval.sh` / `llm-reset.sh` (length-guard the expansion).
- `llm-reset.sh --legacy` widened removal scope to the parent `Models/` root — data-loss vector for users with unrelated caches. Now scoped to per-model subdirs only.
- `awk '/user/'` and `/sys/` matched the same `time -l` row as `/real/`; all three labels printed the wall-clock value. Now field-position-aware.
- `tee >(…)` process-sub race against subsequent log reads. Now writes directly and `cat`s back to console.
- Python heredocs splicing shell-interpolated paths. Now passed via `argv`.

### Local validation

- `bash -n` clean on all three; verified against system `/bin/bash 3.2.57`.
- End-to-end idempotency against the existing 4.9 GB model directory: 8/8 files verified, 0 downloads, ~18 s wall.
- `llm-reset.sh --dry-run [--legacy]` correctly carved to the per-model subdir post-fix.
- `swift build` clean; `pre-commit run --files <diff>` green.
- `ModelDownloaderTests` 5/5 deterministic passes locally.

## Test plan

- [ ] CI: SwiftLint / pre-commit / Build & Test / Build Release green
- [ ] Gemini Code Assist auto-review addressed
- [ ] Local hardware (M-series) sanity: `./scripts/llm-eval.sh` end-to-end with the bundled manifest (deferred to user's M1 — manual repro path documented in `.claude/references/mlx-lifecycle.md` "Hardware testing")

🤖 Generated with [Claude Code](https://claude.com/claude-code)