### PR TITLE
fix(tests): de-flake PatientPicker debounce with deterministic synchronisation (#117)

### DIFF
--- a/Sources/Views/ClinicalNotes/PatientPickerViewModel.swift
+++ b/Sources/Views/ClinicalNotes/PatientPickerViewModel.swift
@@ -273,4 +273,34 @@ final class PatientPickerViewModel: Identifiable {
         sessionStore.setSelectedPatient(id: nil)
         sessionStore.setSelectedAppointment(id: nil)
     }
+
+    // MARK: - Test seams
+
+    /// Test seam — exposes the currently-scheduled debounced search task
+    /// so a test can `await currentSearchTaskForTests?.value` instead of
+    /// gambling on a wall-clock `Task.sleep` to elapse. The previous
+    /// timing-based shape (5 ms debounce + 250 ms wait, paper-budget
+    /// 50× headroom) was flaky on loaded GitHub-Actions macOS-15
+    /// runners — `Task.sleep` schedule jitter on a busy host can spike
+    /// past the wait budget even when the wait is technically longer
+    /// in wall-clock terms (#117 / previous mitigation in #56).
+    /// Awaiting the task's `value` is a deterministic synchronisation
+    /// point that doesn't care about wall-clock at all.
+    ///
+    /// Production callers MUST NOT use this — the search task lifecycle
+    /// is owned by `updateQuery(_:)` / `clearSelection()`. The accessor
+    /// is `internal` so test code can reach it via `@testable import`.
+    @ObservationIgnored
+    internal var currentSearchTaskForTests: Task<Void, Never>? {
+        searchTask
+    }
+
+    /// Test seam — exposes the currently-scheduled appointment-load task
+    /// for the same `await … .value` shape as `currentSearchTaskForTests`.
+    /// Used by `appointmentPhase_loaded` and `appointmentPhase_error`
+    /// after `selectPatient(_:)` kicks off the load.
+    @ObservationIgnored
+    internal var currentAppointmentTaskForTests: Task<Void, Never>? {
+        appointmentTask
+    }
 }

--- a/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
+++ b/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
@@ -44,12 +44,12 @@ struct PatientPickerViewModelTests {
         let patients = FakePatientSearcher(result: .success([]))
         let appointments = FakeAppointmentLoader(result: .success([]))
         let store = SessionStore()
-        // Tiny debounce so the test budget for the post-keystroke wait
-        // gives a wide margin without slowing the suite. The previous
-        // 30ms / 150ms shape flaked on a loaded GitHub-Actions macOS
-        // runner — Task.sleep schedule jitter on a busy host can spike
-        // past the debounce window even when the wait is technically
-        // longer in wall-clock terms. 5ms / 250ms gives ~50× headroom.
+        // Real (non-zero) debounce here — we want to verify that rapid
+        // keystrokes within the window collapse to a single search call.
+        // Wall-clock budget is irrelevant because we await the in-flight
+        // search task directly via `currentSearchTaskForTests`; see #117
+        // (and #56's earlier insufficient mitigation that still raced
+        // a 5 ms debounce against a 250 ms wall-clock wait).
         let vm = PatientPickerViewModel(
             patientService: patients,
             appointmentService: appointments,
@@ -63,7 +63,11 @@ struct PatientPickerViewModelTests {
         vm.updateQuery("Samp")
         vm.updateQuery("Sample")
 
-        try await Task.sleep(nanoseconds: 250_000_000)
+        // Deterministic synchronisation — wait for the final scheduled
+        // search task to finish (debounce sleep + service call). The
+        // earlier 4 keystrokes already cancelled their respective tasks,
+        // so the remaining task is the "Sample" one.
+        await vm.currentSearchTaskForTests?.value
 
         let count = await patients.callCount
         let lastQuery = await patients.lastQuery
@@ -84,7 +88,11 @@ struct PatientPickerViewModelTests {
         )
 
         vm.updateQuery("   ")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        // Whitespace short-circuits inside `updateQuery` — no search
+        // task is scheduled. A `Task.yield()` is sufficient to let any
+        // synchronous follow-up state mutation settle; no wall-clock
+        // budget needed.
+        await Task.yield()
 
         let count = await patients.callCount
         #expect(count == 0)
@@ -107,7 +115,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.updateQuery("Sample")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await vm.currentSearchTaskForTests?.value
 
         if case .results(let list) = vm.searchPhase {
             #expect(list == [patient])
@@ -129,7 +137,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.updateQuery("zzznomatch")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await vm.currentSearchTaskForTests?.value
 
         #expect(vm.searchPhase == .empty)
     }
@@ -147,7 +155,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.updateQuery("anything")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await vm.currentSearchTaskForTests?.value
 
         #expect(vm.searchPhase == .error(.unauthenticated))
     }
@@ -170,7 +178,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.updateQuery("anything")
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await vm.currentSearchTaskForTests?.value
 
         #expect(vm.searchPhase == .error(.cancelled))
     }
@@ -246,7 +254,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.selectPatient(Patient(id: 1, firstName: "S", lastName: "P"))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await vm.currentAppointmentTaskForTests?.value
 
         if case .loaded(let list) = vm.appointmentPhase {
             #expect(list == [appointment])
@@ -270,7 +278,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.selectPatient(Patient(id: 1, firstName: "S", lastName: "P"))
-        try await Task.sleep(nanoseconds: 50_000_000)
+        await vm.currentAppointmentTaskForTests?.value
 
         #expect(vm.appointmentPhase == .error(.transport(.notConnectedToInternet)))
     }


### PR DESCRIPTION
## Summary

Fixes the post-merge `main` CI failure on `PatientPickerViewModelTests.debounce_rapidKeystrokes_singleCall` ([run 25141620811](https://github.com/CloudbrokerAz/mac-speech-to-text/actions/runs/25141620811)). Mirrors the deterministic-shape pattern from #116 (which fixed the analogous `waitForFileBytes` flake / #115). Closes #117.

### Production (`PatientPickerViewModel.swift`)

Adds two `internal` test seams — `currentSearchTaskForTests` and `currentAppointmentTaskForTests` — read-only computed forwarders to the existing `searchTask` / `appointmentTask` private state. **Zero behaviour change in production paths.**

### Tests (`PatientPickerViewModelTests.swift`)

Replaced wall-clock `try await Task.sleep(nanoseconds: …)` with `await vm.currentSearchTaskForTests?.value` (and the appointment variant) at **all 7 sites** in the file. Audited the whole suite: this was a class-of-flake — fixing only #117's repro would leave 6 more timebombs of the same shape. The fix is mechanical, no wider risk.

`whitespaceQuery_idle_noCall` simplifies to `await Task.yield()` because whitespace short-circuits inside `updateQuery` before scheduling any task.

`debounce_rapidKeystrokes_singleCall` now finishes in ~6 ms instead of the prior 250 ms wall-clock budget that was racing the runner.

## Pre-PR Opus reviewer (`pr-review-toolkit:code-reviewer`)

**No blockers, no important issues.** Confirmed:
- `await searchTask?.value` does wait for `performSearch` to update the actor fake's `callCount` (the task closure's last statement is `await performSearch`; `.value` resolves only when the closure returns).
- No race on the `@MainActor`-isolated seam accessor — `searchTask = Task { ... }` is a synchronous MainActor reassignment, all 5 `updateQuery` calls run as a single sync chunk before the test reads the seam.
- Cancelled `Task<Void, Never>` `.value` cannot hang (body short-circuits at the `Task.sleep` catch / `guard !Task.isCancelled`).
- `@ObservationIgnored` on a computed property is safe-extra — the @Observable macro only tracks stored properties; kept for visual symmetry with the stored fields above.

## Local validation

- `swift build` clean.
- `swiftlint lint --strict` clean on modified files.
- `pre-commit run --files <diff>` green.
- **10/10 consecutive deterministic passes** under `swift test --parallel --filter PatientPickerViewModelTests`.

## Test plan

- [ ] CI: SwiftLint / pre-commit / Build & Test green
- [ ] Gemini Code Assist auto-review addressed
- [ ] Post-merge `main` CI green (currently red on this exact flake — that's what this PR fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)