### PR TITLE
fix(llm): MLXGemmaProvider.unload() so Remove model frees mmap'd bytes (#120)

### DIFF
--- a/.claude/references/mlx-lifecycle.md
+++ b/.claude/references/mlx-lifecycle.md
@@ -85,6 +85,39 @@ Unload policy for v2: keep the model loaded once it's in memory. Don't
 evict on idle — warming it up is expensive. Revisit if memory pressure
 surfaces on smaller Macs (E4B is roughly 2× v1's resident set).
 
+### `unload()` and the release-before-unlink invariant (#120)
+
+`MLXGemmaProvider.unload()` drops the `ModelContainer` reference so the
+mmap-backed weights can be reclaimed. Idempotent — a no-op when the
+container is already nil. Symmetric counterpart to `warmup()`.
+
+**Always called before `FileManager.removeItem(at: dir)`** in
+`AppState.removeClinicalNotesModel()`. POSIX semantics let `removeItem`
+succeed even with a live mmap, but the bytes don't free until the last
+reference drops. Without `unload()` first, the user thinks they
+reclaimed ~5 GB by tapping "Remove model" but the bytes persist until
+the next app restart — and worse, a follow-up "Download model" tap
+could short-circuit on the manifest hash check while the original
+(now-orphaned) container still mmaps the just-deleted directory,
+producing behavioural ambiguity.
+
+The remove path is the only **production** call site today. We don't
+evict on idle (per the policy above) — `unload()` exists for the
+explicit user-driven "release these bytes" gesture, not for memory
+management. Tests exercise it directly (see
+`MLXGemmaProviderUnitTests.unloadIdempotentBeforeWarmup` and the
+hardware-gated `warmupUnloadReWarmupCycle`).
+
+```
+Settings "Remove model" tap
+  → AppState.removeClinicalNotesModel()
+      → cancelClinicalNotesModelDownload()           // cancel in-flight task
+      → await existing.task.value                    // unwind cancellation
+      → await llmProvider?.unload()                  // <-- release container mmap
+      → FileManager.default.removeItem(at: dir)      // unlink directory
+      → llmDownloadState = .idle
+```
+
 ---
 
 ## Inference defaults

--- a/Sources/Services/ClinicalNotes/LLMProvider.swift
+++ b/Sources/Services/ClinicalNotes/LLMProvider.swift
@@ -54,6 +54,28 @@ public protocol LLMProvider: Actor {
         prompt: String,
         options: LLMOptions
     ) -> AsyncThrowingStream<String, any Error>
+
+    /// Release any internal model state so the underlying weights / file
+    /// descriptors can be reclaimed. Idempotent — a second call is a
+    /// no-op once state has been released. Symmetric counterpart to any
+    /// implementation-defined warmup. After `unload()`, the next
+    /// `generate` / `generateStream` call MUST behave as if the provider
+    /// were freshly constructed (typically by lazy-loading on demand).
+    ///
+    /// **Caller invariant (#120).** When the on-disk model directory is
+    /// being removed, callers MUST `await unload()` before unlinking so
+    /// the mmap-backed bytes actually free under POSIX semantics. See
+    /// `MLXGemmaProvider.unload()` and `.claude/references/mlx-lifecycle.md`
+    /// for the release-before-unlink invariant.
+    func unload() async
+}
+
+public extension LLMProvider {
+    /// Default no-op for providers that have no model state to release
+    /// (e.g. trivial test fakes that synthesise responses without
+    /// loading weights). Concrete in-process providers like
+    /// `MLXGemmaProvider` override this with a real release.
+    func unload() async {}
 }
 
 /// Sampling configuration for a single `LLMProvider` call.

--- a/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
+++ b/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
@@ -86,6 +86,10 @@ public actor MLXGemmaProvider: LLMProvider {
     /// instrumentation introduced for #106: when the next MLX-related
     /// crash report lands, the surrounding signposts localise whether
     /// we crashed pre- or post-load. Cheap to leave in.
+    ///
+    /// Pair with `unload()` to release the container — required on the
+    /// `AppState.removeClinicalNotesModel()` path so the unlinked
+    /// directory's mmap-backed bytes actually free (#120).
     public func warmup() async throws {
         if container != nil { return }
         let started = ContinuousClock.now
@@ -118,6 +122,39 @@ public actor MLXGemmaProvider: LLMProvider {
             logger.error("MLX warmup failed kind=\(kind, privacy: .public)")
             throw ProviderError.modelLoadFailed(kind: kind)
         }
+    }
+
+    /// Release the loaded `ModelContainer` so the mmap-backed weights
+    /// can be reclaimed. Idempotent — a no-op when `container == nil`.
+    /// Symmetric counterpart to `warmup()`.
+    ///
+    /// **Invariant for `AppState.removeClinicalNotesModel()` (#120).**
+    /// Must run before `FileManager.removeItem(at: dir)`. POSIX semantics
+    /// let the unlink succeed while a live mmap pins the file's backing
+    /// store until the last reference drops, so without releasing the
+    /// container first the user thinks they reclaimed ~5 GB but the
+    /// bytes don't actually free until the next app restart. Worse,
+    /// a follow-up "Download model" tap could short-circuit on the
+    /// manifest hash check while the original (now-orphaned) container
+    /// still mmaps the just-deleted directory — behavioural ambiguity
+    /// that this method's load-bearing release prevents.
+    ///
+    /// **Caller invariant: no in-flight generation.** Swift actors are
+    /// reentrant, so `unload()` can land while a `runGeneration` is
+    /// suspended on `await container.generate(…)` or inside its chunk
+    /// loop. `runGeneration` binds the container into a strong local
+    /// (`let container = try await requireContainer()`), so clearing
+    /// `self.container` here does **not** release the mmap until that
+    /// local goes out of scope at the end of the in-flight generation.
+    /// Callers MUST ensure no `generate` / `generateStream` task is
+    /// active before calling. The release-before-unlink in
+    /// `AppState.removeClinicalNotesModel()` is correct for the steady
+    /// state (no Generate Notes mid-flight while the user is in
+    /// Settings); the active-generation race is tracked separately.
+    public func unload() {
+        guard container != nil else { return }
+        container = nil
+        logger.info("MLX unload completed")
     }
 
     public func generate(

--- a/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
+++ b/Sources/Services/ClinicalNotes/MLXGemmaProvider.swift
@@ -151,7 +151,7 @@ public actor MLXGemmaProvider: LLMProvider {
     /// `AppState.removeClinicalNotesModel()` is correct for the steady
     /// state (no Generate Notes mid-flight while the user is in
     /// Settings); the active-generation race is tracked separately.
-    public func unload() {
+    public func unload() async {
         guard container != nil else { return }
         container = nil
         logger.info("MLX unload completed")

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -659,20 +659,16 @@ class AppState {
     /// PHI-free: only the model directory is touched. The path is logged
     /// as `.private` per `phi-handling.md` (user-home paths count as PII
     /// in the OSLog channel).
+    ///
+    /// **Release-before-unlink invariant (#120).** When the provider is
+    /// `.ready`, its `ModelContainer` mmaps the model directory we're
+    /// about to remove. POSIX `removeItem` succeeds even with a live
+    /// mmap, but the bytes don't free until the last reference drops —
+    /// so we call `await llmProvider?.unload()` before the unlink so the
+    /// user actually reclaims the ~5 GB they expect from "Remove model".
+    /// `unload()` is idempotent and safe to call from any state, so we
+    /// don't need to gate on `llmDownloadState == .ready`.
     func removeClinicalNotesModel() async {
-        // Mitigation for the mmap-still-active concern (silent-failure-hunter
-        // H5): if the provider has warmed up, its `ModelContainer` may still
-        // mmap the directory we're about to unlink. POSIX semantics let the
-        // unlink succeed but the bytes don't get freed until the provider
-        // releases the container. Surface a structural warning so a
-        // regression here is debuggable. Proper fix is `MLXGemmaProvider.unload()`
-        // — tracked as a follow-up; the warning is the bridge.
-        if llmDownloadState == .ready {
-            AppLogger.app.warning(
-                "AppState: removing Gemma 4 model while provider may still hold mmap — bytes may persist until app restart"
-            )
-        }
-
         cancelClinicalNotesModelDownload()
         // Wait for any cancelled task to unwind before we delete on-disk
         // state — otherwise the downloader's `.partial` rename can race
@@ -684,6 +680,13 @@ class AppState {
                 clinicalNotesDownloadTask = nil
             }
         }
+
+        // Release any live `ModelContainer` mmap before unlinking the
+        // directory — see the doc comment above for the POSIX rationale.
+        // Sequenced after the in-flight task await so we can't race a
+        // warmup that's about to set `container`. Idempotent no-op when
+        // the provider was never warmed.
+        await llmProvider?.unload()
 
         guard let manifest = llmManifest else {
             // No manifest means no `<bundleId>/Models/<dir>/` to clear; just

--- a/Tests/SpeechToTextTests/Services/AppStateModelStatusTests.swift
+++ b/Tests/SpeechToTextTests/Services/AppStateModelStatusTests.swift
@@ -76,6 +76,34 @@ struct AppStateModelStatusTests {
         #expect(appState.modelStatusViewModel.state == .idle)
     }
 
+    /// **#120 — `.ready` → remove collapses to `.idle` without
+    /// the bridge warning that PR #119 emitted.**
+    ///
+    /// PR #119 added a structural `OSLog.warning` on the `.ready → remove`
+    /// path as a bridge until `MLXGemmaProvider.unload()` shipped (#120).
+    /// This test pins down the post-#120 contract: forcing `.ready` then
+    /// calling `removeClinicalNotesModel()` collapses cleanly to `.idle`
+    /// — and the `await llmProvider?.unload()` call sequenced into the
+    /// remove path neither throws nor hangs.
+    ///
+    /// In tests the `llmProvider` is the real `MLXGemmaProvider` (the
+    /// manifest is bundled at `Sources/Resources/Models/.../manifest.json`),
+    /// but it has not been warmed in this test, so `unload()` resolves
+    /// to its idempotent no-op branch (`guard container != nil`). We
+    /// can't observe the mmap release without real weights — that's
+    /// covered by the hardware-gated `warmupUnloadReWarmupCycle` test
+    /// in `MLXGemmaProviderGoldenTests`.
+    @Test("removeClinicalNotesModel from .ready collapses to .idle")
+    func removeClinicalNotesModel_fromReady_collapsesToIdle() async {
+        let appState = AppState()
+        appState.llmDownloadState = .ready
+
+        await appState.removeClinicalNotesModel()
+
+        #expect(appState.llmDownloadState == .idle)
+        #expect(appState.modelStatusViewModel.state == .idle)
+    }
+
     @Test("modelStatusViewModel mirrors manifest size at init")
     func modelStatusViewModel_mirrorsManifestSize() async {
         let appState = AppState()

--- a/Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift
+++ b/Tests/SpeechToTextTests/Services/MLXGemmaProviderTests.swift
@@ -91,6 +91,36 @@ struct MLXGemmaProviderUnitTests {
         #expect(boundary == text.endIndex)
     }
 
+    /// **#120 — `unload()` idempotency on a never-warmed provider.**
+    /// `unload()` is the load-bearing release used by
+    /// `AppState.removeClinicalNotesModel()` to drop the
+    /// `ModelContainer` mmap before unlinking the model directory.
+    /// The container starts `nil`, so calling `unload()` before any
+    /// `warmup()` must be a structural no-op — and a second call must
+    /// also no-op. Both must complete without throwing or blocking.
+    ///
+    /// The warmup → unload → re-warmup state-machine cycle requires
+    /// real weights and lives in `MLXGemmaProviderGoldenTests` below
+    /// (`RUN_MLX_GOLDEN=1`, `.requiresHardware`).
+    @Test("unload is a no-op on a never-warmed provider and is idempotent")
+    func unloadIdempotentBeforeWarmup() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mlx-gemma-unload-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempDir,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let provider = MLXGemmaProvider(modelDirectory: tempDir)
+        // Two calls back-to-back — both must complete cleanly. The
+        // assertion is implicit in not throwing or hanging; the actor
+        // serialises the calls so a concurrent re-entry can't trip
+        // a half-loaded state.
+        await provider.unload()
+        await provider.unload()
+    }
+
     /// **#106 — warmup error mapping (shape, not specific error type).**
     /// Verifies that `warmup()` catches *any* underlying error from
     /// `LLMModelFactory.shared.loadContainer` and re-raises it as
@@ -175,6 +205,33 @@ struct MLXGemmaProviderGoldenTests {
         // Loose budget — load latency varies wildly with thermal state
         // and disk pressure. The hard contract is just "completes".
         #expect(seconds < 30, "warmup took \(seconds)s, expected <30s")
+    }
+
+    /// **#120 — warmup → unload → re-warmup state-machine cycle.**
+    /// Verifies that `unload()` releases the `ModelContainer` cleanly
+    /// enough for a subsequent `warmup()` to repopulate it and a
+    /// follow-up `generate` to succeed. The hardware-gated test is the
+    /// only place this can run end-to-end; the fast-path counterpart
+    /// in `MLXGemmaProviderUnitTests.unloadIdempotentBeforeWarmup`
+    /// covers the never-warmed branch.
+    @Test("warmup → unload → re-warmup → generate cycle", .enabled(if: enabled))
+    func warmupUnloadReWarmupCycle() async throws {
+        guard let dir = Self.modelDirectory() else {
+            Issue.record("model directory not available; set MLX_GEMMA_DIR or run downloader first")
+            return
+        }
+        let provider = MLXGemmaProvider(modelDirectory: dir)
+        try await provider.warmup()
+        await provider.unload()
+        // Second warmup must succeed against the same on-disk weights.
+        try await provider.warmup()
+        let opts = LLMOptions(temperature: 0, topP: 1.0, maxTokens: 8, stop: [])
+        // PHI-free synthetic prompt per testing-conventions.md — we only
+        // assert that `generate` returns without throwing, not on text
+        // shape. Re-warmup soundness is the contract under test, not
+        // generation quality (covered by `deterministicGeneration`).
+        let prompt = "Briefly summarise: morning standup notes."
+        _ = try await provider.generate(prompt: prompt, options: opts)
     }
 
     @Test("greedy generation is deterministic across two calls", .enabled(if: enabled))

--- a/Tests/SpeechToTextTests/Utilities/MockLLMProvider.swift
+++ b/Tests/SpeechToTextTests/Utilities/MockLLMProvider.swift
@@ -55,6 +55,7 @@ public actor MockLLMProvider: LLMProvider {
 
     private var behavior: Behavior
     private var callLog: [Call] = []
+    private var unloadCalls: Int = 0
 
     /// Fixed-response mode. Default empty string is useful for tests
     /// that only care whether the consumer called `generate` at all.
@@ -93,6 +94,15 @@ public actor MockLLMProvider: LLMProvider {
         }
     }
 
+    /// Test-fake `unload()` overriding the protocol default. Increments
+    /// `unloadCalls` so consumers can assert wire-through from
+    /// `AppState.removeClinicalNotesModel()` (#120) — the production
+    /// `MLXGemmaProvider.unload()` releases the `ModelContainer` mmap;
+    /// the fake just records that the call landed.
+    public func unload() async {
+        unloadCalls += 1
+    }
+
     public nonisolated func generateStream(
         prompt: String,
         options: LLMOptions
@@ -128,6 +138,12 @@ public actor MockLLMProvider: LLMProvider {
 
     /// Most recent call, or `nil` if none has been made.
     public func lastCall() -> Call? { callLog.last }
+
+    /// Number of times `unload()` has been called against this fake.
+    /// Used by `AppState` integration tests (#120) to assert
+    /// `removeClinicalNotesModel()` releases the container before
+    /// unlinking the directory.
+    public func unloadCallCount() -> Int { unloadCalls }
 
     /// Swap the response mode mid-test.
     public func setBehavior(_ newBehavior: Behavior) {

--- a/Tests/SpeechToTextTests/Utilities/MockLLMProviderTests.swift
+++ b/Tests/SpeechToTextTests/Utilities/MockLLMProviderTests.swift
@@ -184,6 +184,25 @@ struct MockLLMProviderTests {
         // One generate call, regardless of whether we drained the stream.
         #expect(await provider.callCount() == 1)
     }
+
+    // MARK: - Unload
+
+    /// **#120 — `unload()` is recordable on the fake.** Mirrors the
+    /// production contract added to the `LLMProvider` protocol so
+    /// future AppState integration tests can assert call ordering
+    /// between `unload()` and `removeItem(at:)` without needing real
+    /// MLX weights. Every call increments the counter; the protocol
+    /// default is a no-op, but this fake overrides it.
+    @Test("unload increments unloadCallCount on every call")
+    func unload_recordsEachCall() async {
+        let provider = MockLLMProvider(response: "ignored")
+        #expect(await provider.unloadCallCount() == 0)
+        await provider.unload()
+        #expect(await provider.unloadCallCount() == 1)
+        await provider.unload()
+        await provider.unload()
+        #expect(await provider.unloadCallCount() == 3)
+    }
 }
 
 // MARK: - Test fixtures


### PR DESCRIPTION
## Summary

- Adds idempotent `MLXGemmaProvider.unload()` that releases the `ModelContainer` so the mmap-backed Gemma 4 weights can be reclaimed under POSIX semantics.
- Wires `await llmProvider?.unload()` into `AppState.removeClinicalNotesModel()` after the in-flight task await and before `FileManager.removeItem(at:)`. Drops the L670–674 bridge warning log added in #119.
- Surfaces `unload()` on the `LLMProvider` protocol with a default no-op extension; `MockLLMProvider` records call counts for future integration tests.

Closes #120.

## Why

POSIX `removeItem` succeeds even with a live mmap, so `removeClinicalNotesModel()` previously left the user thinking they reclaimed ~5 GB while the bytes stayed pinned until the next app restart. PR #119 mitigated with a structural warning log; this PR is the load-bearing fix that the [L668 comment](https://github.com/CloudbrokerAz/mac-speech-to-text/blob/main/Sources/SpeechToTextApp/AppState.swift#L668) explicitly named as the proper resolution.

## Tests

| Test | Suite | Tag |
|---|---|---|
| `unloadIdempotentBeforeWarmup` | `MLXGemmaProviderUnitTests` | `.fast` |
| `warmupUnloadReWarmupCycle` | `MLXGemmaProviderGoldenTests` | `.requiresHardware`, gated on `RUN_MLX_GOLDEN=1` |
| `removeClinicalNotesModel_fromReady_collapsesToIdle` | `AppStateModelStatusTests` | `.fast` |
| `unload_recordsEachCall` | `MockLLMProviderTests` | `.fast` |

`swift test --parallel` — 395 tests, all green.

## Pre-PR review (Opus)

Per `AGENTS.md` three-layer review:

- **`pr-review-toolkit:code-reviewer`** — ship-with-NITs. All three NITs folded in (test-comment accuracy, `unload()` doc comment honesty, "only place" → "only production call site" in `mlx-lifecycle.md`).
- **`pr-review-toolkit:silent-failure-hunter`** — flagged two MAJOR findings (F1, F2) about an active `runGeneration` capturing `let container` into a strong local that survives `unload()` because Swift actors are reentrant. The race is real but **out of scope for #120** (this PR fixes the steady-state warmup-pin case the L668 comment named). Filed as **#121** with three remediation options. The `unload()` doc comment now honestly describes the "no active generation" caller invariant.

## Behaviour against `main`

- Steady-state Remove: `.ready → unload → removeItem → .idle`. ~5 GB actually freed. ✅ (verifiable via `du -sh` on hardware.)
- Cancelled-warmup race: `await existing.task.value` drains; subsequent `unload()` releases whatever the unwound warmup left. ✅
- Failed `removeItem`: `.failed` state surfaces; on retry, hash short-circuit + `warmup()` re-mmaps cleanly. ✅
- Active-generation race (out of scope): tracked in #121.

## Refs

- Issue: #120
- Bridge warning PR: #119 (the L670–674 warning is removed in this PR)
- Follow-up: #121 (active-generation reentrancy gap)
- Doc: `.claude/references/mlx-lifecycle.md` "Load / warmup / unload" + new "`unload()` and the release-before-unlink invariant" subsection