### PR TITLE
feat(clinical-notes): visible Gemma 4 model status — Settings row, About badge, fallback deep-link (#104)

### DIFF
--- a/.claude/references/mlx-lifecycle.md
+++ b/.claude/references/mlx-lifecycle.md
@@ -57,12 +57,14 @@ on Apple Silicon. (`mlx-swift-examples` was deprecated in
   CI), (b) slow every notarisation, (c) force a full new DMG for every
   model swap. Mirrors the existing `FluidAudioService` pattern
   (`AsrModels.downloadAndLoad(version: .v3)`).
-- **Trigger UX**: today the download fires lazily on the first
-  Generate-Notes tap (with the existing empty-draft fallback if it
-  fails). A follow-up PR will move the trigger to the Settings
-  Clinical-Notes-Mode toggle so the user opts in *before* the first
-  recording, and surfaces progress via `AppState.llmDownloadProgress`
-  / `llmDownloadState`.
+- **Trigger UX**: the download is triggered explicitly from Settings →
+  Clinical Notes (the model-status row's "Download model" button) so the
+  practitioner opts in to the 5.25 GB before recording. Progress is
+  surfaced via `AppState.llmDownloadProgress` / `llmDownloadState`,
+  mirrored into `ClinicalNotesModelStatusViewModel`. If a Generate Notes
+  tap lands while the model is `.idle` or `.failed`, the Review screen
+  renders a `model_unavailable` fallback banner with a deep-link back to
+  Settings — the silent multi-GB block on first tap is gone.
 - **No HF auth needed** for `mlx-community` public weights, so the
   downloader uses `URLSession` with no token plumbing.
 

--- a/Sources/Services/ClinicalNotes/ClinicalNotesProcessor.swift
+++ b/Sources/Services/ClinicalNotes/ClinicalNotesProcessor.swift
@@ -76,6 +76,13 @@ actor ClinicalNotesProcessor {
     /// the ReviewScreen surfaces lives in a single namespace.
     static let reasonModelUnavailable = "model_unavailable"
 
+    /// Structural sentinel emitted by `AppState` when the user actively
+    /// cancelled the model download / warmup (vs. it failing for other
+    /// reasons). The recovery affordance is the same as
+    /// `reasonModelUnavailable` (deep-link to Settings), but the banner
+    /// copy is more honest — the model isn't broken, it's half-fetched.
+    static let reasonModelDownloadCancelled = "model_download_cancelled"
+
     /// Structural sentinel emitted by `ReviewViewModel.loadState` (NOT
     /// by the processor) when the active `ClinicalSession` was cleared
     /// while the Review window was still on screen — typically the

--- a/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
+++ b/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
@@ -104,6 +104,15 @@ public actor MLXGemmaProvider: LLMProvider {
             logger.info(
                 "MLX warmup completed in \(ms, privacy: .public)ms"
             )
+        } catch is CancellationError {
+            // #104: cancel-during-warmup must surface as `CancellationError`,
+            // not as `ProviderError.modelLoadFailed`. The Settings row's
+            // "Cancel" button relies on `runDownloadAndWarmup`'s
+            // `catch is CancellationError` arm to flip state to `.cancelled`
+            // (showing "Download model"); collapsing into `.modelLoadFailed`
+            // here would leave the row showing "Retry" instead.
+            logger.info("MLX warmup cancelled")
+            throw CancellationError()
         } catch {
             let kind = String(describing: type(of: error))
             logger.error("MLX warmup failed kind=\(kind, privacy: .public)")

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -532,6 +532,13 @@ class AppState {
     /// resolves after the model is actually ready. The `Task` storage
     /// makes `cancelClinicalNotesModelDownload()` actionable.
     func downloadClinicalNotesModel() async {
+        // Already-ready short-circuit: re-running download/warmup when
+        // the model is loaded just causes a `.downloading` → `.verified`
+        // → `.ready` UI flicker and a redundant warmup. The Generate-Notes
+        // path delegates here on every tap; this gate keeps it fast on
+        // the steady-state common case (Gemini Code Assist PR #119).
+        if llmDownloadState == .ready { return }
+
         // Re-entry: there's already a download in flight. Await its
         // completion (cancelled-but-still-unwinding tasks complete
         // promptly) and return. We deliberately don't gate on
@@ -580,6 +587,12 @@ class AppState {
         downloader: ModelDownloader,
         provider: MLXGemmaProvider
     ) async {
+        // Concurrency note: progress events are dispatched via per-event
+        // `Task { @MainActor in ... }` hops and can land out of order with
+        // respect to each other. `applyDownloadProgress` is hardened to
+        // be monotonic (latches at 1.0) and terminal-state-aware (early
+        // out on `.cancelled` / `.failed`), so a stale event after this
+        // helper has flipped to a terminal state cannot regress UI.
         // Track which phase threw so error logs distinguish a network /
         // hash failure during fetch from an MLX load failure during
         // warmup. Cheap; helps post-mortem on real crash reports.

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -64,6 +64,29 @@ class AppState {
     /// Manifest's total bytes — captured once at `.starting`.
     @ObservationIgnored private var llmDownloadTotalBytes: Int64 = 0
 
+    /// Settings-side surface for the Gemma 4 model lifecycle (#104). Mirrors
+    /// the two `llmDownload*` properties + `modelDirectoryURL` so the
+    /// Settings row can bind directly. Constructed once at init with three
+    /// closures that route to `downloadClinicalNotesModel()`,
+    /// `cancelClinicalNotesModelDownload()`, and `removeClinicalNotesModel()`
+    /// below. PHI-free by construction.
+    ///
+    /// `var` rather than `let` so init can construct it with `[weak self]`
+    /// closures at the bottom of init (after all other stored properties
+    /// have been assigned). Re-assigned exactly once and never mutated
+    /// afterwards.
+    @ObservationIgnored private(set) var modelStatusViewModel: ClinicalNotesModelStatusViewModel = .init()
+
+    /// In-flight model-download / warmup task (#104). Set by
+    /// `runClinicalNotesPipeline` and `downloadClinicalNotesModel` so that
+    /// `cancelClinicalNotesModelDownload` can call `cancel()` on it.
+    /// Re-entrant guard: a second call while the task is alive returns
+    /// fast — the downloader is itself idempotent. Token-tagged so a
+    /// fresh download started after a cancel doesn't have its slot
+    /// clobbered by the original caller's slot-clear (silent-failure-hunter
+    /// H2 / code-reviewer B2).
+    @ObservationIgnored private var clinicalNotesDownloadTask: (token: UUID, task: Task<Void, Never>)?
+
     /// Static manipulations taxonomy bundled with the app (#6). Loaded
     /// once at launch and handed to `ReviewWindowController` so the
     /// review surface (#13) renders the checklist without re-parsing the
@@ -251,6 +274,34 @@ class AppState {
         }
         clinicalNotesGenerateObserver = clinicalObserver
         deinitClinicalNotesGenerateObserver = clinicalObserver
+
+        // Settings-side model status surface (#104). Replace the placeholder
+        // VM (`@ObservationIgnored ... = .init()` in the property declaration)
+        // with the wired one. By this point in init, all stored properties
+        // have been assigned, so `[weak self]` is legal in the action
+        // closures. The closures hop to MainActor explicitly because the VM's
+        // `@Sendable` shape lets the row's button-tap fire them from any
+        // context — defence in depth even when SwiftUI dispatches on Main.
+        let totalBytes = llmManifest?.totalBytes ?? 0
+        modelStatusViewModel = ClinicalNotesModelStatusViewModel(
+            state: llmDownloadState,
+            progress: llmDownloadProgress,
+            manifestSizeBytes: totalBytes,
+            modelDirectoryURL: nil,
+            onDownload: { [weak self] in
+                await self?.downloadClinicalNotesModel()
+            },
+            onCancel: { [weak self] in
+                await self?.cancelClinicalNotesModelDownload()
+            },
+            onRemove: { [weak self] in
+                await self?.removeClinicalNotesModel()
+            }
+        )
+        // Wire the singleton MainWindowController with the VM so any
+        // subsequently-constructed MainWindow threads it through to
+        // ClinicalNotesSection. Mirrors `ReviewWindowController.shared.configure`.
+        MainWindowController.shared.configure(modelStatusViewModel: modelStatusViewModel)
     }
 
     deinit {
@@ -323,8 +374,6 @@ class AppState {
     /// a structural reason sentinel — never PHI.
     private func runClinicalNotesPipeline(transcript: String) async {
         guard
-            let downloader = modelDownloader,
-            let provider = llmProvider,
             let processor = clinicalNotesProcessor
         else {
             AppLogger.app.warning(
@@ -336,47 +385,25 @@ class AppState {
             applyClinicalNotesFallback(reasonCode: ClinicalNotesProcessor.reasonModelUnavailable)
             return
         }
-        do {
-            llmDownloadState = .downloading
-            // Per-event Task hops to MainActor are not strictly ordered
-            // (Gemini Code Assist, PR #70). After the refactor to
-            // `URLSession.download(for:)` the events are far apart in
-            // time (one `.fileStarted` / `.bytesReceived` / `.fileVerified`
-            // per file in the manifest, not per byte) so practical
-            // reordering is highly unlikely. The aggregator
-            // (`applyDownloadProgress`) is also hardened to be order-
-            // insensitive: progress monotonically increases and latches
-            // at 1.0 on `.completed`, and `.cancelled` / `.failed` are
-            // terminal. Promote to an `AsyncStream`-piped source if a
-            // future progress event design becomes per-byte.
-            let modelDir = try await downloader.ensureModelDownloaded { [weak self] event in
-                Task { @MainActor [weak self] in
-                    self?.applyDownloadProgress(event)
-                }
-            }
-            llmDownloadState = .verified(directory: modelDir)
-            try await provider.warmup()
-            llmDownloadState = .ready
-        } catch is CancellationError {
-            // User-initiated cancel is a clean state transition, not a
-            // failure. Don't overwrite to `.failed` — `applyDownloadProgress`
-            // may have already set `.cancelled`, and either order yields the
-            // correct final state.
-            AppLogger.app.info("AppState: clinical-notes pipeline cancelled")
-            if llmDownloadState != .cancelled {
-                llmDownloadState = .cancelled
-            }
-            // Pipeline cancellation leaves the Review screen alive (the
-            // user may have backgrounded the app, not closed the window);
-            // surface the same fallback so the editors are interactive
-            // rather than stuck in `.pending`.
-            applyClinicalNotesFallback(reasonCode: ClinicalNotesProcessor.reasonModelUnavailable)
+
+        // Delegate the download+warmup phase to the shared helper so the
+        // Settings-side "Download model" button (#104) and the Generate-Notes
+        // path drive the same pipeline. The helper updates `llmDownloadState`
+        // / `llmDownloadProgress` / `modelStatusViewModel` consistently.
+        await downloadClinicalNotesModel()
+
+        // Branch on the helper's terminal state. Cancellation is a distinct
+        // user gesture from a network/load failure — same recovery path
+        // (deep-link to Settings) but the banner copy differs so the
+        // practitioner isn't told "model unavailable" when they actively
+        // tapped Cancel (silent-failure-hunter H1).
+        switch llmDownloadState {
+        case .ready:
+            break  // proceed to processor
+        case .cancelled:
+            applyClinicalNotesFallback(reasonCode: ClinicalNotesProcessor.reasonModelDownloadCancelled)
             return
-        } catch {
-            AppLogger.app.error(
-                "AppState: clinical-notes warmup failed kind=\(String(describing: type(of: error)), privacy: .public)"
-            )
-            llmDownloadState = .failed
+        case .idle, .downloading, .verified, .failed:
             applyClinicalNotesFallback(reasonCode: ClinicalNotesProcessor.reasonModelUnavailable)
             return
         }
@@ -415,6 +442,18 @@ class AppState {
     /// across the multi-file manifest (file boundaries no longer leave
     /// the UI looking frozen).
     private func applyDownloadProgress(_ event: ModelDownloader.DownloadProgress) {
+        // Late events from a torn-down download (terminal `.cancelled` /
+        // `.failed` already set) must not advance the progress bar or
+        // re-flip state. The progress callback is dispatched via a Task
+        // hop, so a `.bytesReceived` queued before cancel can land after
+        // `runDownloadAndWarmup`'s catch arm has already terminated state
+        // (silent-failure-hunter M1).
+        switch llmDownloadState {
+        case .cancelled, .failed:
+            return
+        case .idle, .downloading, .verified, .ready:
+            break
+        }
         switch event {
         case .starting(let totalBytes):
             llmDownloadProgress = 0
@@ -451,6 +490,230 @@ class AppState {
         case .cancelled:
             llmDownloadState = .cancelled
         }
+        updateModelStatusMirror()
+    }
+
+    /// Push the latest `llmDownloadState` / `llmDownloadProgress` /
+    /// model-directory into `modelStatusViewModel`. Called from every site
+    /// that mutates either of the source fields so the Settings UI surface
+    /// (#104) never lags the underlying state. Cheap — three property
+    /// writes on a `@MainActor`-isolated VM. PHI-free; the model directory
+    /// is structural.
+    private func updateModelStatusMirror() {
+        modelStatusViewModel.state = llmDownloadState
+        modelStatusViewModel.progress = llmDownloadProgress
+        switch llmDownloadState {
+        case .verified(let directory):
+            modelStatusViewModel.modelDirectoryURL = directory
+        case .ready:
+            // `.verified(directory:)` already wrote `modelDirectoryURL` on
+            // the immediately-prior transition. Re-resolving here would be
+            // a no-op at best and could mask a desync at worst (type-design
+            // analyzer Nit 1). Leave the prior value in place.
+            break
+        case .idle, .cancelled, .failed:
+            modelStatusViewModel.modelDirectoryURL = nil
+        case .downloading:
+            // Keep any prior directory hint until the next terminal state.
+            break
+        }
+    }
+
+    // MARK: - Settings-side model lifecycle (#104)
+
+    /// Trigger a Gemma 4 download + warmup with no transcript and no Review
+    /// surface side-effects. Used by the Settings model-status row's
+    /// "Download model" / "Retry" actions. Idempotent across model state —
+    /// a re-entrant call while a download Task is in flight returns
+    /// immediately. Every terminal branch updates `llmDownloadState`
+    /// + the mirrored `modelStatusViewModel`. PHI-free; model bytes only.
+    ///
+    /// Awaits the in-flight task on re-entry so the caller's `await`
+    /// resolves after the model is actually ready. The `Task` storage
+    /// makes `cancelClinicalNotesModelDownload()` actionable.
+    func downloadClinicalNotesModel() async {
+        // Re-entry: there's already a download in flight. Await its
+        // completion (cancelled-but-still-unwinding tasks complete
+        // promptly) and return. We deliberately don't gate on
+        // `!isCancelled`: a cancelled task whose body is still running
+        // would otherwise let a second caller spawn a parallel task,
+        // and our slot can only hold one. The body's catch arm will
+        // flip state to `.cancelled` before the task resolves.
+        if let existing = clinicalNotesDownloadTask {
+            await existing.task.value
+            return
+        }
+
+        guard
+            let downloader = modelDownloader,
+            let provider = llmProvider
+        else {
+            AppLogger.app.warning(
+                "AppState: clinical-notes download requested but pipeline unavailable"
+            )
+            llmDownloadState = .failed
+            updateModelStatusMirror()
+            return
+        }
+
+        let token = UUID()
+        let task: Task<Void, Never> = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runDownloadAndWarmup(downloader: downloader, provider: provider)
+        }
+        clinicalNotesDownloadTask = (token: token, task: task)
+        await task.value
+        // Identity-guarded clear: only nil the slot if it's still the
+        // generation we set. `removeClinicalNotesModel()` may have
+        // claimed the slot while we were suspended on `task.value`, and
+        // an unconditional `= nil` would clobber the fresh task it set.
+        if clinicalNotesDownloadTask?.token == token {
+            clinicalNotesDownloadTask = nil
+        }
+    }
+
+    /// Body of the download + warmup phase, isolated so
+    /// `downloadClinicalNotesModel` can store / cancel the wrapping Task.
+    /// Mirrors the original inline pipeline shape from
+    /// `runClinicalNotesPipeline` — the two now share this implementation.
+    private func runDownloadAndWarmup(
+        downloader: ModelDownloader,
+        provider: MLXGemmaProvider
+    ) async {
+        // Track which phase threw so error logs distinguish a network /
+        // hash failure during fetch from an MLX load failure during
+        // warmup. Cheap; helps post-mortem on real crash reports.
+        var phase = "download"
+        do {
+            llmDownloadState = .downloading
+            updateModelStatusMirror()
+            let modelDir = try await downloader.ensureModelDownloaded { [weak self] event in
+                Task { @MainActor [weak self] in
+                    self?.applyDownloadProgress(event)
+                }
+            }
+            llmDownloadState = .verified(directory: modelDir)
+            updateModelStatusMirror()
+            phase = "warmup"
+            try await provider.warmup()
+            llmDownloadState = .ready
+            updateModelStatusMirror()
+        } catch is CancellationError {
+            AppLogger.app.info(
+                "AppState: clinical-notes download cancelled phase=\(phase, privacy: .public)"
+            )
+            if llmDownloadState != .cancelled {
+                llmDownloadState = .cancelled
+            }
+            updateModelStatusMirror()
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            // URLSession reifies `Task.cancel()` as `URLError(.cancelled)`
+            // for some transports; treat it identically to `CancellationError`
+            // so the user-cancel UX matches.
+            AppLogger.app.info(
+                "AppState: clinical-notes download cancelled (URLError.cancelled) phase=\(phase, privacy: .public)"
+            )
+            if llmDownloadState != .cancelled {
+                llmDownloadState = .cancelled
+            }
+            updateModelStatusMirror()
+        } catch {
+            AppLogger.app.error(
+                "AppState: clinical-notes download failed phase=\(phase, privacy: .public) kind=\(String(describing: type(of: error)), privacy: .public)"
+            )
+            llmDownloadState = .failed
+            updateModelStatusMirror()
+        }
+    }
+
+    /// Cancel the active model download / warmup, if any. Safe to call
+    /// when no download is in flight — the no-op is the common case
+    /// after a `.ready` state is reached. Doesn't await; cancellation
+    /// propagates through `Task.cancel()` and lands in the in-flight
+    /// task's `catch is CancellationError` arm.
+    func cancelClinicalNotesModelDownload() {
+        guard let entry = clinicalNotesDownloadTask else { return }
+        AppLogger.app.info("AppState: cancelling clinical-notes model download")
+        entry.task.cancel()
+    }
+
+    /// Remove the on-disk Gemma 4 model directory and reset the download
+    /// state machine to `.idle`. Used by the Settings row's "Remove" action.
+    /// Idempotent — a missing directory is a no-op apart from the state
+    /// reset. Cancels any in-flight download first so the `Task` can't
+    /// race the unlink.
+    ///
+    /// PHI-free: only the model directory is touched. The path is logged
+    /// as `.private` per `phi-handling.md` (user-home paths count as PII
+    /// in the OSLog channel).
+    func removeClinicalNotesModel() async {
+        // Mitigation for the mmap-still-active concern (silent-failure-hunter
+        // H5): if the provider has warmed up, its `ModelContainer` may still
+        // mmap the directory we're about to unlink. POSIX semantics let the
+        // unlink succeed but the bytes don't get freed until the provider
+        // releases the container. Surface a structural warning so a
+        // regression here is debuggable. Proper fix is `MLXGemmaProvider.unload()`
+        // — tracked as a follow-up; the warning is the bridge.
+        if llmDownloadState == .ready {
+            AppLogger.app.warning(
+                "AppState: removing Gemma 4 model while provider may still hold mmap — bytes may persist until app restart"
+            )
+        }
+
+        cancelClinicalNotesModelDownload()
+        // Wait for any cancelled task to unwind before we delete on-disk
+        // state — otherwise the downloader's `.partial` rename can race
+        // the directory removal. Identity-guarded clear so a re-entrant
+        // download started by a parallel caller isn't clobbered.
+        if let existing = clinicalNotesDownloadTask {
+            await existing.task.value
+            if clinicalNotesDownloadTask?.token == existing.token {
+                clinicalNotesDownloadTask = nil
+            }
+        }
+
+        guard let manifest = llmManifest else {
+            // No manifest means no `<bundleId>/Models/<dir>/` to clear; just
+            // collapse the state machine.
+            llmDownloadState = .idle
+            llmDownloadProgress = 0
+            llmDownloadCompletedBytes = 0
+            llmDownloadTotalBytes = 0
+            updateModelStatusMirror()
+            return
+        }
+        let dir = ModelDownloader.defaultBaseDirectory()
+            .appendingPathComponent(manifest.modelDirectoryName, isDirectory: true)
+        if FileManager.default.fileExists(atPath: dir.path) {
+            do {
+                try FileManager.default.removeItem(at: dir)
+                AppLogger.app.info(
+                    "AppState: removed Gemma 4 model directory at \(dir.path, privacy: .private)"
+                )
+            } catch {
+                // Surface failure as `.failed` (silent-failure-hunter H4):
+                // collapsing to `.idle` after a failed unlink would mislead
+                // the user into thinking the model is gone, while the next
+                // `Download model` tap silently re-uses the still-on-disk
+                // bytes — they'd think a re-download succeeded when it
+                // never ran. Surface state honestly so the row's "Retry"
+                // affordance is reachable.
+                AppLogger.app.error(
+                    "AppState: failed to remove Gemma 4 model directory kind=\(String(describing: type(of: error)), privacy: .public)"
+                )
+                llmDownloadState = .failed
+                updateModelStatusMirror()
+                return
+            }
+        } else {
+            AppLogger.app.info("AppState: Gemma 4 model directory already absent")
+        }
+
+        llmDownloadState = .idle
+        llmDownloadProgress = 0
+        llmDownloadCompletedBytes = 0
+        llmDownloadTotalBytes = 0
+        updateModelStatusMirror()
     }
 
     /// Lookup the manifest-declared size of a file by its repo-relative

--- a/Sources/Views/ClinicalNotes/ReviewScreen.swift
+++ b/Sources/Views/ClinicalNotes/ReviewScreen.swift
@@ -324,6 +324,18 @@ struct ReviewScreen: View {
 
             Spacer()
 
+            if showsOpenSettingsAffordance {
+                Button {
+                    viewModel.openClinicalNotesSettings()
+                } label: {
+                    Label("Open Clinical Notes Settings", systemImage: "gearshape")
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                }
+                .buttonStyle(.bordered)
+                .tint(Color.amberPrimary)
+                .accessibilityIdentifier("reviewScreen.fallback.openClinicalNotesSettings")
+            }
+
             Button {
                 viewModel.insertRawTranscriptIntoSubjective()
             } label: {
@@ -347,13 +359,33 @@ struct ReviewScreen: View {
         .accessibilityIdentifier("reviewScreen.fallbackBanner")
     }
 
-    /// Banner copy. Currently a single sentence regardless of
-    /// `fallbackReasonCode` — the codes are diagnostic, not user-
-    /// facing. Future copy could branch on `reasonCode == "model_unavailable"`
-    /// to nudge toward Settings; for now the unified surface keeps
-    /// the doctor's attention on editing.
+    /// Banner copy switches on the structural fallback reason code; see
+    /// `ClinicalNotesProcessor` for the code constants.
     private var fallbackBannerSubtitle: String {
-        "Edit the SOAP sections manually, or insert the raw transcript into Subjective as a starting point."
+        switch viewModel.fallbackReasonCode {
+        case ClinicalNotesProcessor.reasonModelUnavailable:
+            return "The clinical-notes model isn't ready. Open Settings → Clinical Notes to download it."
+        case ClinicalNotesProcessor.reasonModelDownloadCancelled:
+            return "Model download cancelled. Open Settings → Clinical Notes to finish it."
+        case ClinicalNotesProcessor.reasonSessionExpired:
+            return "Session expired — please cancel and re-record."
+        default:
+            // llm_error, invalid_json_after_retry, all_soap_empty_after_retry, nil
+            return "Edit the SOAP sections manually, or insert the raw transcript into Subjective as a starting point."
+        }
+    }
+
+    /// Show the "Open Clinical Notes Settings" deep-link button for the
+    /// model-availability reasons (download not run / cancelled). Both
+    /// recover via the same Settings → Clinical Notes route.
+    private var showsOpenSettingsAffordance: Bool {
+        switch viewModel.fallbackReasonCode {
+        case ClinicalNotesProcessor.reasonModelUnavailable,
+             ClinicalNotesProcessor.reasonModelDownloadCancelled:
+            return true
+        default:
+            return false
+        }
     }
 
     // MARK: Sidebar column

--- a/Sources/Views/ClinicalNotes/ReviewViewModel.swift
+++ b/Sources/Views/ClinicalNotes/ReviewViewModel.swift
@@ -164,6 +164,15 @@ final class ReviewViewModel {
     /// "set up Cliniko in Settings" message in that case.
     @ObservationIgnored private let makePatientPickerViewModel: () async -> PatientPickerViewModel?
 
+    /// Closure invoked when the practitioner taps "Open Clinical Notes
+    /// Settings" on the `model_unavailable` fallback banner (#104). Routed
+    /// through a closure (rather than reaching for
+    /// `MainWindowController.shared` directly) so unit tests can verify
+    /// the navigation intent without wiring a real `AppKit` window.
+    /// Default implementation mirrors the `AppState.openClinikoSettings`
+    /// pattern at `Sources/SpeechToTextApp/AppState.swift:676`.
+    @ObservationIgnored private let openClinicalNotesSettingsHandler: @MainActor () -> Void
+
     @ObservationIgnored private let now: @Sendable () -> Date
     @ObservationIgnored private let reAddTargetWindow: TimeInterval
     @ObservationIgnored private let logger = Logger(
@@ -193,7 +202,10 @@ final class ReviewViewModel {
         reAddTargetWindow: TimeInterval = 5.0,
         now: @escaping @Sendable () -> Date = { Date() },
         makeExportFlowViewModel: @escaping () async -> ExportFlowViewModel? = { nil },
-        makePatientPickerViewModel: @escaping () async -> PatientPickerViewModel? = { nil }
+        makePatientPickerViewModel: @escaping () async -> PatientPickerViewModel? = { nil },
+        openClinicalNotesSettingsHandler: @escaping @MainActor () -> Void = {
+            MainWindowController.shared.showSection(.clinicalNotes)
+        }
     ) {
         self.sessionStore = sessionStore
         self.manipulationsRepo = manipulations
@@ -201,6 +213,7 @@ final class ReviewViewModel {
         self.now = now
         self.makeExportFlowViewModel = makeExportFlowViewModel
         self.makePatientPickerViewModel = makePatientPickerViewModel
+        self.openClinicalNotesSettingsHandler = openClinicalNotesSettingsHandler
     }
 
     // MARK: - Manipulations accessor
@@ -641,6 +654,20 @@ final class ReviewViewModel {
         guard patientPickerSheet != nil else { return }
         logger.info("ReviewViewModel: patient picker dismissed")
         patientPickerSheet = nil
+    }
+
+    /// Deep-link to Settings → Clinical Notes from the
+    /// `model_unavailable` fallback banner (#104). Routes through the
+    /// closure-injected handler so tests can verify the navigation
+    /// intent without instantiating a real `MainWindowController`.
+    ///
+    /// PHI: structural log only — the fallback reason code is a
+    /// `String` constant on `ClinicalNotesProcessor` (never PHI).
+    func openClinicalNotesSettings() {
+        logger.info(
+            "ReviewViewModel: deep-link to Clinical Notes Settings (reason=\(self.fallbackReasonCode ?? "nil", privacy: .public))"
+        )
+        openClinicalNotesSettingsHandler()
     }
 }
 

--- a/Sources/Views/MainView/MainView.swift
+++ b/Sources/Views/MainView/MainView.swift
@@ -30,6 +30,12 @@ struct MainView: View {
     /// Permission service for checking/requesting system permissions
     private let permissionService: PermissionService
 
+    /// Optional model-status surface for the Gemma 4 download lifecycle
+    /// (#104, Deliverable A). Threaded into `ClinicalNotesSection` so the
+    /// row can bind directly to `AppState`-mirrored state. Defaults to
+    /// `nil` to keep existing previews and tests intact.
+    private let modelStatusViewModel: ClinicalNotesModelStatusViewModel?
+
     // MARK: - Section ViewModels (lazy initialized)
 
     @State private var languageViewModel: LanguageSectionViewModel?
@@ -42,11 +48,13 @@ struct MainView: View {
     init(
         viewModel: MainViewModel = MainViewModel(),
         settingsService: SettingsService = SettingsService(),
-        permissionService: PermissionService = PermissionService()
+        permissionService: PermissionService = PermissionService(),
+        modelStatusViewModel: ClinicalNotesModelStatusViewModel? = nil
     ) {
         self._viewModel = State(initialValue: viewModel)
         self.settingsService = settingsService
         self.permissionService = permissionService
+        self.modelStatusViewModel = modelStatusViewModel
     }
 
     // MARK: - Body
@@ -321,14 +329,15 @@ struct MainView: View {
             if let clinicalNotesVM = clinicalNotesViewModel {
                 ClinicalNotesSection(
                     viewModel: clinicalNotesVM,
-                    settingsService: settingsService
+                    settingsService: settingsService,
+                    modelStatusViewModel: modelStatusViewModel
                 )
             } else {
                 ClinicalNotesSectionPlaceholder()
             }
         case .about:
             if let aboutVM = aboutViewModel {
-                AboutSection(viewModel: aboutVM)
+                AboutSection(viewModel: aboutVM, modelStatusViewModel: modelStatusViewModel)
             } else {
                 AboutSectionPlaceholder()
             }

--- a/Sources/Views/MainView/MainWindow.swift
+++ b/Sources/Views/MainView/MainWindow.swift
@@ -25,6 +25,12 @@ final class MainWindow: NSObject, NSWindowDelegate {
     private let settingsService: SettingsService
     private let permissionService: PermissionService
 
+    /// Optional Gemma 4 model status surface (#104). Routed through
+    /// `MainView` → `ClinicalNotesSection`. `nil` for tests + the
+    /// fallback `MainWindowController.shared` constructions where
+    /// AppState hasn't called `configure(...)` yet.
+    private let modelStatusViewModel: ClinicalNotesModelStatusViewModel?
+
     /// Window dimensions
     private static let windowWidth: CGFloat = 900
     private static let windowHeight: CGFloat = 820
@@ -37,11 +43,13 @@ final class MainWindow: NSObject, NSWindowDelegate {
     init(
         viewModel: MainViewModel = MainViewModel(),
         settingsService: SettingsService = SettingsService(),
-        permissionService: PermissionService = PermissionService()
+        permissionService: PermissionService = PermissionService(),
+        modelStatusViewModel: ClinicalNotesModelStatusViewModel? = nil
     ) {
         self.viewModel = viewModel
         self.settingsService = settingsService
         self.permissionService = permissionService
+        self.modelStatusViewModel = modelStatusViewModel
         super.init()
     }
 
@@ -66,7 +74,8 @@ final class MainWindow: NSObject, NSWindowDelegate {
         let mainView = MainView(
             viewModel: viewModel,
             settingsService: settingsService,
-            permissionService: permissionService
+            permissionService: permissionService,
+            modelStatusViewModel: modelStatusViewModel
         )
 
         // Create the window with standard macOS chrome
@@ -201,6 +210,13 @@ final class MainWindowController {
     /// Observer for window close notifications
     private var windowCloseObserver: NSObjectProtocol?
 
+    /// Cached Gemma 4 model status VM (#104). Captured once via
+    /// `configure(modelStatusViewModel:)` from `AppState.init` and threaded
+    /// into every `MainWindow` constructed here. Defaults to `nil` so
+    /// any pre-configure window construction (tests, defensive paths)
+    /// still works — the `ClinicalNotesSection` row hides when this is nil.
+    private var modelStatusViewModel: ClinicalNotesModelStatusViewModel?
+
     // MARK: - Initialization
 
     private init() {
@@ -224,10 +240,31 @@ final class MainWindowController {
 
     // MARK: - Public Methods
 
+    /// Wire the controller with cross-window dependencies that can't be
+    /// reached at MainWindow's construction site (tests, AppDelegate).
+    /// Called once by `AppState.init`; subsequent calls overwrite, mirroring
+    /// `ReviewWindowController.shared.configure(...)`.
+    ///
+    /// A second call replaces the cached VM, but any already-presented
+    /// `MainWindow` was constructed with the first VM and continues to
+    /// bind against that — so a clobber after a window is open silently
+    /// goes stale on screen. Surface a structural warning so a regression
+    /// here is debuggable; in production this is a singleton path called
+    /// exactly once from `AppState.init`.
+    func configure(modelStatusViewModel: ClinicalNotesModelStatusViewModel) {
+        if self.modelStatusViewModel != nil,
+           self.modelStatusViewModel !== modelStatusViewModel {
+            AppLogger.app.warning(
+                "MainWindowController.configure: replacing live modelStatusViewModel — open windows may bind to stale VM"
+            )
+        }
+        self.modelStatusViewModel = modelStatusViewModel
+    }
+
     /// Show the main window
     func showWindow() {
         if mainWindow == nil {
-            mainWindow = MainWindow()
+            mainWindow = makeMainWindow()
         }
         mainWindow?.show()
     }
@@ -246,7 +283,7 @@ final class MainWindowController {
     /// Toggle main window visibility
     func toggleWindow() {
         if mainWindow == nil {
-            mainWindow = MainWindow()
+            mainWindow = makeMainWindow()
         }
         mainWindow?.toggle()
     }
@@ -259,7 +296,7 @@ final class MainWindowController {
     /// Navigate to a specific section and show window
     func showSection(_ section: SidebarSection) {
         if mainWindow == nil {
-            mainWindow = MainWindow()
+            mainWindow = makeMainWindow()
         }
         mainWindow?.navigateTo(section)
     }
@@ -268,6 +305,15 @@ final class MainWindowController {
     /// Called when user presses Cmd+, or clicks Settings
     func showSettings() {
         showSection(.general)
+    }
+
+    // MARK: - Private
+
+    /// Construct a `MainWindow` with the configured cross-window
+    /// dependencies threaded in. Pulled out so every `mainWindow == nil`
+    /// branch above gets the same wiring.
+    private func makeMainWindow() -> MainWindow {
+        MainWindow(modelStatusViewModel: modelStatusViewModel)
     }
 }
 

--- a/Sources/Views/MainView/Sections/AboutSection.swift
+++ b/Sources/Views/MainView/Sections/AboutSection.swift
@@ -13,6 +13,13 @@ struct AboutSection: View {
 
     @Bindable var viewModel: AboutSectionViewModel
 
+    /// Optional clinical-notes model status (#104). When non-nil and the
+    /// app's Clinical Notes Mode pipeline is configured, the "Powered By"
+    /// section renders a Gemma 4 badge with a live state pill. nil keeps
+    /// the section Parakeet-only — used by previews and tests that don't
+    /// stand up the full pipeline.
+    let modelStatusViewModel: ClinicalNotesModelStatusViewModel?
+
     // MARK: - Environment
 
     @Environment(\.openURL) private var openURL
@@ -20,6 +27,16 @@ struct AboutSection: View {
     // MARK: - Animation State
 
     @State private var isPulsing: Bool = false
+
+    // MARK: - Init
+
+    init(
+        viewModel: AboutSectionViewModel,
+        modelStatusViewModel: ClinicalNotesModelStatusViewModel? = nil
+    ) {
+        self.viewModel = viewModel
+        self.modelStatusViewModel = modelStatusViewModel
+    }
 
     // MARK: - Body
 
@@ -68,8 +85,14 @@ struct AboutSection: View {
             return image
         }
 
-        // Fallback to app icon
-        return NSApp.applicationIconImage
+        // Fallback to app icon. In a unit-test context (no NSApplication
+        // launched) `NSApp.applicationIconImage` is nil; return an empty
+        // placeholder so view inspection doesn't crash. The production
+        // path always has at least the system icon available.
+        if let appIcon = NSApp?.applicationIconImage {
+            return appIcon
+        }
+        return NSImage()
     }
 
     // MARK: - App Identity Section
@@ -157,6 +180,46 @@ struct AboutSection: View {
 
     // MARK: - Technology Section
 
+    private static let gemmaByteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useGB, .useMB]
+        formatter.countStyle = .file
+        formatter.includesUnit = true
+        return formatter
+    }()
+
+    /// Manifest size in human-readable form. Falls back to a generic phrase
+    /// when the manifest is missing (`manifestSizeBytes == 0`) — keeps the
+    /// subtitle copy from reading "Zero KB" mid-sentence.
+    private func formattedGemmaSize(_ bytes: Int64) -> String {
+        guard bytes > 0 else { return "~5 GB" }
+        return Self.gemmaByteFormatter.string(fromByteCount: bytes)
+    }
+
+    /// Maps the live `LLMDownloadState` to the badge's pill copy + tint.
+    /// PHI-free — only structural state.
+    private func pillForGemmaState(
+        _ state: LLMDownloadState,
+        progress: Double
+    ) -> PoweredByBadge.StatePill {
+        switch state {
+        case .idle:
+            return PoweredByBadge.StatePill(label: "Not downloaded", tint: Color.warmAmber)
+        case .downloading:
+            let clamped = min(max(progress, 0), 1)
+            let pct = Int((clamped * 100).rounded())
+            return PoweredByBadge.StatePill(label: "Downloading \(pct)%", tint: Color.warmAmber)
+        case .verified:
+            return PoweredByBadge.StatePill(label: "Verifying", tint: Color.warmAmber)
+        case .ready:
+            return PoweredByBadge.StatePill(label: "Ready", tint: Color.successGreen)
+        case .failed:
+            return PoweredByBadge.StatePill(label: "Failed", tint: Color.errorRed)
+        case .cancelled:
+            return PoweredByBadge.StatePill(label: "Cancelled", tint: Color.secondary)
+        }
+    }
+
     private var technologySection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Powered By")
@@ -166,38 +229,36 @@ struct AboutSection: View {
                 .accessibilityAddTraits(.isHeader)
 
             VStack(alignment: .leading, spacing: 8) {
-                // Parakeet model info
-                HStack(spacing: 12) {
-                    Image(systemName: "waveform.badge.mic")
-                        .font(.title2)
-                        .foregroundStyle(Color.amberPrimary)
-                        .frame(width: 32)
+                // Parakeet — always shown, no state pill (always-on).
+                PoweredByBadge(
+                    icon: "waveform.badge.mic",
+                    iconColor: Color.amberPrimary,
+                    name: "NVIDIA Parakeet TDT",
+                    versionTag: "0.6b-v3",
+                    subtitle: "State-of-the-art multilingual speech recognition running locally via Apple Neural Engine",
+                    accentColor: Color.amberPrimary,
+                    statePill: nil
+                )
 
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(spacing: 6) {
-                            Text("NVIDIA Parakeet TDT")
-                                .font(.callout)
-                                .fontWeight(.medium)
-
-                            Text("0.6b-v3")
-                                .font(.caption)
-                                .fontWeight(.medium)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(Color.amberPrimary.opacity(0.2))
-                                .foregroundStyle(Color.amberPrimary)
-                                .clipShape(RoundedRectangle(cornerRadius: 4))
-                        }
-
-                        Text("State-of-the-art multilingual speech recognition running locally via Apple Neural Engine")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
+                // Gemma 4 — only when the VM is available (Clinical Notes
+                // Mode pipeline is configured). The state pill reflects
+                // the live download lifecycle. PHI-free by construction
+                // (#104 / `.claude/references/phi-handling.md`).
+                if let modelStatusViewModel {
+                    let sizeText = formattedGemmaSize(modelStatusViewModel.manifestSizeBytes)
+                    PoweredByBadge(
+                        icon: "brain.head.profile",
+                        iconColor: Color.amberPrimary,
+                        name: "Gemma 4 E4B-IT",
+                        versionTag: "mlx-4bit",
+                        subtitle: "Local clinical-note drafting via MLX Swift on Apple Silicon. \(sizeText). PHI never leaves your Mac.",
+                        accentColor: Color.amberPrimary,
+                        statePill: pillForGemmaState(
+                            modelStatusViewModel.state,
+                            progress: modelStatusViewModel.progress
+                        )
+                    )
                 }
-                .padding(12)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(nsColor: .controlBackgroundColor))
-                .clipShape(RoundedRectangle(cornerRadius: 8))
 
                 // Privacy note
                 HStack(spacing: 8) {
@@ -430,6 +491,106 @@ final class AboutSectionViewModel {
     }
 }
 
+// MARK: - Powered By Badge
+
+/// Reusable "Powered By" technology card. Used twice in `AboutSection`:
+/// once for Parakeet (always shown, no state pill) and once for Gemma 4
+/// (shown when Clinical Notes Mode infrastructure is available; renders a
+/// real download-state pill driven by `ClinicalNotesModelStatusViewModel`).
+///
+/// PHI-free by construction — every input is structural metadata
+/// (model name, version tag, byte size). See
+/// `.claude/references/phi-handling.md`.
+private struct PoweredByBadge: View {
+    /// Pill rendered next to the version tag. `nil` hides the pill
+    /// entirely (used by Parakeet, which is always-on).
+    struct StatePill: Equatable {
+        let label: String
+        let tint: Color
+    }
+
+    let icon: String
+    let iconColor: Color
+    let name: String
+    let versionTag: String
+    let subtitle: String
+    let accentColor: Color
+    let statePill: StatePill?
+
+    private var slug: String { aboutSectionSlugify(name) }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(iconColor)
+                .frame(width: 32)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(name)
+                        .font(.callout)
+                        .fontWeight(.medium)
+
+                    Text(versionTag)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(accentColor.opacity(0.2))
+                        .foregroundStyle(accentColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                    if let pill = statePill {
+                        Text(pill.label)
+                            .font(.caption)
+                            .fontWeight(.medium)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(pill.tint.opacity(0.2))
+                            .foregroundStyle(pill.tint)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
+                            .accessibilityIdentifier("aboutSection.poweredByBadge.\(slug).statePill")
+                    }
+                }
+
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("aboutSection.poweredByBadge.\(slug)")
+    }
+}
+
+/// Lower-cases an arbitrary display name and converts non-alphanumeric
+/// runs to single hyphens for use as an accessibility-identifier suffix.
+/// Pure / Sendable / file-scope — no Foundation dependency beyond
+/// `String`. Lives at file scope so previews + the badge can share it.
+private func aboutSectionSlugify(_ value: String) -> String {
+    var result = ""
+    var lastWasHyphen = true   // so leading non-alphanumerics drop, not produce "-foo"
+    for scalar in value.unicodeScalars {
+        if scalar.isASCII, let ascii = Character(scalar).lowercased().first,
+           ascii.isLetter || ascii.isNumber {
+            result.append(ascii)
+            lastWasHyphen = false
+        } else if !lastWasHyphen {
+            result.append("-")
+            lastWasHyphen = true
+        }
+    }
+    if result.hasSuffix("-") { result.removeLast() }
+    return result
+}
+
 // MARK: - Previews
 
 #Preview("About Section") {
@@ -443,4 +604,22 @@ final class AboutSectionViewModel {
         .frame(width: 320, height: 600)
         .padding()
         .preferredColorScheme(.dark)
+}
+
+#Preview("About Section - With Gemma 4 Ready") {
+    // Real Gemma 4 manifest size — keeps the subtitle copy realistic.
+    let modelStatusVM = ClinicalNotesModelStatusViewModel(
+        state: .ready,
+        progress: 1,
+        manifestSizeBytes: 5_249_808_308,
+        modelDirectoryURL: URL(
+            fileURLWithPath: "/Users/example/Library/Application Support/com.speechtotext.app/Models/gemma-4-e4b-it-4bit"
+        )
+    )
+    return AboutSection(
+        viewModel: AboutSectionViewModel(),
+        modelStatusViewModel: modelStatusVM
+    )
+        .frame(width: 320, height: 700)
+        .padding()
 }

--- a/Sources/Views/MainView/Sections/AboutSection.swift
+++ b/Sources/Views/MainView/Sections/AboutSection.swift
@@ -204,7 +204,10 @@ struct AboutSection: View {
     ) -> PoweredByBadge.StatePill {
         switch state {
         case .idle:
-            return PoweredByBadge.StatePill(label: "Not downloaded", tint: Color.warmAmber)
+            // Match `ClinicalNotesModelStatusRow`'s `.idle` pill tint:
+            // gray reads as "not yet started"; amber would read as
+            // "active/warning" (Gemini Code Assist PR #119).
+            return PoweredByBadge.StatePill(label: "Not downloaded", tint: Color.secondary)
         case .downloading:
             let clamped = min(max(progress, 0), 1)
             let pct = Int((clamped * 100).rounded())

--- a/Sources/Views/MainView/Sections/ClinicalNotesModelStatusRow.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesModelStatusRow.swift
@@ -1,0 +1,322 @@
+// ClinicalNotesModelStatusRow.swift
+// macOS Local Speech-to-Text Application
+//
+// Issue #104 (Deliverable A) — Settings UI surface for the Gemma 4 model
+// download lifecycle. Lives inside `ClinicalNotesSection` between the
+// connection-status card and the API-key block. PHI-free — only model
+// bytes / directory / state are surfaced. See
+// `.claude/references/mlx-lifecycle.md`.
+
+import SwiftUI
+
+/// Row that surfaces Gemma 4 download state inside `ClinicalNotesSection`.
+///
+/// Shape: leading icon + name/size header + state pill on the right; an
+/// optional progress bar (only while `.downloading`); a short caption
+/// row (model directory) when `.ready`; and a trailing actions cluster
+/// driven by the current state.
+///
+/// Confirmation alerts gate the destructive / bandwidth-heavy actions —
+/// a 5+ GB download, a directory removal, and a re-download all cost
+/// the user's network or disk and warrant an "are you sure" prompt.
+struct ClinicalNotesModelStatusRow: View {
+    @Bindable var viewModel: ClinicalNotesModelStatusViewModel
+
+    @State private var showDownloadConfirm: Bool = false
+    @State private var showRemoveConfirm: Bool = false
+    @State private var showRedownloadConfirm: Bool = false
+
+    private static let modelDisplayName = "Gemma 4 E4B-IT (MLX 4-bit)"
+
+    private static let byteFormatter: ByteCountFormatter = {
+        let formatter = ByteCountFormatter()
+        formatter.allowedUnits = [.useGB, .useMB]
+        formatter.countStyle = .file
+        formatter.includesUnit = true
+        return formatter
+    }()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "brain.head.profile")
+                    .font(.system(size: 22))
+                    .foregroundStyle(Color.warmAmber)
+                    .frame(width: 28)
+                    .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(Self.modelDisplayName) — \(formattedSize)")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text("Local LLM that turns your transcript into structured SOAP notes.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                statePill
+            }
+
+            if case .downloading = viewModel.state {
+                progressBar
+            }
+
+            if isReady, let url = viewModel.modelDirectoryURL {
+                diskUsageRow(url: url)
+            }
+
+            actionButtons
+        }
+        .padding(16)
+        .background(
+            RoundedRectangle(cornerRadius: 14)
+                .fill(Color.cardBackgroundAdaptive)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14)
+                        .stroke(Color.cardBorderAdaptive, lineWidth: 1)
+                )
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("clinicalNotesModelStatusRow")
+        .alert("Download Gemma 4 model?", isPresented: $showDownloadConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Download") {
+                Task { await viewModel.onDownload() }
+            }
+        } message: {
+            Text("This will download \(formattedSize) to ~/Library/Application Support/. The download runs once; subsequent launches reuse the cached model.")
+        }
+        .alert("Remove Gemma 4 model?", isPresented: $showRemoveConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Remove", role: .destructive) {
+                Task { await viewModel.onRemove() }
+            }
+        } message: {
+            Text("This deletes \(formattedSize) of model files from this Mac. You'll need to re-download to use Clinical Notes Mode again.")
+        }
+        .alert("Re-download Gemma 4 model?", isPresented: $showRedownloadConfirm) {
+            Button("Cancel", role: .cancel) {}
+            Button("Re-download") {
+                Task {
+                    await viewModel.onRemove()
+                    // If the removal failed (e.g. mmap holds the directory,
+                    // permissions, or the in-flight task didn't fully unwind)
+                    // the state lands in `.failed`, not `.idle`. Skipping the
+                    // re-download in that case means the user sees the
+                    // honest "Failed" state and can retry from there, instead
+                    // of a silent "Ready" backed by the original (still
+                    // on-disk) bytes (silent-failure-hunter M3).
+                    guard case .idle = viewModel.state else { return }
+                    await viewModel.onDownload()
+                }
+            }
+        } message: {
+            Text("This will remove the existing \(formattedSize) of model files and download them again.")
+        }
+    }
+
+    // MARK: - State pill
+
+    private var statePill: some View {
+        Text(pillCopy)
+            .font(.caption)
+            .fontWeight(.medium)
+            .foregroundStyle(pillTint)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(pillTint.opacity(0.15))
+            .clipShape(Capsule())
+            .accessibilityIdentifier("clinicalNotesModelStatusRow.statePill")
+    }
+
+    private var pillCopy: String {
+        switch viewModel.state {
+        case .idle:
+            return "Not downloaded"
+        case .downloading:
+            return "Downloading \(Int((viewModel.progress * 100).rounded()))%"
+        case .verified:
+            return "Verifying"
+        case .ready:
+            return "Ready"
+        case .failed:
+            return "Failed"
+        case .cancelled:
+            return "Cancelled"
+        }
+    }
+
+    private var pillTint: Color {
+        switch viewModel.state {
+        case .ready:
+            return Color.successGreen
+        case .failed:
+            return Color.errorRed
+        case .downloading, .verified:
+            return Color.warmAmber
+        case .idle, .cancelled:
+            return Color.secondary
+        }
+    }
+
+    // MARK: - Progress bar
+
+    private var progressBar: some View {
+        ProgressView(value: viewModel.progress)
+            .progressViewStyle(.linear)
+            .tint(Color.warmAmber)
+            .accessibilityIdentifier("clinicalNotesModelStatusRow.progressBar")
+            .accessibilityLabel("Downloading model, \(Int((viewModel.progress * 100).rounded())) percent complete")
+    }
+
+    // MARK: - Disk usage caption
+
+    private func diskUsageRow(url: URL) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "externaldrive")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .accessibilityHidden(true)
+            // Abbreviate the user-home path so screen-share scenarios
+            // don't leak the macOS username (which is often the
+            // practitioner's name). `~/Library/...` reads cleaner anyway.
+            // No log emission — this is a UI-only surface.
+            Text("\(formattedSize) at \(NSString(string: url.path).abbreviatingWithTildeInPath)")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .lineLimit(2)
+                .truncationMode(.middle)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer()
+        }
+        .accessibilityIdentifier("clinicalNotesModelStatusRow.diskUsageRow")
+    }
+
+    // MARK: - Action buttons
+
+    @ViewBuilder
+    private var actionButtons: some View {
+        switch viewModel.state {
+        case .idle, .cancelled:
+            HStack {
+                Spacer()
+                Button {
+                    showDownloadConfirm = true
+                } label: {
+                    Label("Download model", systemImage: "arrow.down.circle")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Color.warmAmber)
+                .accessibilityIdentifier("clinicalNotesModelStatusRow.actionButton")
+            }
+        case .downloading, .verified:
+            HStack {
+                Spacer()
+                Button(role: .destructive) {
+                    Task { await viewModel.onCancel() }
+                } label: {
+                    Label("Cancel", systemImage: "xmark.circle")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("clinicalNotesModelStatusRow.actionButton")
+            }
+        case .ready:
+            HStack(spacing: 8) {
+                Spacer()
+                Button {
+                    showRedownloadConfirm = true
+                } label: {
+                    Label("Re-download", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("clinicalNotesModelStatusRow.redownloadButton")
+
+                Button(role: .destructive) {
+                    showRemoveConfirm = true
+                } label: {
+                    Label("Remove", systemImage: "trash")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityIdentifier("clinicalNotesModelStatusRow.actionButton")
+            }
+        case .failed:
+            HStack {
+                Spacer()
+                Button {
+                    showDownloadConfirm = true
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Color.warmAmber)
+                .accessibilityIdentifier("clinicalNotesModelStatusRow.actionButton")
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var isReady: Bool {
+        if case .ready = viewModel.state { return true }
+        return false
+    }
+
+    /// Manifest-size in human-readable form. `0` is rare (manifest absent)
+    /// but harmless — `ByteCountFormatter` returns "Zero KB".
+    private var formattedSize: String {
+        Self.byteFormatter.string(fromByteCount: viewModel.manifestSizeBytes)
+    }
+}
+
+// MARK: - Previews
+
+#Preview("Idle") {
+    ClinicalNotesModelStatusRow(
+        viewModel: ClinicalNotesModelStatusViewModel(
+            state: .idle,
+            manifestSizeBytes: 5_250_000_000
+        )
+    )
+    .frame(width: 600)
+    .padding()
+}
+
+#Preview("Downloading") {
+    ClinicalNotesModelStatusRow(
+        viewModel: ClinicalNotesModelStatusViewModel(
+            state: .downloading,
+            progress: 0.42,
+            manifestSizeBytes: 5_250_000_000
+        )
+    )
+    .frame(width: 600)
+    .padding()
+}
+
+#Preview("Ready") {
+    ClinicalNotesModelStatusRow(
+        viewModel: ClinicalNotesModelStatusViewModel(
+            state: .ready,
+            progress: 1,
+            manifestSizeBytes: 5_250_000_000,
+            modelDirectoryURL: URL(fileURLWithPath: "/Users/example/Library/Application Support/com.speechtotext.app/Models/gemma-4-e4b-it-4bit")
+        )
+    )
+    .frame(width: 600)
+    .padding()
+}
+
+#Preview("Failed") {
+    ClinicalNotesModelStatusRow(
+        viewModel: ClinicalNotesModelStatusViewModel(
+            state: .failed,
+            manifestSizeBytes: 5_250_000_000
+        )
+    )
+    .frame(width: 600)
+    .padding()
+}

--- a/Sources/Views/MainView/Sections/ClinicalNotesModelStatusViewModel.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesModelStatusViewModel.swift
@@ -1,0 +1,91 @@
+// ClinicalNotesModelStatusViewModel.swift
+// macOS Local Speech-to-Text Application
+//
+// Issue #104 (Deliverable A) — Settings-side surface for the Gemma 4 model
+// download lifecycle. Mirrors the relevant `AppState` properties so the
+// `ClinicalNotesModelStatusRow` view can bind without reaching into the
+// app-wide observable. PHI-free by construction — the model bytes and
+// directory are not patient-adjacent. See `.claude/references/mlx-lifecycle.md`
+// for the lifecycle this VM surfaces and `.claude/references/phi-handling.md`
+// for the logging policy (this VM logs nothing on its own).
+
+import Foundation
+import Observation
+
+/// Observable state for the "Model status" row inside `ClinicalNotesSection`.
+///
+/// `AppState` constructs and owns one instance, mirrors its own
+/// `llmDownloadState` / `llmDownloadProgress` into this VM, and routes the
+/// three user actions (Download, Cancel, Remove) through injected closures.
+/// Defaulting the closures to no-ops keeps `ClinicalNotesModelStatusRowTests`
+/// dependency-free.
+///
+/// Concurrency: `@Observable @MainActor` — the closures cross the actor
+/// boundary as `@Sendable` so the row's button taps can fire them
+/// directly. Callers run them inside a `Task { await ... }` from the UI.
+@Observable
+@MainActor
+final class ClinicalNotesModelStatusViewModel {
+    /// Mirrors `AppState.llmDownloadState`. Drives every visible affordance
+    /// in the row — pill copy, button shape, progress-bar visibility.
+    var state: LLMDownloadState
+
+    /// Mirrors `AppState.llmDownloadProgress`, in `[0, 1]`. Only consulted
+    /// while `state == .downloading`. Clamped at the property so consumers
+    /// (the row's progress bar, the About-section pill) don't have to
+    /// repeat the clamp at every read site (type-design-analyzer suggestion).
+    var progress: Double {
+        didSet {
+            let clamped = min(max(progress, 0), 1)
+            // `didSet` re-fires on a self-write only when the new value
+            // differs, so the loop terminates on the first tail call.
+            if clamped != progress { progress = clamped }
+        }
+    }
+
+    /// Manifest's `total_bytes`. May be `0` if the bundled manifest is
+    /// missing — in that pathological case the row reads "Gemma 4 E4B-IT —
+    /// 0 bytes" rather than crashing. The byte-count formatter handles 0
+    /// gracefully ("Zero KB").
+    var manifestSizeBytes: Int64
+
+    /// Set when the model directory has been verified on disk. Surfaced in
+    /// the disk-usage caption row that only appears in `.ready`.
+    var modelDirectoryURL: URL?
+
+    /// Tap handler for the primary "Download model" / "Retry" affordance.
+    /// `@Sendable` so the row can fire it from a `Task` without capturing
+    /// VM state. Defaults to a no-op so test fixtures don't have to wire
+    /// production hooks.
+    @ObservationIgnored let onDownload: @Sendable () async -> Void
+
+    /// Tap handler for the "Cancel" affordance — visible during
+    /// `.downloading` and during the post-download `.verified` warmup
+    /// window where cancel is still meaningful.
+    @ObservationIgnored let onCancel: @Sendable () async -> Void
+
+    /// Tap handler for the "Remove" affordance — visible when the model is
+    /// `.ready`. Removes the on-disk directory and resets state.
+    @ObservationIgnored let onRemove: @Sendable () async -> Void
+
+    /// Production wiring constructor. `AppState.init` calls this with
+    /// closures that route to `AppState.downloadClinicalNotesModel()`,
+    /// `cancelClinicalNotesModelDownload()`, and `removeClinicalNotesModel()`.
+    init(
+        state: LLMDownloadState = .idle,
+        progress: Double = 0,
+        manifestSizeBytes: Int64 = 0,
+        modelDirectoryURL: URL? = nil,
+        onDownload: @escaping @Sendable () async -> Void = {},
+        onCancel: @escaping @Sendable () async -> Void = {},
+        onRemove: @escaping @Sendable () async -> Void = {}
+    ) {
+        self.state = state
+        self.progress = progress
+        self.manifestSizeBytes = manifestSizeBytes
+        self.modelDirectoryURL = modelDirectoryURL
+        self.onDownload = onDownload
+        self.onCancel = onCancel
+        self.onRemove = onRemove
+    }
+}

--- a/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
@@ -21,6 +21,12 @@ struct ClinicalNotesSection: View {
 
     let settingsService: SettingsService
 
+    /// Optional Gemma 4 download status surface (#104, Deliverable A).
+    /// `nil` in render-only test fixtures and historical previews so
+    /// existing tests don't have to wire up the production VM. AppState
+    /// passes a real instance through `MainWindowController.configure(...)`.
+    let modelStatusViewModel: ClinicalNotesModelStatusViewModel?
+
     // MARK: - State
 
     @State private var settings: UserSettings
@@ -31,10 +37,12 @@ struct ClinicalNotesSection: View {
 
     init(
         viewModel: ClinicalNotesSectionViewModel,
-        settingsService: SettingsService = SettingsService()
+        settingsService: SettingsService = SettingsService(),
+        modelStatusViewModel: ClinicalNotesModelStatusViewModel? = nil
     ) {
         self.viewModel = viewModel
         self.settingsService = settingsService
+        self.modelStatusViewModel = modelStatusViewModel
         self._settings = State(initialValue: settingsService.load())
     }
 
@@ -54,6 +62,10 @@ struct ClinicalNotesSection: View {
                 }
 
                 connectionStatusCard
+
+                if showModelStatusRow, let modelStatusViewModel {
+                    ClinicalNotesModelStatusRow(viewModel: modelStatusViewModel)
+                }
 
                 Divider().padding(.vertical, 4)
 
@@ -120,6 +132,15 @@ struct ClinicalNotesSection: View {
     /// Cliniko credentials are present.
     private var showShortcutRow: Bool {
         settings.general.clinicalNotesModeEnabled && viewModel.hasStoredCredentials
+    }
+
+    /// Whether the Gemma 4 model status row should appear (#104). Gated on
+    /// Clinical Notes Mode being on — the model is only relevant once the
+    /// feature is enabled. Deliberately *not* gated on Cliniko credentials:
+    /// model and credentials are orthogonal pre-conditions for the SOAP
+    /// pipeline and the user can prepare them in any order.
+    private var showModelStatusRow: Bool {
+        settings.general.clinicalNotesModeEnabled
     }
 
     // MARK: - Section Header

--- a/Tests/SpeechToTextTests/Services/AppStateModelStatusTests.swift
+++ b/Tests/SpeechToTextTests/Services/AppStateModelStatusTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+/// Swift Testing coverage for the new Settings-side model lifecycle methods
+/// on `AppState` (#104, Deliverable A): `cancelClinicalNotesModelDownload()`
+/// and `removeClinicalNotesModel()`. The full download path is exercised by
+/// `MLXGemmaProviderGoldenTests` (gated on `RUN_MLX_GOLDEN=1` and
+/// `.requiresHardware`); we don't repeat that here. These tests are
+/// `.fast` — pure state-machine / file-cleanup checks against a real
+/// `AppState`, no network or LLM inference.
+@Suite("AppState model status (#104)", .tags(.fast))
+@MainActor
+struct AppStateModelStatusTests {
+
+    @Test("cancelClinicalNotesModelDownload is safe with no active task")
+    func cancelClinicalNotesModelDownload_safeWhenNoneInFlight() async {
+        let appState = AppState()
+        // Default state at fresh init: nothing in flight, slot is nil.
+        // Cancel must be a structural no-op — no crash, no state change.
+        appState.cancelClinicalNotesModelDownload()
+        appState.cancelClinicalNotesModelDownload()
+        #expect(appState.llmDownloadState == .idle)
+    }
+
+    @Test("removeClinicalNotesModel resets state to idle")
+    func removeClinicalNotesModel_resetsState() async {
+        let appState = AppState()
+        // Force the state machine into a non-idle state so we can witness
+        // the reset. We use the public mirror surface: writing the
+        // `@Observable` properties directly is the same path the pipeline
+        // uses internally.
+        appState.llmDownloadState = .failed
+        appState.llmDownloadProgress = 0.5
+
+        await appState.removeClinicalNotesModel()
+
+        #expect(appState.llmDownloadState == .idle)
+        #expect(appState.llmDownloadProgress == 0)
+        // The mirrored VM follows.
+        #expect(appState.modelStatusViewModel.state == .idle)
+        #expect(appState.modelStatusViewModel.progress == 0)
+        #expect(appState.modelStatusViewModel.modelDirectoryURL == nil)
+    }
+
+    @Test("removeClinicalNotesModel deletes an on-disk fixture directory when present")
+    func removeClinicalNotesModel_deletesFixtureDirectory() async throws {
+        let appState = AppState()
+        // We can only meaningfully exercise the `removeItem` branch if the
+        // bundled manifest loaded. In pathological dev builds without the
+        // manifest, AppState wires `llmManifest = nil` and `removeClinicalNotesModel`
+        // collapses to the "no manifest" branch — which still resets state
+        // (already covered by the previous test), so we soft-skip here.
+        guard let manifest = appState.llmManifest else {
+            // The structural pre-condition didn't hold; still assert
+            // state-only behaviour is correct, then return.
+            await appState.removeClinicalNotesModel()
+            #expect(appState.llmDownloadState == .idle)
+            return
+        }
+        let dir = ModelDownloader.defaultBaseDirectory()
+            .appendingPathComponent(manifest.modelDirectoryName, isDirectory: true)
+
+        // Seed a marker file inside the model directory so we can prove
+        // the unlink ran. Using a tiny placeholder keeps disk churn cheap.
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let marker = dir.appendingPathComponent("test-marker.txt")
+        try Data("marker".utf8).write(to: marker)
+        #expect(FileManager.default.fileExists(atPath: marker.path))
+
+        await appState.removeClinicalNotesModel()
+
+        #expect(!FileManager.default.fileExists(atPath: marker.path))
+        #expect(!FileManager.default.fileExists(atPath: dir.path))
+        #expect(appState.llmDownloadState == .idle)
+        #expect(appState.modelStatusViewModel.state == .idle)
+    }
+
+    @Test("modelStatusViewModel mirrors manifest size at init")
+    func modelStatusViewModel_mirrorsManifestSize() async {
+        let appState = AppState()
+        // The wired VM reflects the bundled manifest. We don't assert on a
+        // hard-coded byte count (it bumps with manifest revisions); we just
+        // confirm the wiring delivers the same value the manifest carries.
+        let expected = appState.llmManifest?.totalBytes ?? 0
+        #expect(appState.modelStatusViewModel.manifestSizeBytes == expected)
+    }
+}

--- a/Tests/SpeechToTextTests/Views/ClinicalNotesModelStatusRowTests.swift
+++ b/Tests/SpeechToTextTests/Views/ClinicalNotesModelStatusRowTests.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import SpeechToText
+
+/// Render-crash + state-affordance tests for `ClinicalNotesModelStatusRow`
+/// (#104, Deliverable A). Each case constructs a fresh
+/// `ClinicalNotesModelStatusViewModel` with a hand-built state, mounts the
+/// row, and asserts the expected accessibility identifiers are reachable.
+/// No production wiring (downloader, file system) is involved — the VM's
+/// no-op-closure test convenience init keeps these tests pure.
+@MainActor
+final class ClinicalNotesModelStatusRowTests: XCTestCase {
+
+    // 5.25 GB — the manifest size we expect to surface in the row's header.
+    // Tests don't depend on the exact value but using a realistic one keeps
+    // the formatted string assertions plausible.
+    private static let sampleManifestBytes: Int64 = 5_250_000_000
+
+    private func makeViewModel(
+        state: LLMDownloadState,
+        progress: Double = 0,
+        modelDirectoryURL: URL? = nil
+    ) -> ClinicalNotesModelStatusViewModel {
+        ClinicalNotesModelStatusViewModel(
+            state: state,
+            progress: progress,
+            manifestSizeBytes: Self.sampleManifestBytes,
+            modelDirectoryURL: modelDirectoryURL
+        )
+    }
+
+    // MARK: - Render-crash test
+
+    func test_modelStatusRow_instantiatesWithoutCrash() {
+        let viewModel = makeViewModel(state: .idle)
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+        XCTAssertNotNil(view)
+    }
+
+    // MARK: - Idle
+
+    func test_idleState_showsDownloadButton() throws {
+        let viewModel = makeViewModel(state: .idle)
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.statePill")
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton")
+        )
+        // No progress bar when idle.
+        XCTAssertThrowsError(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.progressBar"),
+            "Progress bar must be hidden when not downloading"
+        )
+        // No disk-usage row when idle (model not on disk).
+        XCTAssertThrowsError(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.diskUsageRow"),
+            "Disk-usage row only shows in .ready"
+        )
+    }
+
+    // MARK: - Downloading
+
+    func test_downloadingState_showsProgressBarAndCancel() throws {
+        let viewModel = makeViewModel(state: .downloading, progress: 0.42)
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.progressBar")
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton")
+        )
+        // No disk-usage row mid-download.
+        XCTAssertThrowsError(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.diskUsageRow")
+        )
+    }
+
+    // MARK: - Verifying (post-download warmup)
+
+    func test_verifyingState_showsCancel() throws {
+        let dir = URL(fileURLWithPath: "/tmp/test/gemma-4-e4b-it-4bit")
+        let viewModel = makeViewModel(state: .verified(directory: dir), progress: 1)
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.statePill")
+        )
+        // The action button is "Cancel" in `.verified` state.
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton")
+        )
+        // Progress bar hidden — verifying is post-download.
+        XCTAssertThrowsError(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.progressBar")
+        )
+    }
+
+    // MARK: - Ready
+
+    func test_readyState_showsRemoveAndReDownload_andDiskUsageRow() throws {
+        let dir = URL(fileURLWithPath: "/tmp/test/gemma-4-e4b-it-4bit")
+        let viewModel = makeViewModel(state: .ready, progress: 1, modelDirectoryURL: dir)
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+
+        // Remove + redownload buttons.
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton"),
+            "Remove button must be present in .ready"
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.redownloadButton"),
+            "Re-download button must be present in .ready"
+        )
+        // Disk-usage row visible only in .ready.
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.diskUsageRow")
+        )
+        // Progress bar hidden in .ready.
+        XCTAssertThrowsError(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.progressBar")
+        )
+    }
+
+    // MARK: - Failed
+
+    func test_failedState_showsRetry() throws {
+        let viewModel = makeViewModel(state: .failed)
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.statePill")
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton"),
+            "Retry button must be present in .failed"
+        )
+    }
+
+    // MARK: - Cancelled
+
+    func test_cancelledState_showsDownloadButton() throws {
+        let viewModel = makeViewModel(state: .cancelled)
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.statePill")
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton"),
+            "Download button must be present in .cancelled (cancelled is recoverable)"
+        )
+    }
+}

--- a/Tests/SpeechToTextTests/Views/PoweredByBadgeTests.swift
+++ b/Tests/SpeechToTextTests/Views/PoweredByBadgeTests.swift
@@ -1,0 +1,166 @@
+import SwiftUI
+import ViewInspector
+import XCTest
+@testable import SpeechToText
+
+/// Render + state-pill tests for the `PoweredByBadge` component embedded in
+/// `AboutSection` (#104, Deliverable B). The badge itself is `fileprivate`,
+/// so these tests exercise it indirectly through the public `AboutSection`
+/// surface — instantiating the section with / without a
+/// `ClinicalNotesModelStatusViewModel`, then inspecting the published
+/// accessibility identifiers.
+///
+/// PHI-free by construction — the VM only carries model bytes, directory,
+/// and download state. No transcript / patient data flows through the
+/// badge.
+@MainActor
+final class PoweredByBadgeTests: XCTestCase {
+
+    // Realistic Gemma 4 manifest size — keeps the subtitle copy plausible.
+    private static let sampleManifestBytes: Int64 = 5_249_808_308
+
+    // MARK: - Helpers
+
+    private func makeAbout(
+        modelStatusViewModel: ClinicalNotesModelStatusViewModel? = nil
+    ) -> AboutSection {
+        AboutSection(
+            viewModel: AboutSectionViewModel(),
+            modelStatusViewModel: modelStatusViewModel
+        )
+    }
+
+    private func makeVM(
+        state: LLMDownloadState,
+        progress: Double = 0
+    ) -> ClinicalNotesModelStatusViewModel {
+        ClinicalNotesModelStatusViewModel(
+            state: state,
+            progress: progress,
+            manifestSizeBytes: Self.sampleManifestBytes
+        )
+    }
+
+    /// All six `LLMDownloadState` variants — kept as a fixture so the
+    /// "Parakeet has no pill" exhaustiveness test doesn't drift if the
+    /// enum ever grows a case.
+    private func allStates() -> [LLMDownloadState] {
+        [
+            .idle,
+            .downloading,
+            .verified(directory: URL(fileURLWithPath: "/tmp/test/gemma-4")),
+            .ready,
+            .failed,
+            .cancelled
+        ]
+    }
+
+    // MARK: - Without VM: Parakeet only
+
+    func test_aboutSection_withoutVM_rendersOnlyParakeet() throws {
+        let view = makeAbout()
+        let inspected = try view.inspect()
+
+        XCTAssertNoThrow(
+            try inspected.find(viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.nvidia-parakeet-tdt"),
+            "Parakeet badge must always render"
+        )
+        XCTAssertThrowsError(
+            try inspected.find(viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.gemma-4-e4b-it"),
+            "Gemma 4 badge must be hidden when no model-status VM is supplied"
+        )
+    }
+
+    // MARK: - With VM: state-pill copy per state
+
+    func test_aboutSection_withVMReady_rendersGemmaBadgeAndReadyPill() throws {
+        let viewModel = makeVM(state: .ready, progress: 1)
+        let view = makeAbout(modelStatusViewModel: viewModel)
+        let inspected = try view.inspect()
+
+        XCTAssertNoThrow(
+            try inspected.find(viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.gemma-4-e4b-it"),
+            "Gemma 4 badge must render when VM is supplied"
+        )
+        let pill = try inspected.find(
+            viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.gemma-4-e4b-it.statePill"
+        )
+        let pillText = try pill.text().string()
+        XCTAssertTrue(
+            pillText.contains("Ready"),
+            "State pill in .ready must read 'Ready'. Got: \(pillText)"
+        )
+    }
+
+    func test_aboutSection_withVMIdle_pillSaysNotDownloaded() throws {
+        let viewModel = makeVM(state: .idle)
+        let view = makeAbout(modelStatusViewModel: viewModel)
+        let inspected = try view.inspect()
+
+        let pill = try inspected.find(
+            viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.gemma-4-e4b-it.statePill"
+        )
+        let pillText = try pill.text().string()
+        XCTAssertTrue(
+            pillText.contains("Not downloaded"),
+            "State pill in .idle must read 'Not downloaded'. Got: \(pillText)"
+        )
+    }
+
+    func test_aboutSection_withVMDownloading_pillShowsPercent() throws {
+        let viewModel = makeVM(state: .downloading, progress: 0.42)
+        let view = makeAbout(modelStatusViewModel: viewModel)
+        let inspected = try view.inspect()
+
+        let pill = try inspected.find(
+            viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.gemma-4-e4b-it.statePill"
+        )
+        let pillText = try pill.text().string()
+        XCTAssertTrue(
+            pillText.contains("42"),
+            "State pill in .downloading must include the percent value '42'. Got: \(pillText)"
+        )
+        XCTAssertTrue(
+            pillText.contains("Downloading"),
+            "State pill in .downloading must read 'Downloading …'. Got: \(pillText)"
+        )
+    }
+
+    func test_aboutSection_withVMFailed_pillSaysFailed() throws {
+        let viewModel = makeVM(state: .failed)
+        let view = makeAbout(modelStatusViewModel: viewModel)
+        let inspected = try view.inspect()
+
+        let pill = try inspected.find(
+            viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.gemma-4-e4b-it.statePill"
+        )
+        let pillText = try pill.text().string()
+        XCTAssertTrue(
+            pillText.contains("Failed"),
+            "State pill in .failed must read 'Failed'. Got: \(pillText)"
+        )
+    }
+
+    // MARK: - Parakeet has no state pill regardless of VM state
+
+    func test_aboutSection_parakeetBadgeNeverShowsStatePill() throws {
+        for state in allStates() {
+            let viewModel = makeVM(state: state, progress: 0.5)
+            let view = makeAbout(modelStatusViewModel: viewModel)
+            let inspected = try view.inspect()
+
+            // Parakeet badge always present.
+            XCTAssertNoThrow(
+                try inspected.find(viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.nvidia-parakeet-tdt"),
+                "Parakeet badge must render in every state. State: \(state)"
+            )
+            // Parakeet's pill identifier never present.
+            XCTAssertThrowsError(
+                try inspected.find(
+                    viewWithAccessibilityIdentifier: "aboutSection.poweredByBadge.nvidia-parakeet-tdt.statePill"
+                ),
+                "Parakeet badge must never expose a state pill. State: \(state)"
+            )
+        }
+    }
+}

--- a/Tests/SpeechToTextTests/Views/ReviewScreenFallbackCopyTests.swift
+++ b/Tests/SpeechToTextTests/Views/ReviewScreenFallbackCopyTests.swift
@@ -1,0 +1,250 @@
+// ReviewScreenFallbackCopyTests.swift
+// macOS Local Speech-to-Text Application
+//
+// Coverage for #104 Deliverable C — fallback-banner copy branches on
+// `ReviewViewModel.fallbackReasonCode`, and the
+// `model_unavailable` variant exposes a deep-link button to Settings →
+// Clinical Notes.
+//
+// Two surfaces tested in one file:
+//   - Swift Testing `.fast` suite for the per-reason-code subtitle copy
+//     plus the `openClinicalNotesSettings` handler routing.
+//   - XCTest + ViewInspector class for the deep-link button's visibility
+//     across reason codes (matches the existing `ReviewScreenRenderTests`
+//     idiom — accessibility-identifier based assertions).
+//
+// PHI: synthetic fixtures only. Reason codes are structural `String`
+// constants on `ClinicalNotesProcessor` — never PHI. See
+// `.claude/references/phi-handling.md`.
+
+import Foundation
+import SwiftUI
+import Testing
+import ViewInspector
+import XCTest
+@testable import SpeechToText
+
+// MARK: - Helpers
+
+@MainActor
+private enum ReviewScreenFallbackCopyFixture {
+    static func stubManipulations() -> ManipulationsRepository {
+        ManipulationsRepository(all: [
+            Manipulation(id: "diversified_hvla", displayName: "Diversified HVLA", clinikoCode: nil)
+        ])
+    }
+
+    /// Build a `ReviewViewModel` whose `loadState` is
+    /// `.fallback(reasonCode:)` for the supplied code. Mirrors the
+    /// fixture shape used by `ReviewScreenRenderTests` so the two
+    /// suites stay in lockstep.
+    static func makeFallbackViewModel(
+        reasonCode: String,
+        openClinicalNotesSettingsHandler: @escaping @MainActor () -> Void = {}
+    ) -> ReviewViewModel {
+        let store = SessionStore()
+        var recording = RecordingSession(language: "en", state: .completed)
+        recording.transcribedText = "Synthetic transcript for fallback-copy coverage."
+        store.start(from: recording)
+        store.setDraftNotes(StructuredNotes())
+        store.setDraftStatus(.fallback(reasonCode: reasonCode))
+        return ReviewViewModel(
+            sessionStore: store,
+            manipulations: stubManipulations(),
+            openClinicalNotesSettingsHandler: openClinicalNotesSettingsHandler
+        )
+    }
+
+    /// Walk the rendered ReviewScreen and return the joined `Text`
+    /// contents inside the fallback banner. Lets the subtitle-copy
+    /// assertions pin user-visible wording without exposing the
+    /// `private` `fallbackBannerSubtitle` accessor.
+    static func joinedFallbackBannerText(viewModel: ReviewViewModel) throws -> String {
+        let screen = ReviewScreen(viewModel: viewModel)
+        let inspected = try screen.inspect()
+        let banner = try inspected.find(viewWithAccessibilityIdentifier: "reviewScreen.fallbackBanner")
+        return banner
+            .findAll(ViewType.Text.self)
+            .compactMap { try? $0.string() }
+            .joined(separator: " ")
+    }
+}
+
+// MARK: - Subtitle copy (Swift Testing)
+
+@Suite("ReviewScreen fallback banner subtitle copy", .tags(.fast))
+@MainActor
+struct ReviewScreenFallbackBannerSubtitleTests {
+
+    @Test("model_unavailable copy points the doctor to Settings")
+    func fallbackBannerSubtitle_modelUnavailable_pointsToSettings() throws {
+        let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(
+            reasonCode: ClinicalNotesProcessor.reasonModelUnavailable
+        )
+        let joined = try ReviewScreenFallbackCopyFixture.joinedFallbackBannerText(viewModel: viewModel)
+        #expect(
+            joined.contains("isn't ready"),
+            "model_unavailable copy must surface the readiness explanation. Joined banner text: \(joined)"
+        )
+        #expect(
+            joined.contains("Settings"),
+            "model_unavailable copy must mention Settings as the next step. Joined banner text: \(joined)"
+        )
+    }
+
+    @Test("model_download_cancelled copy points the doctor to Settings to finish")
+    func fallbackBannerSubtitle_modelDownloadCancelled_pointsToSettings() throws {
+        let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(
+            reasonCode: ClinicalNotesProcessor.reasonModelDownloadCancelled
+        )
+        let joined = try ReviewScreenFallbackCopyFixture.joinedFallbackBannerText(viewModel: viewModel)
+        #expect(
+            joined.contains("cancelled"),
+            "model_download_cancelled copy must say cancelled. Joined banner text: \(joined)"
+        )
+        #expect(
+            joined.contains("Settings"),
+            "model_download_cancelled copy must mention Settings. Joined banner text: \(joined)"
+        )
+    }
+
+    @Test("session_expired copy prompts the doctor to re-record")
+    func fallbackBannerSubtitle_sessionExpired_promptsReRecord() throws {
+        let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(
+            reasonCode: ClinicalNotesProcessor.reasonSessionExpired
+        )
+        let joined = try ReviewScreenFallbackCopyFixture.joinedFallbackBannerText(viewModel: viewModel)
+        #expect(
+            joined.contains("Session expired"),
+            "session_expired copy must surface the lifecycle reason. Joined banner text: \(joined)"
+        )
+    }
+
+    @Test("llm_error keeps the generic edit-or-insert copy")
+    func fallbackBannerSubtitle_llmError_keepsGenericCopy() throws {
+        let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(
+            reasonCode: ClinicalNotesProcessor.reasonLLMError
+        )
+        let joined = try ReviewScreenFallbackCopyFixture.joinedFallbackBannerText(viewModel: viewModel)
+        #expect(
+            joined.contains("Edit the SOAP"),
+            "llm_error must fall back to the generic copy. Joined banner text: \(joined)"
+        )
+    }
+
+    @Test("invalid_json_after_retry keeps the generic edit-or-insert copy")
+    func fallbackBannerSubtitle_invalidJSON_keepsGenericCopy() throws {
+        let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(
+            reasonCode: ClinicalNotesProcessor.reasonInvalidJSONAfterRetry
+        )
+        let joined = try ReviewScreenFallbackCopyFixture.joinedFallbackBannerText(viewModel: viewModel)
+        #expect(
+            joined.contains("Edit the SOAP"),
+            "invalid_json_after_retry must fall back to the generic copy. Joined banner text: \(joined)"
+        )
+    }
+
+    @Test("all_soap_empty_after_retry keeps the generic edit-or-insert copy")
+    func fallbackBannerSubtitle_allEmpty_keepsGenericCopy() throws {
+        let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(
+            reasonCode: ClinicalNotesProcessor.reasonAllSOAPEmptyAfterRetry
+        )
+        let joined = try ReviewScreenFallbackCopyFixture.joinedFallbackBannerText(viewModel: viewModel)
+        #expect(
+            joined.contains("Edit the SOAP"),
+            "all_soap_empty_after_retry must fall back to the generic copy. Joined banner text: \(joined)"
+        )
+    }
+}
+
+// MARK: - Handler routing (Swift Testing)
+
+/// Tiny `actor` flag used by the handler-routing test to capture the
+/// closure invocation deterministically across the `@MainActor`
+/// boundary. Avoids the `nonisolated(unsafe)` SwiftLint warning.
+actor InvocationFlag {
+    private(set) var didFire: Bool = false
+
+    func mark() {
+        didFire = true
+    }
+
+    func value() -> Bool { didFire }
+}
+
+@Suite("ReviewViewModel.openClinicalNotesSettings", .tags(.fast))
+@MainActor
+struct ReviewViewModelOpenClinicalNotesSettingsTests {
+
+    @Test("openClinicalNotesSettings invokes the injected handler")
+    func openClinicalNotesSettings_invokesInjectedHandler() async {
+        let flag = InvocationFlag()
+        let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(
+            reasonCode: ClinicalNotesProcessor.reasonModelUnavailable,
+            openClinicalNotesSettingsHandler: {
+                Task { await flag.mark() }
+            }
+        )
+
+        viewModel.openClinicalNotesSettings()
+
+        // The handler dispatches a child Task so the flag write may
+        // race the assertion. Yield until the actor reports the
+        // mutation rather than gating on a timer.
+        for _ in 0..<50 where await flag.value() == false {
+            await Task.yield()
+        }
+
+        #expect(await flag.value(), "Injected handler must be invoked exactly once")
+    }
+}
+
+// MARK: - Deep-link button visibility (XCTest + ViewInspector)
+
+@MainActor
+final class ReviewScreenOpenClinicalNotesSettingsButtonVisibilityTests: XCTestCase {
+
+    /// `model_unavailable` and `model_download_cancelled` should both
+    /// expose the deep-link button — both recover via Settings → Clinical
+    /// Notes (start the download / finish the cancelled download). Every
+    /// other fallback reason must omit it so the doctor's attention stays
+    /// on the editing surface.
+    func test_openClinicalNotesSettingsButton_visibleOnlyForModelLifecycleReasons() throws {
+        let visibleCases: [String] = [
+            ClinicalNotesProcessor.reasonModelUnavailable,
+            ClinicalNotesProcessor.reasonModelDownloadCancelled
+        ]
+        let hiddenCases: [String] = [
+            ClinicalNotesProcessor.reasonSessionExpired,
+            ClinicalNotesProcessor.reasonLLMError,
+            ClinicalNotesProcessor.reasonInvalidJSONAfterRetry,
+            ClinicalNotesProcessor.reasonAllSOAPEmptyAfterRetry
+        ]
+
+        for reason in visibleCases {
+            let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(reasonCode: reason)
+            let screen = ReviewScreen(viewModel: viewModel)
+            let inspected = try screen.inspect()
+            XCTAssertNoThrow(
+                try inspected.find(viewWithAccessibilityIdentifier: "reviewScreen.fallback.openClinicalNotesSettings"),
+                "Deep-link button must be visible for reason=\(reason)"
+            )
+            // Sanity: the existing raw-transcript affordance also stays
+            // — the deep-link is *additive*, not a replacement.
+            XCTAssertNoThrow(
+                try inspected.find(viewWithAccessibilityIdentifier: "reviewScreen.fallback.insertRawTranscript"),
+                "Insert raw transcript button must remain visible for reason=\(reason)"
+            )
+        }
+
+        for reason in hiddenCases {
+            let viewModel = ReviewScreenFallbackCopyFixture.makeFallbackViewModel(reasonCode: reason)
+            let screen = ReviewScreen(viewModel: viewModel)
+            let inspected = try screen.inspect()
+            XCTAssertThrowsError(
+                try inspected.find(viewWithAccessibilityIdentifier: "reviewScreen.fallback.openClinicalNotesSettings"),
+                "Deep-link button must NOT be visible for reason=\(reason)"
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #104. Closes the user-facing visibility gap on the headline clinical-notes feature: Generate Notes no longer triggers a 5+ GB silent download on first tap. The doctor opts in from Settings → Clinical Notes, sees live state + progress, and gets actionable banner copy + a deep-link back to Settings if the model isn't ready when they hit Generate Notes.

Three deliverables, built by parallel Opus subagent teams, then folded through the three-layer review pipeline:

- **A.** Settings → Clinical Notes "Model status" row (`ClinicalNotesModelStatusRow` + `ClinicalNotesModelStatusViewModel`) with state pill, progress bar, contextual action button, and confirmation alerts before destructive / bandwidth-heavy actions. `AppState` exposes `downloadClinicalNotesModel()` / `cancelClinicalNotesModelDownload()` / `removeClinicalNotesModel()` and refactors the existing transcript-driven pipeline to delegate the download/warmup phase to the same helper.
- **B.** About → "Powered By" Gemma 4 badge. Extracted reusable `PoweredByBadge`; Parakeet stays always-on, Gemma 4 surfaces a real `Ready` / `Not downloaded` / `Downloading X%` pill.
- **C.** `ReviewScreen.fallbackBannerSubtitle` branches on the structural `fallbackReasonCode`. New `reasonModelDownloadCancelled` distinguishes user-cancel from download-failed. Both lifecycle reasons surface the "Open Clinical Notes Settings" deep-link.

## Acceptance criteria

- [x] **A1** Settings model-status row driven by `AppState.llmDownloadState`. All 6 visible states.
- [x] **A2** First-launch (no model on disk) does NOT silently fire on first Generate Notes tap. Settings row's Download button is the only trigger.
- [x] **A3** Generate Notes when model is not `.ready` surfaces "Open Clinical Notes Settings" deep-link in the Review banner — no silent multi-GB block.
- [x] **A4** About → Powered By has a Gemma 4 E4B-IT badge with a real `.ready` / `.notDownloaded` pill.
- [x] **A5** Review fallback banner branches on `fallbackReasonCode`; `model_unavailable` + `model_download_cancelled` show actionable copy + deep-link.
- [x] **A6** All new logging structural-only per `.claude/references/phi-handling.md`.
- [x] **A7** ViewInspector render tests for the new row + Gemma 4 badge across all `LLMDownloadState` cases. Swift Testing `.fast`-tagged for view-model logic.
- [x] **A8** `mlx-lifecycle.md` Trigger UX bullet rewritten — old "follow-up will move trigger to Settings" note removed.

## Three-layer review pipeline

1. **Pre-PR (local):** parallel Opus reviewers ran before push.
   - `pr-review-toolkit:code-reviewer` — 2 blockers (cancel-during-warmup misclassification + re-entrancy race) — **fixed**.
   - `pr-review-toolkit:silent-failure-hunter` — 5 blockers (cancellation copy, removal-fail-path, mmap warning, late progress events, etc.) — **fixed** (H5 mmap-unload tracked as follow-up).
   - `pr-review-toolkit:type-design-analyzer` — 0 blockers; suggestions on `progress` clamping + `.ready` mirror — **applied**.
2. **Automated (this PR):** Gemini Code Assist runs automatically.
3. **On-demand:** `/code-review` on standby for review-comment triage.

## Calibrations vs the issue body

- `fallbackBannerSubtitle` is at `ReviewScreen.swift:355`, not 337 (issue body line ref was off).
- `LanguageSection`'s `Task.sleep` simulated download lives at L697 (VM), not in the L102–158 view region.
- `fallbackReasonCode` is `String?`, not an enum — codes are `String` constants on `ClinicalNotesProcessor`. The `switch` branches on those constants. Added a sixth: `reasonModelDownloadCancelled`.

## Test plan

- [x] `swift build` — clean (pre-existing warnings only).
- [x] `swift test --parallel` (CI shape, hardware skip-list applied) — **391 / 391 pass** across 38 suites.
- [x] `swiftlint lint --strict` on all 11 touched source files — 0 violations.
- [x] `pre-commit run --files <diff>` — all hooks pass.
- [ ] Real-hardware verification on M-series (Macbook Pro M1 Pro / 32 GB / macOS 26.x) of the Settings download trigger + cancel + Re-download paths — recommended pre-merge.
- [ ] CI green on PR (this PR's `pr-checks` workflow).
- [ ] Post-merge `main` CI green (`gh run list --branch main --limit 3`).

## Diff

16 files changed, 1762 insertions(+), 97 deletions(-). 4 new source files, 4 new test files (15 cases total).

## Follow-up (out of scope)

- `MLXGemmaProvider.unload()` — proper fix for the mmap-still-active concern when the user removes the model while in `.ready`. Today: structural warning log + `removeItem` proceeds (POSIX semantics). New issue to track.
- Pause/resume support on `ModelDownloader` — would require a `URLSessionDownloadDelegate`-based shape.
- Mid-download server-side resume (range requests) — also a downloader-shape change.

## References

- AGENTS.md — Correctness Checklist + workflow + review pipeline.
- `.claude/references/{mlx-lifecycle,phi-handling,testing-conventions,concurrency}.md`.
- EPIC #1 — Clinical Notes Mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)