### PR TITLE
fix(llm): drain in-flight pipeline before unloading model (#121)

### DIFF
--- a/Sources/Services/ClinicalNotes/ClinicalNotesProcessor.swift
+++ b/Sources/Services/ClinicalNotes/ClinicalNotesProcessor.swift
@@ -83,6 +83,16 @@ actor ClinicalNotesProcessor {
     /// copy is more honest — the model isn't broken, it's half-fetched.
     static let reasonModelDownloadCancelled = "model_download_cancelled"
 
+    /// Structural sentinel emitted by the processor when generation was
+    /// cancelled because the user tapped "Remove model" while the
+    /// pipeline was in flight (#121). Distinct from `reasonLLMError`
+    /// (which means the LLM itself failed) so the Review banner can be
+    /// honest about *why* generation didn't complete: the model isn't
+    /// broken, the user removed it. Surfaced when `process(transcript:)`
+    /// catches `CancellationError` from the provider — see the
+    /// `catch is CancellationError` arms inside `process`.
+    static let reasonModelRemovedMidFlight = "model_removed_mid_flight"
+
     /// Structural sentinel emitted by `ReviewViewModel.loadState` (NOT
     /// by the processor) when the active `ClinicalSession` was cleared
     /// while the Review window was still on screen — typically the
@@ -126,6 +136,14 @@ actor ClinicalNotesProcessor {
                 prompt: initialPrompt,
                 options: options
             )
+        } catch is CancellationError {
+            // User tapped "Remove model" mid-stream (#121) — the wrapping
+            // pipeline Task was cancelled by `removeClinicalNotesModel()`,
+            // which trips `Task.checkCancellation()` inside
+            // `MLXGemmaProvider.runGeneration`'s chunk loop. Surface a
+            // distinct reason so the Review banner can say "you removed
+            // the model" rather than "LLM error".
+            return .rawTranscriptFallback(reason: Self.reasonModelRemovedMidFlight)
         } catch {
             logLLMError(error, attempt: 1)
             return .rawTranscriptFallback(reason: Self.reasonLLMError)
@@ -152,6 +170,10 @@ actor ClinicalNotesProcessor {
                 prompt: retryPrompt,
                 options: options
             )
+        } catch is CancellationError {
+            // Mirror the first-attempt cancellation handling above —
+            // distinguishing "user removed model" from "LLM error" (#121).
+            return .rawTranscriptFallback(reason: Self.reasonModelRemovedMidFlight)
         } catch {
             logLLMError(error, attempt: 2)
             return .rawTranscriptFallback(reason: Self.reasonLLMError)

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -87,6 +87,39 @@ class AppState {
     /// H2 / code-reviewer B2).
     @ObservationIgnored private var clinicalNotesDownloadTask: (token: UUID, task: Task<Void, Never>)?
 
+    /// In-flight clinical-notes pipeline task (#121). Set by
+    /// `handleClinicalNotesGenerateRequested` so that
+    /// `removeClinicalNotesModel` can drain it before releasing the
+    /// `ModelContainer` mmap. Without this drain, an active
+    /// `MLXGemmaProvider.runGeneration` would hold the container in a
+    /// strong local across actor suspensions and pin the mmap past
+    /// `unload()` due to Swift actor reentrancy. Token-tagged with the
+    /// same identity-guarded-clear pattern as `clinicalNotesDownloadTask`
+    /// so a re-entrant Generate Notes tap can't have its slot clobbered.
+    @ObservationIgnored private var clinicalNotesPipelineTask: (token: UUID, task: Task<Void, Never>)?
+
+    /// Mirror of `clinicalNotesPipelineTask != nil`, exposed as an
+    /// `@Observable` Bool so the Settings model-status row (#104) can
+    /// gate the "Remove" affordance while a pipeline is in flight (#121).
+    /// Set + cleared on the same MainActor as the task slot itself, so
+    /// the Bool and the slot are always in sync from a UI bind's
+    /// perspective.
+    var isClinicalNotesPipelineActive: Bool = false
+
+    /// Set to `true` for the duration of `removeClinicalNotesModel()` so
+    /// `handleClinicalNotesGenerateRequested` can short-circuit any
+    /// fresh transcript hand-off arriving via the menu-bar / hotkey /
+    /// other recording surfaces while the remove is draining (#121,
+    /// silent-failure-hunter Scenario 4 / Finding 9). Without this
+    /// gate, a new pipeline could start during the drain's `await
+    /// existing.task.value`, complete a fresh `requireContainer()` →
+    /// `warmup()` against the still-on-disk weights, and capture the
+    /// container into a strong local that survives the subsequent
+    /// `unload()` — exactly the reentrancy hazard #121 set out to fix,
+    /// in a different shape. Cleared via `defer` so an early-return
+    /// branch can't leave the flag stuck.
+    @ObservationIgnored private var isRemovingClinicalNotesModel: Bool = false
+
     /// Static manipulations taxonomy bundled with the app (#6). Loaded
     /// once at launch and handed to `ReviewWindowController` so the
     /// review surface (#13) renders the checklist without re-parsing the
@@ -356,13 +389,57 @@ class AppState {
 
         ReviewWindowController.shared.present()
 
+        // Re-entrant guard for #121 / silent-failure-hunter Scenario 4:
+        // if a Settings-initiated `removeClinicalNotesModel()` is mid-drain
+        // we must NOT spawn a fresh pipeline — it would re-mmap the model
+        // directory we're about to unlink and re-introduce the exact race
+        // the drain closes. The Settings row's gate on Remove is one
+        // surface; this check covers the menu-bar / hotkey / Generate-Notes
+        // surfaces that bypass the Settings UI.
+        if isRemovingClinicalNotesModel {
+            AppLogger.app.info(
+                "AppState: clinical-notes hand-off declined — model removal in flight"
+            )
+            applyClinicalNotesFallback(reasonCode: ClinicalNotesProcessor.reasonModelUnavailable)
+            return
+        }
+
         // Kick off LLM processing without blocking the UI present.
         // `runClinicalNotesPipeline` ensures-download + warms-up + runs
         // the processor; every terminal branch flips `draftStatus` so
         // the Review screen never silently lingers in `.pending`.
-        Task { @MainActor [weak self] in
+        //
+        // The task handle is stored on `clinicalNotesPipelineTask` so
+        // `removeClinicalNotesModel` can drain it before releasing the
+        // ModelContainer (#121). Identity-guarded clear inside the same
+        // Task body — mirrors the `clinicalNotesDownloadTask` pattern at
+        // `downloadClinicalNotesModel` so a re-entrant Generate Notes tap
+        // that started a fresh pipeline doesn't have its slot clobbered
+        // by the original task's completion path. The clear runs via
+        // `clearClinicalNotesPipelineSlotIfMatching(token:)` so this site
+        // and `removeClinicalNotesModel` stay in sync.
+        let token = UUID()
+        let task: Task<Void, Never> = Task { @MainActor [weak self, token] in
             await self?.runClinicalNotesPipeline(transcript: transcript)
+            self?.clearClinicalNotesPipelineSlotIfMatching(token: token)
         }
+        clinicalNotesPipelineTask = (token: token, task: task)
+        isClinicalNotesPipelineActive = true
+        updateModelStatusMirror()
+    }
+
+    /// Token-guarded clear for `clinicalNotesPipelineTask` (#121). Called
+    /// from both the pipeline Task body's trailing line and the drain
+    /// inside `removeClinicalNotesModel()`; centralising the three
+    /// writes (`slot = nil`, `isClinicalNotesPipelineActive = false`,
+    /// `updateModelStatusMirror()`) prevents the two sites from drifting.
+    /// No-op if the slot is empty or holds a different generation —
+    /// re-entrant Generate Notes that swapped the slot keeps its slot.
+    private func clearClinicalNotesPipelineSlotIfMatching(token: UUID) {
+        guard clinicalNotesPipelineTask?.token == token else { return }
+        clinicalNotesPipelineTask = nil
+        isClinicalNotesPipelineActive = false
+        updateModelStatusMirror()
     }
 
     /// Drive the LLM pipeline end-to-end for a single transcript. Idempotent
@@ -502,6 +579,7 @@ class AppState {
     private func updateModelStatusMirror() {
         modelStatusViewModel.state = llmDownloadState
         modelStatusViewModel.progress = llmDownloadProgress
+        modelStatusViewModel.isPipelineActive = isClinicalNotesPipelineActive
         switch llmDownloadState {
         case .verified(let directory):
             modelStatusViewModel.modelDirectoryURL = directory
@@ -668,7 +746,26 @@ class AppState {
     /// user actually reclaims the ~5 GB they expect from "Remove model".
     /// `unload()` is idempotent and safe to call from any state, so we
     /// don't need to gate on `llmDownloadState == .ready`.
+    ///
+    /// **Pipeline drain (#121).** Before `unload()` we also cancel +
+    /// await any in-flight clinical-notes pipeline. `runGeneration`
+    /// inside `MLXGemmaProvider` binds the container into a strong local
+    /// that survives `self.container = nil` due to actor reentrancy, so
+    /// `unload()` alone wouldn't release the mmap if a generate were
+    /// suspended on a chunk. Cancelling the wrapping Task trips
+    /// `Task.checkCancellation()` in the chunk loop; the processor
+    /// catches `CancellationError` and falls back gracefully. The Review
+    /// screen flips to fallback banner — honest UX for "you removed the
+    /// model mid-stream" — and the unload is then race-free.
     func removeClinicalNotesModel() async {
+        // Block any fresh pipeline from spawning while we're draining +
+        // unloading + unlinking. Cleared via `defer` so any early return
+        // (no-manifest branch, removeItem failure) leaves the gate open.
+        // See `isRemovingClinicalNotesModel`'s doc comment for the race
+        // this closes (#121, silent-failure-hunter Scenario 4).
+        isRemovingClinicalNotesModel = true
+        defer { isRemovingClinicalNotesModel = false }
+
         cancelClinicalNotesModelDownload()
         // Wait for any cancelled task to unwind before we delete on-disk
         // state — otherwise the downloader's `.partial` rename can race
@@ -681,11 +778,29 @@ class AppState {
             }
         }
 
+        // Drain any in-flight clinical-notes pipeline before we touch
+        // the provider (#121). The pipeline calls `processor.process` →
+        // `provider.generate` → `MLXGemmaProvider.runGeneration`, which
+        // captures the `ModelContainer` into a strong local that
+        // survives `self.container = nil` due to Swift actor reentrancy.
+        // Cancelling the wrapping Task trips `Task.checkCancellation()`
+        // inside the chunk loop; the processor catches `CancellationError`
+        // and resolves to `.rawTranscriptFallback(reason: reasonLLMError)`,
+        // so the Review screen flips out of its loading overlay into the
+        // honest fallback banner. Identity-guarded clear mirrors the
+        // download-task pattern above.
+        if let existing = clinicalNotesPipelineTask {
+            existing.task.cancel()
+            await existing.task.value
+            clearClinicalNotesPipelineSlotIfMatching(token: existing.token)
+        }
+
         // Release any live `ModelContainer` mmap before unlinking the
         // directory — see the doc comment above for the POSIX rationale.
-        // Sequenced after the in-flight task await so we can't race a
-        // warmup that's about to set `container`. Idempotent no-op when
-        // the provider was never warmed.
+        // Sequenced after the in-flight task awaits so we can't race a
+        // warmup that's about to set `container` or a generation whose
+        // local container binding would otherwise pin the mmap past the
+        // unlink. Idempotent no-op when the provider was never warmed.
         await llmProvider?.unload()
 
         guard let manifest = llmManifest else {

--- a/Sources/SpeechToTextApp/AppState.swift
+++ b/Sources/SpeechToTextApp/AppState.swift
@@ -404,6 +404,22 @@ class AppState {
             return
         }
 
+        // Re-entrant Generate Notes (a second tap arriving while Pipeline
+        // A is still running): cancel A and chain B behind it so A's
+        // `runGeneration` unwinds, releases its captured container, and
+        // the slot ends up holding only B. Without this chain the slot
+        // assignment below would orphan A's task handle — A keeps
+        // running, captures the container into a strong local that
+        // survives any subsequent `unload()`, and `removeClinicalNotesModel`
+        // can no longer drain it (Gemini Code Assist HIGH on PR #124).
+        // The previous task is captured into B's body so `await` is
+        // legal here in this synchronous notification handler; the
+        // slot flips to B immediately so `removeClinicalNotesModel`
+        // arriving during B's prologue still finds the load-bearing
+        // handle.
+        let previousTask = clinicalNotesPipelineTask?.task
+        previousTask?.cancel()
+
         // Kick off LLM processing without blocking the UI present.
         // `runClinicalNotesPipeline` ensures-download + warms-up + runs
         // the processor; every terminal branch flips `draftStatus` so
@@ -419,7 +435,17 @@ class AppState {
         // `clearClinicalNotesPipelineSlotIfMatching(token:)` so this site
         // and `removeClinicalNotesModel` stay in sync.
         let token = UUID()
-        let task: Task<Void, Never> = Task { @MainActor [weak self, token] in
+        let task: Task<Void, Never> = Task { @MainActor [weak self, token, previousTask] in
+            // Wait for any cancelled predecessor to fully unwind before
+            // we touch the provider. `Task<Void, Never>.value` resolves
+            // when the body returns, including via the cancellation
+            // path. If `removeClinicalNotesModel` cancels *this* task
+            // before the predecessor finishes, we still complete the
+            // await (cancellation propagates a level deeper) and then
+            // exit before `runClinicalNotesPipeline` starts.
+            if let previousTask {
+                await previousTask.value
+            }
             await self?.runClinicalNotesPipeline(transcript: transcript)
             self?.clearClinicalNotesPipelineSlotIfMatching(token: token)
         }
@@ -754,9 +780,10 @@ class AppState {
     /// `unload()` alone wouldn't release the mmap if a generate were
     /// suspended on a chunk. Cancelling the wrapping Task trips
     /// `Task.checkCancellation()` in the chunk loop; the processor
-    /// catches `CancellationError` and falls back gracefully. The Review
-    /// screen flips to fallback banner — honest UX for "you removed the
-    /// model mid-stream" — and the unload is then race-free.
+    /// catches `CancellationError` and resolves to
+    /// `.rawTranscriptFallback(reason: reasonModelRemovedMidFlight)` —
+    /// honest UX for "you removed the model mid-stream" — and the
+    /// unload is then race-free.
     func removeClinicalNotesModel() async {
         // Block any fresh pipeline from spawning while we're draining +
         // unloading + unlinking. Cleared via `defer` so any early return
@@ -785,9 +812,10 @@ class AppState {
         // survives `self.container = nil` due to Swift actor reentrancy.
         // Cancelling the wrapping Task trips `Task.checkCancellation()`
         // inside the chunk loop; the processor catches `CancellationError`
-        // and resolves to `.rawTranscriptFallback(reason: reasonLLMError)`,
-        // so the Review screen flips out of its loading overlay into the
-        // honest fallback banner. Identity-guarded clear mirrors the
+        // and resolves to `.rawTranscriptFallback(reason:
+        // reasonModelRemovedMidFlight)`, so the Review screen flips out
+        // of its loading overlay into the banner that names the user's
+        // gesture honestly. Identity-guarded clear mirrors the
         // download-task pattern above.
         if let existing = clinicalNotesPipelineTask {
             existing.task.cancel()

--- a/Sources/Views/ClinicalNotes/ReviewScreen.swift
+++ b/Sources/Views/ClinicalNotes/ReviewScreen.swift
@@ -367,6 +367,8 @@ struct ReviewScreen: View {
             return "The clinical-notes model isn't ready. Open Settings → Clinical Notes to download it."
         case ClinicalNotesProcessor.reasonModelDownloadCancelled:
             return "Model download cancelled. Open Settings → Clinical Notes to finish it."
+        case ClinicalNotesProcessor.reasonModelRemovedMidFlight:
+            return "Model was removed before generation finished. Edit the SOAP sections manually, or re-download from Settings to try again."
         case ClinicalNotesProcessor.reasonSessionExpired:
             return "Session expired — please cancel and re-record."
         default:

--- a/Sources/Views/MainView/Sections/ClinicalNotesModelStatusRow.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesModelStatusRow.swift
@@ -225,23 +225,43 @@ struct ClinicalNotesModelStatusRow: View {
                 .accessibilityIdentifier("clinicalNotesModelStatusRow.actionButton")
             }
         case .ready:
-            HStack(spacing: 8) {
-                Spacer()
-                Button {
-                    showRedownloadConfirm = true
-                } label: {
-                    Label("Re-download", systemImage: "arrow.clockwise")
-                }
-                .buttonStyle(.bordered)
-                .accessibilityIdentifier("clinicalNotesModelStatusRow.redownloadButton")
+            VStack(alignment: .trailing, spacing: 4) {
+                HStack(spacing: 8) {
+                    Spacer()
+                    Button {
+                        showRedownloadConfirm = true
+                    } label: {
+                        Label("Re-download", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.isPipelineActive)
+                    .accessibilityIdentifier("clinicalNotesModelStatusRow.redownloadButton")
 
-                Button(role: .destructive) {
-                    showRemoveConfirm = true
-                } label: {
-                    Label("Remove", systemImage: "trash")
+                    Button(role: .destructive) {
+                        showRemoveConfirm = true
+                    } label: {
+                        Label("Remove", systemImage: "trash")
+                    }
+                    .buttonStyle(.bordered)
+                    // Gate Remove + Re-download while a clinical-notes pipeline
+                    // is in flight (#121). The drain inside
+                    // `AppState.removeClinicalNotesModel()` would still close
+                    // the race correctly if the user forced a remove, but the
+                    // resulting cancellation flips the Review screen to a
+                    // fallback banner that the practitioner didn't ask for —
+                    // gating the button keeps the UX honest. The accessibility
+                    // identifier stays stable across enabled / disabled so
+                    // existing UI tests don't need conditional locators.
+                    .disabled(viewModel.isPipelineActive)
+                    .accessibilityIdentifier("clinicalNotesModelStatusRow.actionButton")
                 }
-                .buttonStyle(.bordered)
-                .accessibilityIdentifier("clinicalNotesModelStatusRow.actionButton")
+                if viewModel.isPipelineActive {
+                    Text("Cannot remove while generating notes — finish the active note first.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.trailing)
+                        .accessibilityIdentifier("clinicalNotesModelStatusRow.pipelineActiveCaption")
+                }
             }
         case .failed:
             HStack {

--- a/Sources/Views/MainView/Sections/ClinicalNotesModelStatusViewModel.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesModelStatusViewModel.swift
@@ -53,6 +53,17 @@ final class ClinicalNotesModelStatusViewModel {
     /// the disk-usage caption row that only appears in `.ready`.
     var modelDirectoryURL: URL?
 
+    /// Mirrors `AppState.isClinicalNotesPipelineActive` (#121). When `true`,
+    /// the Settings-row "Remove" button must be disabled — releasing the
+    /// `ModelContainer` mid-generation cannot reclaim the mmap-backed
+    /// bytes (Swift actor reentrancy + a strong local container binding
+    /// inside `runGeneration`), so the row gates the affordance until
+    /// the active pipeline completes. The drain inside
+    /// `AppState.removeClinicalNotesModel()` is the load-bearing
+    /// correctness mechanism; this flag drives the UX gate that keeps
+    /// users from hitting the post-cancel fallback banner unnecessarily.
+    var isPipelineActive: Bool
+
     /// Tap handler for the primary "Download model" / "Retry" affordance.
     /// `@Sendable` so the row can fire it from a `Task` without capturing
     /// VM state. Defaults to a no-op so test fixtures don't have to wire
@@ -76,6 +87,7 @@ final class ClinicalNotesModelStatusViewModel {
         progress: Double = 0,
         manifestSizeBytes: Int64 = 0,
         modelDirectoryURL: URL? = nil,
+        isPipelineActive: Bool = false,
         onDownload: @escaping @Sendable () async -> Void = {},
         onCancel: @escaping @Sendable () async -> Void = {},
         onRemove: @escaping @Sendable () async -> Void = {}
@@ -84,6 +96,7 @@ final class ClinicalNotesModelStatusViewModel {
         self.progress = progress
         self.manifestSizeBytes = manifestSizeBytes
         self.modelDirectoryURL = modelDirectoryURL
+        self.isPipelineActive = isPipelineActive
         self.onDownload = onDownload
         self.onCancel = onCancel
         self.onRemove = onRemove

--- a/Tests/SpeechToTextTests/Services/AppStateModelStatusTests.swift
+++ b/Tests/SpeechToTextTests/Services/AppStateModelStatusTests.swift
@@ -104,6 +104,49 @@ struct AppStateModelStatusTests {
         #expect(appState.modelStatusViewModel.state == .idle)
     }
 
+    /// **#121 — `removeClinicalNotesModel()` clears its in-flight gate
+    /// even on the no-manifest early return.**
+    /// `isRemovingClinicalNotesModel` is set at the top of the function
+    /// and cleared by `defer` so an early-return branch (e.g. the
+    /// no-manifest path that flushes state without touching the
+    /// directory) can't leave the gate stuck — which would block all
+    /// subsequent Generate Notes hand-offs forever. We can't read the
+    /// private flag directly, but we can prove the gate clears by
+    /// calling `removeClinicalNotesModel()` twice in sequence and
+    /// asserting the second call also resolves cleanly to `.idle`. If
+    /// the flag had stuck `true`, internal logic that depends on it
+    /// (e.g. fresh pipeline short-circuit) would be observable, but at
+    /// the AppState public surface this is the cleanest pin.
+    @Test("removeClinicalNotesModel clears its in-flight gate via defer")
+    func removeClinicalNotesModel_clearsGateAcrossRepeatedCalls() async {
+        let appState = AppState()
+        await appState.removeClinicalNotesModel()
+        #expect(appState.llmDownloadState == .idle)
+        await appState.removeClinicalNotesModel()
+        #expect(appState.llmDownloadState == .idle)
+    }
+
+    /// **#121 — `isClinicalNotesPipelineActive` defaults false at init
+    /// and is mirrored into the VM.**
+    /// AppState init must NOT spawn a pipeline (no recording has happened
+    /// yet), so the gate the row uses to disable Remove must be `false`.
+    /// The mirror call inside `updateModelStatusMirror` (driven by
+    /// `removeClinicalNotesModel`'s `.idle` no-op write) propagates the
+    /// flag onto the VM as `isPipelineActive`. Pinning down both axes
+    /// here protects against a regression that left the gate stuck
+    /// `true` after init.
+    @Test("isClinicalNotesPipelineActive defaults false and mirrors into VM")
+    func isClinicalNotesPipelineActive_defaultsFalseAndMirrors() async {
+        let appState = AppState()
+        #expect(appState.isClinicalNotesPipelineActive == false)
+        #expect(appState.modelStatusViewModel.isPipelineActive == false)
+
+        // A no-op remove flushes through `updateModelStatusMirror()` so
+        // we observe the propagation into the VM end-to-end.
+        await appState.removeClinicalNotesModel()
+        #expect(appState.modelStatusViewModel.isPipelineActive == false)
+    }
+
     @Test("modelStatusViewModel mirrors manifest size at init")
     func modelStatusViewModel_mirrorsManifestSize() async {
         let appState = AppState()

--- a/Tests/SpeechToTextTests/Services/ClinicalNotesProcessorTests.swift
+++ b/Tests/SpeechToTextTests/Services/ClinicalNotesProcessorTests.swift
@@ -309,6 +309,29 @@ struct ClinicalNotesProcessorTests {
         #expect(await provider.callCount() == 2)
     }
 
+    /// **#121 — `CancellationError` from the provider maps to
+    /// `reasonModelRemovedMidFlight`, not `reasonLLMError`.**
+    /// When `removeClinicalNotesModel()` cancels the wrapping pipeline
+    /// Task mid-stream, `Task.checkCancellation()` inside
+    /// `MLXGemmaProvider.runGeneration` throws `CancellationError`. The
+    /// processor's `catch is CancellationError` arm must distinguish
+    /// "user removed the model" from the broader "LLM error" bucket so
+    /// the Review banner can be honest about why generation didn't
+    /// finish. The retry catch is symmetric — when both arms see
+    /// `CancellationError`, the same sentinel surfaces.
+    @Test("CancellationError on first attempt → .rawTranscriptFallback(model_removed_mid_flight)")
+    func llmCancellation_firstAttempt_modelRemovedSentinel() async {
+        let provider = MockLLMProvider(error: CancellationError())
+        let proc = Self.processor(provider: provider)
+
+        let outcome = await proc.process(transcript: "t")
+
+        #expect(outcome == .rawTranscriptFallback(
+            reason: ClinicalNotesProcessor.reasonModelRemovedMidFlight
+        ))
+        #expect(await provider.callCount() == 1)
+    }
+
     // MARK: - Manipulation mapping
 
     @Test("Mapping matches by Manipulation.id")

--- a/Tests/SpeechToTextTests/Views/ClinicalNotesModelStatusRowTests.swift
+++ b/Tests/SpeechToTextTests/Views/ClinicalNotesModelStatusRowTests.swift
@@ -20,13 +20,15 @@ final class ClinicalNotesModelStatusRowTests: XCTestCase {
     private func makeViewModel(
         state: LLMDownloadState,
         progress: Double = 0,
-        modelDirectoryURL: URL? = nil
+        modelDirectoryURL: URL? = nil,
+        isPipelineActive: Bool = false
     ) -> ClinicalNotesModelStatusViewModel {
         ClinicalNotesModelStatusViewModel(
             state: state,
             progress: progress,
             manifestSizeBytes: Self.sampleManifestBytes,
-            modelDirectoryURL: modelDirectoryURL
+            modelDirectoryURL: modelDirectoryURL,
+            isPipelineActive: isPipelineActive
         )
     }
 
@@ -120,6 +122,79 @@ final class ClinicalNotesModelStatusRowTests: XCTestCase {
         // Progress bar hidden in .ready.
         XCTAssertThrowsError(
             try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.progressBar")
+        )
+    }
+
+    /// **#121 — Remove + Re-download disabled while pipeline active.**
+    /// When `isPipelineActive` is `true` the Settings row gates the
+    /// destructive actions so the user can't trip the post-cancel
+    /// fallback banner unnecessarily. The drain inside
+    /// `AppState.removeClinicalNotesModel()` is the load-bearing
+    /// correctness mechanism (cancels + awaits the pipeline before
+    /// `unload()`); this UI gate is the polite UX layer on top.
+    ///
+    /// Both buttons stay reachable in the view tree (so tests using
+    /// the existing accessibility identifiers don't have to learn a
+    /// new locator), but `.disabled(...)` flips to `true`. The helper
+    /// caption is mounted under a new identifier
+    /// `clinicalNotesModelStatusRow.pipelineActiveCaption`.
+    func test_readyState_pipelineActive_disablesRemoveAndShowsCaption() throws {
+        let dir = URL(fileURLWithPath: "/tmp/test/gemma-4-e4b-it-4bit")
+        let viewModel = makeViewModel(
+            state: .ready,
+            progress: 1,
+            modelDirectoryURL: dir,
+            isPipelineActive: true
+        )
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+
+        let removeButton = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton")
+        XCTAssertTrue(
+            try removeButton.isDisabled(),
+            "Remove button must be disabled while a clinical-notes pipeline is in flight"
+        )
+
+        let redownloadButton = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.redownloadButton")
+        XCTAssertTrue(
+            try redownloadButton.isDisabled(),
+            "Re-download must also be disabled while pipeline active (it routes through the same Remove path)"
+        )
+
+        XCTAssertNoThrow(
+            try view.inspect()
+                .find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.pipelineActiveCaption"),
+            "Caption explaining why Remove is disabled must be visible while pipeline active"
+        )
+    }
+
+    /// Symmetric assertion: when `isPipelineActive == false` the caption
+    /// is absent and the buttons are enabled. Pins down that the gate
+    /// only activates under the documented condition — protects against
+    /// a regression that flips the gate unconditionally.
+    func test_readyState_pipelineIdle_enablesRemoveAndHidesCaption() throws {
+        let dir = URL(fileURLWithPath: "/tmp/test/gemma-4-e4b-it-4bit")
+        let viewModel = makeViewModel(
+            state: .ready,
+            progress: 1,
+            modelDirectoryURL: dir,
+            isPipelineActive: false
+        )
+        let view = ClinicalNotesModelStatusRow(viewModel: viewModel)
+
+        let removeButton = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.actionButton")
+        XCTAssertFalse(try removeButton.isDisabled())
+
+        let redownloadButton = try view.inspect()
+            .find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.redownloadButton")
+        XCTAssertFalse(try redownloadButton.isDisabled())
+
+        XCTAssertThrowsError(
+            try view.inspect()
+                .find(viewWithAccessibilityIdentifier: "clinicalNotesModelStatusRow.pipelineActiveCaption"),
+            "Caption must be hidden when no pipeline is in flight"
         )
     }
 


### PR DESCRIPTION
## Summary

Closes the active-generation reentrancy gap silent-failure-hunter flagged on PR #122 (#120's fix). #120 added \`MLXGemmaProvider.unload()\` for the steady-state remove path; this PR closes the narrower race where an in-flight \`runGeneration\` captured the \`ModelContainer\` into a strong local that survived \`self.container = nil\` due to Swift actor reentrancy.

Five layered changes:

- **(b) Pipeline drain at the AppState seam.** \`clinicalNotesPipelineTask\` slot tracks the in-flight Task; \`removeClinicalNotesModel\` cancels and awaits before \`unload()\`. Identity-guarded clear via new \`clearClinicalNotesPipelineSlotIfMatching(token:)\` helper.
- **(c) UI gate on Settings row.** \`isPipelineActive\` mirrors into \`ClinicalNotesModelStatusViewModel\`; Remove + Re-download disabled with a "Cannot remove while generating notes" caption while active.
- **(d) Re-entrant pipeline gate during remove.** \`isRemovingClinicalNotesModel\` (set at the top of remove, cleared via \`defer\`) short-circuits \`handleClinicalNotesGenerateRequested\` so the menu-bar / hotkey trigger surfaces can't slip a new pipeline through during the drain window.
- **(e) Honest fallback reason.** \`reasonModelRemovedMidFlight\` sentinel + \`catch is CancellationError\` arms in \`ClinicalNotesProcessor.process\` so the Review banner says "Model was removed before generation finished" instead of "LLM error" when the user is responsible for the cancellation.

Closes #121.

## Why

The active-generation race is real but narrow. Realistic trigger: doctor taps "Generate Notes" → pipeline running → opens Settings → taps "Remove model". Before this PR, \`unload()\` would set \`self.container = nil\` but the live stream's captured \`container\` would keep the mmap pinned through end of generation; the user thinks they freed ~5 GB and they haven't. Worse, a re-entrant Generate Notes during the drain (via menu-bar / hotkey) could re-warm + capture against the directory we're about to unlink — same hazard, different shape.

## Tests

| Test | Suite | Tag |
|---|---|---|
| \`isClinicalNotesPipelineActive_defaultsFalseAndMirrors\` | \`AppStateModelStatusTests\` | \`.fast\` |
| \`removeClinicalNotesModel_clearsGateAcrossRepeatedCalls\` | \`AppStateModelStatusTests\` | \`.fast\` |
| \`llmCancellation_firstAttempt_modelRemovedSentinel\` | \`ClinicalNotesProcessorTests\` | \`.fast\` |
| \`test_readyState_pipelineActive_disablesRemoveAndShowsCaption\` | \`ClinicalNotesModelStatusRowTests\` | XCTest+ViewInspector |
| \`test_readyState_pipelineIdle_enablesRemoveAndHidesCaption\` | \`ClinicalNotesModelStatusRowTests\` | XCTest+ViewInspector |

\`swift test --parallel\` — 398 tests, all green.

## Pre-PR review (Opus)

Per AGENTS.md three-layer review:

- **\`pr-review-toolkit:code-reviewer\`** — ship-with-NITs. NIT 1 (slot-clear inline parity with download-task pattern) folded in via the new \`clearClinicalNotesPipelineSlotIfMatching(token:)\` helper. Other NITs (inline English caption matches existing project conventions; shared accessibility identifier is pre-existing) accepted as-is.
- **\`pr-review-toolkit:silent-failure-hunter\`** — two MAJOR findings:
  - **Scenario 4 / Finding 9** (re-entrant pipeline during drain) — folded in via \`isRemovingClinicalNotesModel\` flag.
  - **Scenario 2** (\`reasonLLMError\` for user-initiated remove) — folded in via \`reasonModelRemovedMidFlight\` sentinel.
  - **Scenario 6** (testability gap: \`AppState.llmProvider\` is concrete-typed, no DI seam for a non-hardware drain integration test) — filed as **#123** follow-up; out of scope for this PR.

## Behaviour against \`main\`

- Steady-state remove (covered by #120): no behaviour change.
- Active-generation race (this PR): pipeline cancelled + drained → fallback banner with new honest copy → \`unload()\` releases container → \`removeItem\` unlinks. ✅
- Re-entrant Generate Notes during drain: short-circuited to \`reasonModelUnavailable\` fallback while \`isRemovingClinicalNotesModel\` is set. ✅
- Settings row UX: Remove + Re-download disabled with caption while pipeline is active.

## Refs

- Issue: #121
- Predecessor: #120 (PR #122, merged \`3f1b839\`)
- Follow-up: #123 (testability — protocol-typing \`AppState.llmProvider\`)
- Doc: \`.claude/references/mlx-lifecycle.md\` already documents the release-before-unlink invariant from #120; the new pipeline-drain step extends that contract