### PR TITLE
fix(cliniko): appointment list decode + filtering + endpoint shape (#129)

### DIFF
--- a/Sources/Models/Appointment.swift
+++ b/Sources/Models/Appointment.swift
@@ -2,29 +2,148 @@ import Foundation
 
 /// A Cliniko appointment as the picker UI needs to display them.
 ///
-/// Wire shape: Cliniko's `GET /patients/{id}/appointments` returns numeric
-/// `id` and ISO8601 `starts_at` / `ends_at` (datetime with timezone), which
-/// `ClinikoClient.defaultDecoder` decodes natively via `.iso8601`.
+/// **Domain model — not the wire DTO.** The wire DTO lives in
+/// `ClinikoAppointmentDTO` and is mapped here via `toDomainModel(parser:)`
+/// at the service layer (#129). This split mirrors the patient pattern
+/// from #127 and the reference Cliniko integration in
+/// `CloudbrokerAz/epc-letter-generation`.
+///
+/// **Field nullability + types** (issue #129):
+/// - `id` is `String` because Cliniko's OpenAPI declares the field as
+///   `string($int64)` — same shape as `Patient.id`.
+/// - `startsAt` is `Date`; `endsAt` is `Date?`. Cliniko emits ISO8601 in
+///   either UTC `Z` or AU shard `+10:00` / `+1000` (no colon) form. Swift's
+///   `JSONDecoder` `.iso8601` strategy famously rejects `+1000`. We therefore
+///   decode dates as raw `String` in the DTO and parse them in
+///   `toDomainModel` via `ClinikoDateParser` — see `Sources/Services/Cliniko/AGENTS.md`
+///   §"Cliniko date offsets" for the gotcha.
+/// - `isCancelled` is **derived** from the wire fields `cancelled_at`,
+///   `archived_at`, and `did_not_arrive`. Any one being truthy makes the
+///   appointment ineligible for note attachment; `ClinikoAppointmentService`
+///   filters the list defensively after the upstream `q[]=cancelled_at:!?`
+///   server filter.
+///
+/// **Identity / equality** (matches #127's Patient pattern): equality and
+/// hashing are over `id` only. Two fetches of the same appointment with a
+/// flipped `cancelled_at` must still equal each other so a `Set<Appointment>`
+/// dedupes correctly and SwiftUI's `ForEach` diffing is stable across
+/// refetches.
 ///
 /// PHI: appointment timing combined with a known patient is PHI. Held in
 /// memory only — no logging beyond structural fields, no on-disk cache.
-public struct Appointment: Decodable, Identifiable, Sendable, Equatable, Hashable {
-    /// Cliniko numeric appointment ID. Stored as `Int` to match the wire
-    /// shape; the picker type-tags it into `OpaqueClinikoID` at the
-    /// `SessionStore` boundary
-    /// (`ClinicalSession.selectedAppointmentID`) — see #59.
-    public let id: Int
+public struct Appointment: Identifiable, Sendable {
+    /// Cliniko appointment ID. Wire shape per Cliniko's OpenAPI is
+    /// `string($int64)`. Stored as `String` so the decoder accepts the
+    /// documented shape; the picker type-tags it into `OpaqueClinikoID`
+    /// at the `SessionStore` boundary
+    /// (`ClinicalSession.selectedAppointmentID`) via `OpaqueClinikoID(_:String)`
+    /// — see #59 / #129.
+    public let id: String
 
-    /// Scheduled start time. Required by Cliniko's schema.
+    /// Scheduled start time, parsed from Cliniko's wire `starts_at`.
     public let startsAt: Date
 
-    /// Scheduled end time. Optional in case Cliniko ever returns an open-
-    /// ended appointment; today it's always present.
+    /// Scheduled end time. Optional — Cliniko has been observed returning
+    /// open-ended appointments on rare appointment-type configurations.
     public let endsAt: Date?
 
-    public init(id: Int, startsAt: Date, endsAt: Date? = nil) {
+    /// `true` if the appointment is cancelled, archived, or marked as a
+    /// did-not-arrive. The picker filters these out — they aren't valid
+    /// candidates for clinical-note attachment. Derived in
+    /// `ClinikoAppointmentDTO.toDomainModel(parser:)`.
+    public let isCancelled: Bool
+
+    /// Cliniko appointment-type ID, extracted from the nested
+    /// `appointment_type.links.self` URL (`.../appointment_types/<id>`).
+    /// `nil` if Cliniko omitted the relationship link or the URL had no
+    /// trailing path component. Held for future picker / export display;
+    /// not load-bearing for #129 itself.
+    public let appointmentTypeID: String?
+
+    /// Cliniko practitioner ID, extracted from the nested
+    /// `practitioner.links.self` URL. Same rationale as
+    /// `appointmentTypeID`.
+    public let practitionerID: String?
+
+    public init(
+        id: String,
+        startsAt: Date,
+        endsAt: Date? = nil,
+        isCancelled: Bool = false,
+        appointmentTypeID: String? = nil,
+        practitionerID: String? = nil
+    ) {
         self.id = id
         self.startsAt = startsAt
         self.endsAt = endsAt
+        self.isCancelled = isCancelled
+        self.appointmentTypeID = appointmentTypeID
+        self.practitionerID = practitionerID
+    }
+
+    /// Pick the appointment most likely to be the one the doctor is
+    /// recording for. Heuristic (#129):
+    ///
+    /// 1. **Slot-containing wins outright.** If `recordingStart` falls in
+    ///    `[startsAt, endsAt)` for some appointment, return it. The doctor
+    ///    pressed record during that slot — there is no ambiguity.
+    /// 2. **Otherwise nearest by `startsAt`** within `maxDistance`.
+    ///    Return the appointment whose `startsAt` is closest to
+    ///    `recordingStart` in either direction, provided that distance
+    ///    is within `maxDistance` (default: 24 hours). Beyond that we
+    ///    bail to `nil` — pre-selecting an appointment that's days
+    ///    away is wrong more often than right and erodes the doctor's
+    ///    trust in the picker. Tied distances resolve to the appointment
+    ///    in the past (`startsAt < recordingStart`) over one in the
+    ///    future, since clinically a doctor records during or after
+    ///    the slot, not before.
+    /// 3. Returns `nil` for an empty input.
+    ///
+    /// This is non-blocking — the picker still lets the user pick a
+    /// different appointment. The point is to skip the tap when the
+    /// natural answer is unambiguous.
+    public static func mostLikelyMatch(
+        in appointments: [Appointment],
+        for recordingStart: Date,
+        maxDistance: TimeInterval = 24 * 60 * 60
+    ) -> Appointment? {
+        if let containing = appointments.first(where: { appointment in
+            guard let endsAt = appointment.endsAt else { return false }
+            return appointment.startsAt <= recordingStart && recordingStart < endsAt
+        }) {
+            return containing
+        }
+        // Explicit tie-breaker rather than inheriting the caller's input
+        // ordering — keeps the helper's behaviour stable regardless of
+        // how the service layer happens to sort.
+        let nearest = appointments.min(by: { lhs, rhs in
+            let lDistance = abs(lhs.startsAt.timeIntervalSince(recordingStart))
+            let rDistance = abs(rhs.startsAt.timeIntervalSince(recordingStart))
+            if lDistance != rDistance { return lDistance < rDistance }
+            // Tie: prefer the past-leaning slot (startsAt < recordingStart).
+            return lhs.startsAt > rhs.startsAt
+                ? false
+                : lhs.startsAt < recordingStart && recordingStart <= rhs.startsAt
+        })
+        guard let candidate = nearest,
+              abs(candidate.startsAt.timeIntervalSince(recordingStart)) <= maxDistance
+        else { return nil }
+        return candidate
+    }
+}
+
+extension Appointment: Equatable, Hashable {
+    /// Identity-based equality: two `Appointment` values are equal iff
+    /// their Cliniko `id`s match. Whole-struct equality would mark two
+    /// fetches of the same appointment as non-equal whenever Cliniko
+    /// flipped `cancelled_at` / `archived_at` between calls — breaking
+    /// `Set<Appointment>` dedupe and SwiftUI's `ForEach` diff stability.
+    /// Same shape as `Patient`'s post-#127 equality.
+    public static func == (lhs: Appointment, rhs: Appointment) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
     }
 }

--- a/Sources/Models/ClinikoAppointmentDTO.swift
+++ b/Sources/Models/ClinikoAppointmentDTO.swift
@@ -1,0 +1,141 @@
+import Foundation
+import os
+
+/// Wire-shape DTO for Cliniko's `/individual_appointments` payload.
+///
+/// **Why a DTO + domain split** (issue #129): Cliniko's response carries
+/// fields we cannot decode through the global `ClinikoClient.defaultDecoder`
+/// without breaking — specifically the AU `+10:00` / `+1000` ISO8601
+/// offset variants that `JSONDecoder.DateDecodingStrategy.iso8601` either
+/// half-supports or rejects outright. The DTO holds dates as raw `String`
+/// and the service layer parses them in `toDomainModel(parser:)` via
+/// `ClinikoDateParser`, mirroring the reference Cliniko integration in
+/// `CloudbrokerAz/epc-letter-generation`.
+///
+/// **Pre-#129 history**: an earlier `Appointment: Decodable` model
+/// (numeric `id: Int`, `Date` strategy applied uniformly, top-level
+/// envelope key `appointments`) failed to decode any populated response
+/// because the wire shape diverged on four independent axes. The DTO
+/// encapsulates the wire shape, and the domain model
+/// (`Sources/Models/Appointment.swift`) carries only the parsed,
+/// presentation-shaped fields the picker + export flow need.
+///
+/// **Decoder strategy**: this DTO relies on `JSONDecoder` with
+/// `.convertFromSnakeCase` (the existing `ClinikoClient.defaultDecoder`),
+/// which auto-maps `starts_at` → `startsAt`, `cancelled_at` → `cancelledAt`,
+/// `appointment_type` → `appointmentType`, etc. Explicit `CodingKeys` are
+/// deliberately omitted because they would *conflict* with
+/// `.convertFromSnakeCase` (the strategy rewrites JSON keys before they
+/// match CodingKeys, so an explicit `case startsAt = "starts_at"` would
+/// look for the post-strategy key `"startsAt"` — same name, but breaks if
+/// the strategy is ever changed).
+///
+/// **PHI**: this is a transient decode artefact. The DTO never enters
+/// `OSLog`, never crosses an actor boundary except inside the service,
+/// never lands on disk. After `toDomainModel` runs, the DTO is dropped.
+struct ClinikoAppointmentDTO: Decodable, Sendable {
+    let id: String
+    let startsAt: String
+    let endsAt: String?
+    let cancelledAt: String?
+    let archivedAt: String?
+    let didNotArrive: Bool?
+    let patient: LinkRef?
+    let appointmentType: LinkRef?
+    let practitioner: LinkRef?
+
+    /// Cliniko's ubiquitous reference-only nested object: `{ "links": { "self": "<url>" } }`.
+    /// We extract the trailing path segment as the related resource ID
+    /// (e.g. `https://api.au1.cliniko.com/v1/appointment_types/4321` →
+    /// `"4321"`). All fields are optional because Cliniko omits the
+    /// nested object entirely on appointments without that relationship.
+    struct LinkRef: Decodable, Sendable {
+        let links: Links?
+
+        struct Links: Decodable, Sendable {
+            // Swift property name `self` requires backticks; JSON key is
+            // `self`. `.convertFromSnakeCase` does not transform a
+            // single-word lowercase key, so this matches verbatim.
+            let `self`: String?
+        }
+
+        /// Trailing URL path segment of `links.self`, or `nil` if the
+        /// link is missing, empty, or unparseable. Cliniko's resource
+        /// URLs are canonically `<base>/<resource>/<id>`, so the last
+        /// path segment is the related resource's ID. Parsed via
+        /// `URL.pathComponents` so query strings (`patients/1001?include=archived`)
+        /// and fragments (`patients/1001#anchor`) are stripped before
+        /// the segment lookup, and trailing slashes are tolerated by
+        /// the path-component splitter.
+        var trailingID: String? {
+            guard let raw = links?.`self`,
+                  let url = URL(string: raw)
+            else { return nil }
+            return url.pathComponents.last(where: { $0 != "/" && !$0.isEmpty })
+        }
+    }
+
+    /// Map this wire-shape DTO into the presentation-shaped domain model.
+    /// Throws `ClinikoError.decoding(typeName: "Date")` if `startsAt` is
+    /// malformed; `endsAt` failure degrades to `nil` because Cliniko has
+    /// been observed emitting incomplete end times on edge appointment
+    /// types and the picker can render without one. The degradation is
+    /// surfaced via a structural log on `ClinikoAppointmentDTO`'s logger
+    /// so a tenant-wide regression in Cliniko's `ends_at` shape is
+    /// visible in `OSLog` without leaking PHI.
+    ///
+    /// **Future-proofing note**: `isCancelled` is derived from
+    /// `cancelled_at`, `archived_at`, and `did_not_arrive`. If Cliniko
+    /// ever introduces a new exclusion-shaped status field (e.g.
+    /// `marked_no_show`, `voided`), update this derivation alongside
+    /// the DTO's properties — silently ignoring a new field would let
+    /// a non-attachable slot land in the picker.
+    func toDomainModel(parser: ClinikoDateParser) throws -> Appointment {
+        let startsAtDate = try parser.parse(startsAt)
+        let endsAtDate: Date?
+        if let endsAtString = endsAt {
+            do {
+                endsAtDate = try parser.parse(endsAtString)
+            } catch {
+                // Structural log only — no PHI (no patient/appointment
+                // IDs, no value strings). Lets ops detect a tenant-wide
+                // regression in Cliniko's ends_at shape without
+                // breaking the picker UX (the slot still renders; the
+                // most-likely-this-recording slot-containing rule
+                // simply degrades to nearest-startsAt).
+                Self.logger.error("ClinikoAppointmentDTO: ends_at parse failed; degrading to nil")
+                endsAtDate = nil
+            }
+        } else {
+            endsAtDate = nil
+        }
+        let cancelled = cancelledAt != nil
+            || archivedAt != nil
+            || (didNotArrive ?? false)
+        return Appointment(
+            id: id,
+            startsAt: startsAtDate,
+            endsAt: endsAtDate,
+            isCancelled: cancelled,
+            appointmentTypeID: appointmentType?.trailingID,
+            practitionerID: practitioner?.trailingID
+        )
+    }
+
+    /// File-scoped logger. Tag is a constant; never carries PHI.
+    private static let logger = os.Logger(
+        subsystem: "com.speechtotext",
+        category: "ClinikoAppointmentDTO"
+    )
+}
+
+/// Top-level envelope for `GET /individual_appointments?...`. Cliniko's
+/// list endpoints share this shape (a typed `array` field, optional
+/// `total_entries`, optional `links`) — only the array's field name
+/// changes per resource. The patient endpoint has `patients`; this one
+/// has `individual_appointments`.
+struct ClinikoAppointmentListDTO: Decodable, Sendable {
+    let individualAppointments: [ClinikoAppointmentDTO]
+    let totalEntries: Int?
+    let links: ClinikoPaginationLinks?
+}

--- a/Sources/Models/ClinikoPagination.swift
+++ b/Sources/Models/ClinikoPagination.swift
@@ -21,21 +21,13 @@ public struct PatientSearchResponse: Decodable, Sendable, Equatable {
     }
 }
 
-public struct AppointmentListResponse: Decodable, Sendable, Equatable {
-    public let appointments: [Appointment]
-    public let totalEntries: Int?
-    public let links: ClinikoPaginationLinks?
-
-    public init(
-        appointments: [Appointment],
-        totalEntries: Int? = nil,
-        links: ClinikoPaginationLinks? = nil
-    ) {
-        self.appointments = appointments
-        self.totalEntries = totalEntries
-        self.links = links
-    }
-}
+// Note: `AppointmentListResponse` was removed in #129. The appointment
+// list now decodes through `ClinikoAppointmentListDTO` (wire-shape) and
+// maps to `[Appointment]` via `ClinikoAppointmentDTO.toDomainModel(parser:)`
+// at the service layer. Cliniko's `/individual_appointments` envelope key
+// is `individual_appointments`, not `appointments` — the previous shape
+// failed to decode any populated response. See the DTO file at
+// `Sources/Models/ClinikoAppointmentDTO.swift`.
 
 /// `links` envelope shared by every Cliniko list endpoint. We don't follow
 /// `next` today — keep the type loose (`URL?`) so a future paginate helper

--- a/Sources/Models/OpaqueClinikoID.swift
+++ b/Sources/Models/OpaqueClinikoID.swift
@@ -4,9 +4,11 @@ import Foundation
 ///
 /// Cliniko's wire shape for these resources is mixed: `Patient.id` is
 /// documented as `string($int64)` and decoded as `String` (#127);
-/// `Appointment.id` and `TreatmentNoteCreated.id` are still numeric
-/// (`Int`). The audit ledger and `SessionStore` need an opaque-but-typed
-/// handle that:
+/// `Appointment.id` is also documented as `string($int64)` and decoded
+/// as `String` (#129); `TreatmentNoteCreated.id` is still numeric
+/// (`Int`) per the Cliniko `treatment_notes` POST response shape.
+/// The audit ledger and `SessionStore` need an opaque-but-typed handle
+/// that:
 ///
 /// 1. **Refuses free-form strings** at every migrated callsite.
 ///    `AuditRecord.init(patientID:)` accepts only `OpaqueClinikoID`, not
@@ -25,18 +27,20 @@ import Foundation
 ///    `AuditStoreTests.line_pins_opaque_id_byte_shape`.
 /// 3. Round-trips through the `Int` ↔ `String` boundary in one place.
 ///    Production code uses `init(_ int: Int)` at numeric Cliniko-response
-///    boundaries (`Appointment.id`, `TreatmentNoteCreated.id`) and
-///    `init(_ string: String)` at the `Patient.id` boundary (#127);
-///    `init(rawValue: String)` is reserved for Codable round-trip from
-///    `audit.jsonl` and for tests that want deterministic string
-///    literals.
+///    boundaries (`TreatmentNoteCreated.id`) and `init(_ string: String)`
+///    at string-shaped boundaries (`Patient.id` per #127 and
+///    `Appointment.id` per #129); `init(rawValue: String)` is reserved
+///    for Codable round-trip from `audit.jsonl` and for tests that want
+///    deterministic string literals.
 ///
 /// **Issue #59.** Replaces the three bare-`String` ID fields on
-/// `AuditRecord` and the two on `ClinicalSession`. Wire-shape IDs on
-/// `Appointment` and `TreatmentNotePayload` remain `Int` — those are
-/// what Cliniko's HTTP API speaks for those resources. `Patient.id`
-/// flipped to `String` in #127 to match Cliniko's documented
-/// `string($int64)` shape.
+/// `AuditRecord` and the two on `ClinicalSession`. The wire-shape ID on
+/// `TreatmentNoteCreated` (and the `Int` field on
+/// `TreatmentNotePayload.appointmentID` / `.patientID` going OUT to
+/// Cliniko) remain `Int` — that's the request-side wire shape Cliniko
+/// expects for `POST /treatment_notes`. `Patient.id` (#127) and
+/// `Appointment.id` (#129) flipped to `String` to match Cliniko's
+/// documented `string($int64)` response shape on the read side.
 ///
 /// **`RawRepresentable` rationale.** Required by the issue spec for
 /// symmetry with the predecessor `String`-typed fields and so the

--- a/Sources/Services/ClinicalNotes/SessionStore.swift
+++ b/Sources/Services/ClinicalNotes/SessionStore.swift
@@ -154,8 +154,9 @@ final class SessionStore {
 
     /// Set the Cliniko appointment selection. Same `OpaqueClinikoID`
     /// type-tag invariant as `setSelectedPatient(id:)` — the picker
-    /// constructs from the numeric `Appointment.id`; tests use
-    /// `init(rawValue:)` for deterministic literals.
+    /// constructs from the `String` `Appointment.id` via
+    /// `OpaqueClinikoID(_:String)` (the Cliniko-response shape per #129);
+    /// tests use `init(rawValue:)` for deterministic literals.
     func setSelectedAppointment(id: OpaqueClinikoID?) {
         guard active != nil else { return }
         active?.selectedAppointmentID = id

--- a/Sources/Services/Cliniko/AGENTS.md
+++ b/Sources/Services/Cliniko/AGENTS.md
@@ -85,6 +85,46 @@ double-write a clinical record. The full table lives in
 [`cliniko-api.md`](../../../.claude/references/cliniko-api.md)
 §"Retry policy".
 
+### Cliniko date offsets — do NOT use `.iso8601` decoder strategy
+
+Cliniko's AU shards return ISO8601 timestamps in **three** distinct
+shapes the global `JSONDecoder.DateDecodingStrategy.iso8601` does not
+all handle:
+
+- `2026-04-25T09:00:00Z` (UTC) — works.
+- `2026-04-25T19:00:00+10:00` (RFC3339, with colon) — works.
+- `2026-04-25T19:00:00+1000` (ISO8601 basic offset, no colon) —
+  **rejected by `ISO8601DateFormatter` regardless of options**.
+- Plus any of the above with fractional seconds (`2026-04-25T09:00:00.123Z`)
+  which require `[.withInternetDateTime, .withFractionalSeconds]` —
+  also not the strategy default.
+
+**Rule** (#129): for any new endpoint that returns Cliniko-side
+datetimes, decode the wire field as raw `String` in the DTO and parse
+it through `ClinikoDateParser` in the `toDomainModel(parser:)`
+mapping. Do NOT add `.iso8601` (or any custom date strategy) to
+`ClinikoClient.defaultDecoder` — every endpoint that already worked
+(Patient `date_of_birth`, audit timestamps) does so because the field
+is `String`, not `Date`. Adding a strategy would cascade into hidden
+parse failures on the AU `+1000` form and silently degrade existing
+endpoints.
+
+The `ClinikoAppointmentService` flow is the canonical example:
+`Sources/Models/ClinikoAppointmentDTO.swift` decodes `starts_at` /
+`ends_at` / `cancelled_at` / `archived_at` as `String?`, then
+`ClinikoAppointmentService.recentAndTodayAppointments(...)` calls
+`dto.toDomainModel(parser:)` to produce `[Appointment]` with parsed
+`Date` fields.
+
+`ClinikoClient.defaultDecoder` already sets `.iso8601` as its date
+strategy. Every Cliniko endpoint we ship today decodes datetimes as
+`String` in the DTO and parses via `ClinikoDateParser`, so the
+strategy never fires — but don't *rely* on this. Don't *remove* the
+strategy either: removing it would silently change behaviour for any
+future `Date`-typed field added without a paired code review. The
+right pattern for a new `Date` field is to add it as `String` in the
+DTO and parse explicitly.
+
 ### Shard handling
 
 **Never** hardcode `api.au1.cliniko.com` (or any subdomain) anywhere

--- a/Sources/Services/Cliniko/ClinikoAppointmentService.swift
+++ b/Sources/Services/Cliniko/ClinikoAppointmentService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Actor-constrained protocol for the patient picker's appointment-loading
 /// dependency. See `ClinikoPatientSearching` for the rationale on
@@ -14,7 +15,10 @@ public protocol ClinikoAppointmentLoading: Actor {
     ///   - reference: The "today" anchor — defaults to `Date()`. Tests pass
     ///     a fixed date so the from / to query params are deterministic.
     /// - Throws: `ClinikoError`. Same shape as `searchPatients`.
-    /// - Returns: zero or more appointments, Cliniko's natural order.
+    /// - Returns: zero or more appointments, **most-recent first**
+    ///   (descending by `startsAt`). Cancelled / archived /
+    ///   did-not-arrive rows are filtered out and never reach the
+    ///   caller.
     func recentAndTodayAppointments(
         forPatientID patientID: String,
         reference: Date
@@ -30,14 +34,38 @@ public protocol ClinikoAppointmentLoading: Actor {
 /// appointments still match. Both bounds are emitted as ISO8601 in UTC,
 /// matching the encoding `ClinikoEndpoint.patientAppointments` uses.
 ///
+/// **Wire shape** (#129): the underlying request hits Cliniko's
+/// `/individual_appointments` endpoint with server-side filters
+/// (`q[]=patient_id:=`, `q[]=starts_at:>=`/`<=`, `q[]=cancelled_at:!?`)
+/// and server-side `sort=starts_at&order=desc`. The response decodes
+/// through `ClinikoAppointmentListDTO` and maps to `[Appointment]` via
+/// `ClinikoAppointmentDTO.toDomainModel(parser:)`. The service layer
+/// then re-applies `!isCancelled` filtering and a defensive descending
+/// re-sort so a future Cliniko regression in either filter or sort
+/// semantics doesn't cascade into the picker.
+///
 /// PHI: as with `ClinikoPatientService`, this actor never logs query
 /// arguments, never logs the response, and never persists. Logging stays
 /// inside `ClinikoClient`.
 public actor ClinikoAppointmentService: ClinikoAppointmentLoading {
     private let client: ClinikoClient
+    private let parser: ClinikoDateParser
+
+    /// Page size we cap the request at via `per_page` (mirrors the
+    /// constant in `ClinikoEndpoint.queryItems` for the
+    /// `.patientAppointments` arm). The picker doesn't paginate today;
+    /// hitting this cap is a soft signal that the window is too wide
+    /// for the tenant.
+    private static let perPageCap = 50
+
+    private let logger = Logger(
+        subsystem: "com.speechtotext",
+        category: "ClinikoAppointmentService"
+    )
 
     public init(client: ClinikoClient) {
         self.client = client
+        self.parser = ClinikoDateParser()
     }
 
     /// Conformance to `ClinikoAppointmentLoading`. Note: no default for
@@ -63,9 +91,39 @@ public actor ClinikoAppointmentService: ClinikoAppointmentLoading {
         else {
             preconditionFailure("ClinikoAppointmentService: ±day arithmetic returned nil for a valid reference date")
         }
-        let response: AppointmentListResponse = try await client.send(
+        let response: ClinikoAppointmentListDTO = try await client.send(
             .patientAppointments(patientID: patientID, from: from, to: to)
         )
-        return response.appointments
+        // Soft warn when the response was truncated — `per_page=50` is
+        // the cap, and a `total_entries > 50` means the picker is
+        // showing only the most-recent slice. PHI: only the integer
+        // counts are logged (no patient id, no appointment ids, no
+        // timestamps). A doctor with a high-volume tenant can still
+        // see ALL appointments via Cliniko itself; this surfaces
+        // ops-side that the cap matters for them.
+        if let total = response.totalEntries,
+           total > response.individualAppointments.count {
+            logger.notice(
+                "ClinikoAppointmentService: appointment list truncated count=\(response.individualAppointments.count, privacy: .public) total=\(total, privacy: .public) cap=\(Self.perPageCap, privacy: .public)"
+            )
+        }
+        // Map DTO → domain. Date parsing happens here (NOT in the
+        // top-level `JSONDecoder` strategy) because Cliniko emits AU
+        // shard `+10:00` and `+1000` offsets that the default
+        // `.iso8601` strategy mishandles — see
+        // `ClinikoDateParser` for the four-pass cascade.
+        let domain = try response.individualAppointments.map { dto in
+            try dto.toDomainModel(parser: parser)
+        }
+        // Defensive client-side filter + sort. The server-side
+        // `q[]=cancelled_at:!?` should already exclude cancelled rows,
+        // but we re-filter on the wider `!isCancelled` derivation
+        // (`cancelled_at` OR `archived_at` OR `did_not_arrive == true`)
+        // because we do NOT trust either Cliniko or our own URL builder
+        // to defend the picker against showing a non-attachable slot.
+        // Same belt-and-braces shape as #127's archived-patient filter.
+        return domain
+            .filter { !$0.isCancelled }
+            .sorted { $0.startsAt > $1.startsAt }
     }
 }

--- a/Sources/Services/Cliniko/ClinikoDateParser.swift
+++ b/Sources/Services/Cliniko/ClinikoDateParser.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+/// Parses Cliniko's ISO8601 datetime strings into `Date`.
+///
+/// **Why a custom parser** (issue #129): Swift's
+/// `JSONDecoder.DateDecodingStrategy.iso8601` uses `ISO8601DateFormatter`
+/// configured with `[.withInternetDateTime]` only. Cliniko AU shards
+/// emit timestamps in two distinct shapes the default strategy does not
+/// handle cleanly:
+///
+/// - **`+10:00` form (RFC3339, with colon)**: e.g. `2026-04-25T19:00:00+10:00`.
+///   `ISO8601DateFormatter` with `[.withInternetDateTime]` accepts this.
+/// - **`+1000` form (ISO8601 basic offset, no colon)**: e.g.
+///   `2026-04-25T19:00:00+1000`. `ISO8601DateFormatter` rejects this
+///   regardless of options. We fall back to a `DateFormatter` with the
+///   matching pattern.
+/// - **Fractional seconds**: e.g. `2026-04-25T09:00:00.123Z`. Requires
+///   `[.withInternetDateTime, .withFractionalSeconds]`.
+///
+/// The parser tries each path in order — fractional ISO → bare ISO →
+/// `DateFormatter` for `+HHMM` shapes — and throws
+/// `ClinikoError.decoding(typeName: "Date")` if every parse fails. The
+/// thrown error never carries the input string so PHI-adjacent
+/// timestamps (an appointment time + a known patient context) cannot
+/// leak through `localizedDescription`.
+///
+/// PHI: the parser does not log. The caller (`ClinikoAppointmentDTO.toDomainModel`)
+/// catches and re-throws via the typed `ClinikoError` set; the client
+/// emits its kind-tag log without the value.
+struct ClinikoDateParser: Sendable {
+
+    /// Parse an ISO8601 datetime string into `Date`. Tries:
+    /// 1. `ISO8601DateFormatter` with fractional-seconds + internet date-time.
+    /// 2. `ISO8601DateFormatter` with internet date-time only.
+    /// 3. `DateFormatter` with `yyyy-MM-dd'T'HH:mm:ssZZZZ` (covers `+1000`).
+    /// 4. `DateFormatter` with `yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ` (covers
+    ///    `+1000` with fractional seconds).
+    func parse(_ input: String) throws -> Date {
+        // Cascade order: try plain ISO first because the vast majority
+        // of Cliniko payloads carry no fractional seconds; pay the
+        // happy-path cost on the most common shape. Fractional ISO is
+        // strict — it requires fractional seconds to be present — so
+        // it cannot accidentally consume a non-fractional input that
+        // pass 1 already rejected. Same logic for the basic-offset
+        // formatters: plain before fractional.
+        if let date = Self.iso8601Plain.date(from: input) { return date }
+        if let date = Self.iso8601Fractional.date(from: input) { return date }
+        if let date = Self.basicOffsetPlain.date(from: input) { return date }
+        if let date = Self.basicOffsetFractional.date(from: input) { return date }
+        throw ClinikoError.decoding(typeName: "Date")
+    }
+
+    // MARK: - Formatters
+
+    // `ISO8601DateFormatter` is thread-safe per Apple's docs (the relevant
+    // header explicitly states all methods are safe to call concurrently).
+    // `DateFormatter` is also documented as thread-safe on macOS 10.9+.
+    // Both are static `let` so we pay the construction cost exactly once.
+
+    private static let iso8601Fractional: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let iso8601Plain: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let basicOffsetPlain: DateFormatter = {
+        let formatter = DateFormatter()
+        // `ZZZZ` accepts `+HHMM` (no colon) AND `+HH:MM` forms
+        // empirically on macOS 26 (verified by the
+        // `parses_basicOffset_plain` test); strict ICU/TR35
+        // interpretation is "long localised GMT" but Foundation's
+        // `DateFormatter` is more lenient than the spec on the parse
+        // side. The strict-RFC alternative would be `xxxx` (basic-form
+        // `+HHMM` only). Either works for our cascade because
+        // `+HH:MM` is already handled by `iso8601Plain`. Sticking with
+        // `ZZZZ` for backwards compatibility with future devices that
+        // emit the long-localised form. `Locale("en_US_POSIX")` is the
+        // canonical fixed-format-parser locale per Apple's docs (rdar
+        // #18377693 — without it, system locales with non-Gregorian
+        // calendars would silently misparse). `isLenient = false` is
+        // defence-in-depth — Foundation's default could flip in a
+        // future release; pinning here keeps the parser strict.
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZ"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.isLenient = false
+        return formatter
+    }()
+
+    private static let basicOffsetFractional: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZ"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.isLenient = false
+        return formatter
+    }()
+}

--- a/Sources/Services/Cliniko/ClinikoEndpoint.swift
+++ b/Sources/Services/Cliniko/ClinikoEndpoint.swift
@@ -26,8 +26,18 @@ public enum ClinikoEndpoint: Sendable, Equatable {
     /// `patientSearchQueryItems` for the splitting strategy.
     case patientSearch(query: String)
 
-    /// `GET /patients/{id}/appointments?from={ISO8601}&to={ISO8601}` —
-    /// recent + today's appointments for the chosen patient (#9).
+    /// `GET /individual_appointments?q[]=patient_id:=<id>&q[]=starts_at:>=<from>&q[]=starts_at:<=<to>&q[]=cancelled_at:!?&sort=starts_at&order=desc&per_page=50`
+    /// — recent + today's appointments for the chosen patient (#9).
+    /// Switched from the previous `/patients/{id}/appointments` shape in
+    /// #129: the per-patient shorthand returned a different envelope shape
+    /// (`appointments` vs `individual_appointments`) and didn't accept the
+    /// `q[]=cancelled_at:!?` filter that lets the picker drop cancelled
+    /// rows server-side. The new path also takes server-side
+    /// `sort=starts_at&order=desc` so the most-recent slot lands first.
+    /// Defensive client-side filtering + sorting still runs in
+    /// `ClinikoAppointmentService` (`!isCancelled`, descending re-sort).
+    /// Mirrors the reference impl in
+    /// `CloudbrokerAz/epc-letter-generation/Sources/Services/Cliniko/ClinikoAppointmentService.swift`.
     case patientAppointments(patientID: String, from: Date, to: Date)
 
     /// `POST /treatment_notes` with a JSON body — #10 will own the codable
@@ -58,7 +68,11 @@ public enum ClinikoEndpoint: Sendable, Equatable {
         switch self {
         case .usersMe: return "/user"
         case .patientSearch: return "/patients?q[]={filter}"
-        case .patientAppointments: return "/patients/:id/appointments"
+        // Path template is PHI-safe — no bound IDs. The actual filters
+        // (patient_id, starts_at window, cancelled_at) ride in the
+        // query items. Logging this template at `privacy: .public` is
+        // safe; logging the resolved URL is not.
+        case .patientAppointments: return "/individual_appointments?q[]={patient_id}&q[]={starts_at}"
         case .createTreatmentNote: return "/treatment_notes"
         }
     }
@@ -133,15 +147,11 @@ public enum ClinikoEndpoint: Sendable, Equatable {
             return "user"
         case .patientSearch:
             return "patients"
-        case .patientAppointments(let patientID, _, _):
-            // Encode weirdness inside the bound id (spaces, slashes, etc.).
-            // We start from `urlPathAllowed` and *remove* "/" so an embedded
-            // slash in the id can't accidentally introduce a new path
-            // segment. Cliniko ids are numeric in practice; this is
-            // defence-in-depth.
-            let allowed = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
-            let encoded = patientID.addingPercentEncoding(withAllowedCharacters: allowed) ?? patientID
-            return "patients/\(encoded)/appointments"
+        case .patientAppointments:
+            // Patient ID lives in `q[]=patient_id:=...` query value,
+            // not in the path. `URLComponents` percent-encodes query
+            // values for us — see `queryItems` arm.
+            return "individual_appointments"
         case .createTreatmentNote:
             return "treatment_notes"
         }
@@ -159,10 +169,37 @@ public enum ClinikoEndpoint: Sendable, Equatable {
             // hygiene.
             let items = ClinikoEndpoint.patientSearchQueryItems(query: query)
             return items.isEmpty ? nil : items
-        case .patientAppointments(_, let from, let to):
+        case .patientAppointments(let patientID, let from, let to):
+            // Cliniko's `/individual_appointments` filter syntax
+            // (`q[]=field:operator value`) — verified against the
+            // reference impl in `epc-letter-generation`. We:
+            //
+            // - bind the patient ID server-side so a tampered client
+            //   cannot list-all (`patient_id:=` is the equality op);
+            // - constrain the window via `starts_at:>=` / `starts_at:<=`
+            //   in UTC (the helper at `ClinikoEndpoint.iso8601(_:)` emits
+            //   `Z`-form, which Cliniko's filter parser handles);
+            // - drop cancelled rows server-side via `cancelled_at:!?`
+            //   (Cliniko's "is null" filter — `:!?` reads as "no value").
+            //   `archived_at` and `did_not_arrive` are NOT filtered
+            //   server-side (the reference impl doesn't, and we haven't
+            //   verified Cliniko accepts those filter shapes); the
+            //   service layer drops them client-side via
+            //   `Appointment.isCancelled`;
+            // - sort server-side `starts_at desc` so the picker can
+            //   render in display order without an extra sort hop;
+            // - cap `per_page=50` so a runaway window can't blow the
+            //   response budget. The picker doesn't paginate today
+            //   (UX would benefit more from a window narrowing than from
+            //   a "load more" affordance).
             return [
-                URLQueryItem(name: "from", value: ClinikoEndpoint.iso8601(from)),
-                URLQueryItem(name: "to", value: ClinikoEndpoint.iso8601(to))
+                URLQueryItem(name: "q[]", value: "patient_id:=\(patientID)"),
+                URLQueryItem(name: "q[]", value: "starts_at:>=\(ClinikoEndpoint.iso8601(from))"),
+                URLQueryItem(name: "q[]", value: "starts_at:<=\(ClinikoEndpoint.iso8601(to))"),
+                URLQueryItem(name: "q[]", value: "cancelled_at:!?"),
+                URLQueryItem(name: "sort", value: "starts_at"),
+                URLQueryItem(name: "order", value: "desc"),
+                URLQueryItem(name: "per_page", value: "50")
             ]
         }
     }

--- a/Sources/Views/ClinicalNotes/ExportFlowView.swift
+++ b/Sources/Views/ClinicalNotes/ExportFlowView.swift
@@ -429,6 +429,8 @@ struct ExportFlowView: View {
             return "Pick a patient before exporting."
         case .sessionState(.patientIDMalformed):
             return "Internal error. Cancel and re-record."
+        case .sessionState(.appointmentIDMalformed):
+            return "Internal error with the appointment ID. Re-pick the appointment, or choose 'No appointment / general note'."
         case .sessionState(.appointmentUnresolved):
             return "Choose an appointment (or 'No appointment / general note') before confirming."
         case .sessionState(.noDraftNotes):

--- a/Sources/Views/ClinicalNotes/ExportFlowViewModel.swift
+++ b/Sources/Views/ClinicalNotes/ExportFlowViewModel.swift
@@ -200,6 +200,13 @@ enum ExportFailure: Error, Sendable, Equatable {
         /// non-numeric Cliniko ID shape entered. Either way, we
         /// can't build the wire payload.
         case patientIDMalformed
+        /// The selected appointment's `OpaqueClinikoID.rawValue` could
+        /// not be parsed as `Int` — same class as `patientIDMalformed`
+        /// (#127), now applied to `Appointment.id` after #129 flipped
+        /// it to `String`. Without this guard, a malformed appointment
+        /// id would silently degrade the export to a general note,
+        /// losing the appointment linkage with no user-visible signal.
+        case appointmentIDMalformed
         /// `appointment` resolved to `.unset` — the practitioner
         /// hasn't chosen between "an appointment" and "no
         /// appointment". The confirm UI is gated on this; reaching
@@ -384,6 +391,22 @@ final class ExportFlowViewModel: Identifiable {
         guard let notes = sessionStore.active?.draftNotes else {
             state = .failed(.sessionState(.noDraftNotes))
             logger.error("ExportFlowViewModel: confirm blocked — no draft notes")
+            return
+        }
+
+        // Mirror the patientIDMalformed guard for the appointment
+        // boundary. Cliniko's `Appointment.id` is documented as
+        // `string($int64)` (post-#129); in practice every tenant emits
+        // numeric strings and `Int(rawValue)` succeeds. A non-numeric
+        // value reaches here only via a tampered Codable round-trip
+        // or a future Cliniko shape change — surface as
+        // `.appointmentIDMalformed` rather than silently degrading
+        // the export to a general note (which would lose the
+        // appointment linkage with no user-visible signal).
+        if case .appointment(let opaqueID) = summary.appointment,
+           Int(opaqueID.rawValue) == nil {
+            state = .failed(.sessionState(.appointmentIDMalformed))
+            logger.error("ExportFlowViewModel: confirm blocked — appointmentID malformed")
             return
         }
 
@@ -647,6 +670,7 @@ final class ExportFlowViewModel: Identifiable {
             case .noActiveSession: return "sessionState.noActiveSession"
             case .noPatient: return "sessionState.noPatient"
             case .patientIDMalformed: return "sessionState.patientIDMalformed"
+            case .appointmentIDMalformed: return "sessionState.appointmentIDMalformed"
             case .appointmentUnresolved: return "sessionState.appointmentUnresolved"
             case .noDraftNotes: return "sessionState.noDraftNotes"
             }

--- a/Sources/Views/ClinicalNotes/PatientPickerViewModel.swift
+++ b/Sources/Views/ClinicalNotes/PatientPickerViewModel.swift
@@ -52,10 +52,12 @@ final class PatientPickerViewModel: Identifiable {
 
     private(set) var appointmentPhase: AppointmentPhase = .idle
 
-    /// Local mirror of `ClinicalSession.selectedAppointmentID`, kept as an
-    /// `Int?` for the picker UI. `nil` means "No appointment / general
-    /// note" (the post-recording note doesn't tie to an appointment).
-    private(set) var selectedAppointmentID: Int?
+    /// Local mirror of `ClinicalSession.selectedAppointmentID`, kept as a
+    /// `String?` for the picker UI (matches Cliniko's documented
+    /// `string($int64)` `Appointment.id` shape per #129). `nil` means
+    /// "No appointment / general note" (the post-recording note doesn't
+    /// tie to an appointment).
+    private(set) var selectedAppointmentID: String?
 
     // MARK: - Dependencies
 
@@ -223,6 +225,20 @@ final class PatientPickerViewModel: Identifiable {
                 return
             }
             appointmentPhase = .loaded(appointments)
+            // Pre-select the appointment most likely to be the one this
+            // recording is for — non-blocking, the user can still pick a
+            // different one (#129). Anchor on the recording's
+            // `startTime` so the heuristic answers "which slot was the
+            // doctor in when they pressed record?" rather than "which
+            // appointment is most recent". A slot containing
+            // `recordingStart` wins outright; otherwise the appointment
+            // nearest in time. Skip if the user already manually
+            // selected an appointment during the load (rare race).
+            if selectedAppointmentID == nil,
+               let recordingStart = sessionStore.active?.recordingSession.startTime,
+               let bestMatch = Appointment.mostLikelyMatch(in: appointments, for: recordingStart) {
+                selectAppointment(id: bestMatch.id)
+            }
         } catch let error as ClinikoError {
             // `.cancelled` from the service is only safe to swallow
             // when our local task was actually cancelled (the user
@@ -254,11 +270,18 @@ final class PatientPickerViewModel: Identifiable {
     }
 
     /// Select an appointment, or `nil` for "No appointment / general
-    /// note". Writes through to the session store, type-tagging the Int
-    /// into `OpaqueClinikoID` (#59) at the SessionStore boundary.
-    func selectAppointment(id: Int?) {
+    /// note". Writes through to the session store, type-tagging the
+    /// `String` into `OpaqueClinikoID` (#59 / #129) at the SessionStore
+    /// boundary via `OpaqueClinikoID(_:String)`.
+    func selectAppointment(id: String?) {
         selectedAppointmentID = id
-        sessionStore.setSelectedAppointment(id: id.map(OpaqueClinikoID.init))
+        // Disambiguate the `String`-shaped `init(_:String)` (canonical
+        // Cliniko-response boundary, #129) from `init(rawValue:)`
+        // (Codable / test-only). `id.map(OpaqueClinikoID.init)` would be
+        // ambiguous to the compiler given both inits share the same
+        // `String` shape; the explicit closure binds the unambiguous
+        // overload.
+        sessionStore.setSelectedAppointment(id: id.map { OpaqueClinikoID($0) })
     }
 
     /// Clear the entire selection state. Used by the host view when the

--- a/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patient_appointments.json
+++ b/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patient_appointments.json
@@ -1,23 +1,70 @@
 {
-  "appointments": [
+  "individual_appointments": [
     {
-      "id": 5001,
+      "id": "5001",
       "starts_at": "2026-04-25T09:00:00Z",
-      "ends_at": "2026-04-25T09:30:00Z"
+      "ends_at": "2026-04-25T09:30:00Z",
+      "notes": null,
+      "cancelled_at": null,
+      "archived_at": null,
+      "did_not_arrive": false,
+      "patient": {
+        "links": {
+          "self": "https://api.au1.cliniko.com/v1/patients/1001"
+        }
+      },
+      "appointment_type": {
+        "links": {
+          "self": "https://api.au1.cliniko.com/v1/appointment_types/4321"
+        }
+      },
+      "practitioner": {
+        "links": {
+          "self": "https://api.au1.cliniko.com/v1/practitioners/9001"
+        }
+      },
+      "attendees": {
+        "links": {
+          "self": "https://api.au1.cliniko.com/v1/individual_appointments/5001/attendees"
+        }
+      }
     },
     {
-      "id": 5002,
+      "id": "5002",
       "starts_at": "2026-04-22T14:15:00Z",
-      "ends_at": "2026-04-22T14:45:00Z"
+      "ends_at": "2026-04-22T14:45:00Z",
+      "notes": null,
+      "cancelled_at": null,
+      "archived_at": null,
+      "did_not_arrive": false,
+      "patient": {
+        "links": {
+          "self": "https://api.au1.cliniko.com/v1/patients/1001"
+        }
+      },
+      "appointment_type": {
+        "links": {
+          "self": "https://api.au1.cliniko.com/v1/appointment_types/4321"
+        }
+      },
+      "practitioner": {
+        "links": {
+          "self": "https://api.au1.cliniko.com/v1/practitioners/9001"
+        }
+      }
     },
     {
-      "id": 5003,
+      "id": "5003",
       "starts_at": "2026-04-19T08:00:00Z",
-      "ends_at": "2026-04-19T08:30:00Z"
+      "ends_at": "2026-04-19T08:30:00Z",
+      "notes": null,
+      "cancelled_at": null,
+      "archived_at": null,
+      "did_not_arrive": false
     }
   ],
   "total_entries": 3,
   "links": {
-    "self": "https://api.au1.cliniko.com/v1/patients/1001/appointments?from=2026-04-18T00:00:00Z&to=2026-04-26T00:00:00Z"
+    "self": "https://api.au1.cliniko.com/v1/individual_appointments?q%5B%5D=patient_id%3A%3D1001"
   }
 }

--- a/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patient_appointments_au_with_offset.json
+++ b/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patient_appointments_au_with_offset.json
@@ -1,0 +1,32 @@
+{
+  "individual_appointments": [
+    {
+      "id": "7001",
+      "starts_at": "2026-04-25T19:00:00+10:00",
+      "ends_at": "2026-04-25T19:30:00+10:00",
+      "cancelled_at": null
+    },
+    {
+      "id": "7002",
+      "starts_at": "2026-04-25T19:00:00+1000",
+      "ends_at": "2026-04-25T19:30:00+1000",
+      "cancelled_at": null
+    },
+    {
+      "id": "7003",
+      "starts_at": "2026-04-25T09:00:00.123Z",
+      "ends_at": "2026-04-25T09:30:00.456Z",
+      "cancelled_at": null
+    },
+    {
+      "id": "7004",
+      "starts_at": "2026-04-25T19:00:00.123+10:00",
+      "ends_at": "2026-04-25T19:30:00.456+10:00",
+      "cancelled_at": null
+    }
+  ],
+  "total_entries": 4,
+  "links": {
+    "self": "https://api.au1.cliniko.com/v1/individual_appointments?q%5B%5D=patient_id%3A%3D1001"
+  }
+}

--- a/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patient_appointments_with_cancelled.json
+++ b/Tests/SpeechToTextTests/Fixtures/cliniko/responses/patient_appointments_with_cancelled.json
@@ -1,0 +1,40 @@
+{
+  "individual_appointments": [
+    {
+      "id": "6001",
+      "starts_at": "2026-04-25T10:00:00Z",
+      "ends_at": "2026-04-25T10:30:00Z",
+      "cancelled_at": null,
+      "archived_at": null,
+      "did_not_arrive": false
+    },
+    {
+      "id": "6002",
+      "starts_at": "2026-04-24T11:00:00Z",
+      "ends_at": "2026-04-24T11:30:00Z",
+      "cancelled_at": "2026-04-23T18:00:00Z",
+      "archived_at": null,
+      "did_not_arrive": false
+    },
+    {
+      "id": "6003",
+      "starts_at": "2026-04-23T12:00:00Z",
+      "ends_at": "2026-04-23T12:30:00Z",
+      "cancelled_at": null,
+      "archived_at": "2026-04-23T13:00:00Z",
+      "did_not_arrive": false
+    },
+    {
+      "id": "6004",
+      "starts_at": "2026-04-22T13:00:00Z",
+      "ends_at": "2026-04-22T13:30:00Z",
+      "cancelled_at": null,
+      "archived_at": null,
+      "did_not_arrive": true
+    }
+  ],
+  "total_entries": 4,
+  "links": {
+    "self": "https://api.au1.cliniko.com/v1/individual_appointments?q%5B%5D=patient_id%3A%3D1001"
+  }
+}

--- a/Tests/SpeechToTextTests/Models/AppointmentTests.swift
+++ b/Tests/SpeechToTextTests/Models/AppointmentTests.swift
@@ -1,0 +1,407 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+/// Type-level tests for `Appointment` and its wire-shape DTO
+/// (`ClinikoAppointmentDTO`) — domain mapping, derived `isCancelled`,
+/// nested-ref ID extraction, identity-based equality, and the
+/// most-likely-this-recording heuristic. Service-level decode coverage
+/// (HTTP stubs, full envelope, status filtering) lives in
+/// `ClinikoAppointmentServiceTests`.
+@Suite("Appointment", .tags(.fast))
+struct AppointmentTests {
+
+    // MARK: - Identity-based equality
+
+    @Test("equality is identity-based (same id, different cancel state → equal)")
+    func equality_identityBased() {
+        let active = Appointment(
+            id: "5001",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endsAt: Date(timeIntervalSince1970: 1_700_001_800),
+            isCancelled: false
+        )
+        let cancelled = Appointment(
+            id: "5001",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endsAt: Date(timeIntervalSince1970: 1_700_001_800),
+            isCancelled: true
+        )
+        #expect(active == cancelled)
+
+        var bag: Set<Appointment> = []
+        bag.insert(active)
+        bag.insert(cancelled)
+        #expect(bag.count == 1, "Set<Appointment> dedupes on id")
+    }
+
+    @Test("different ids are not equal")
+    func equality_differentIDs_notEqual() {
+        let lhs = Appointment(id: "5001", startsAt: Date(timeIntervalSince1970: 0))
+        let rhs = Appointment(id: "5002", startsAt: Date(timeIntervalSince1970: 0))
+        #expect(lhs != rhs)
+        #expect(lhs.hashValue != rhs.hashValue)
+    }
+
+    // MARK: - DTO → domain mapping
+
+    @Test("DTO maps starts_at, ends_at, and the nested ref IDs into the domain model")
+    func dto_toDomainModel_basics() throws {
+        let dto = ClinikoAppointmentDTO(
+            id: "5001",
+            startsAt: "2026-04-25T09:00:00Z",
+            endsAt: "2026-04-25T09:30:00Z",
+            cancelledAt: nil,
+            archivedAt: nil,
+            didNotArrive: false,
+            patient: linkRef("https://api.au1.cliniko.com/v1/patients/1001"),
+            appointmentType: linkRef("https://api.au1.cliniko.com/v1/appointment_types/4321"),
+            practitioner: linkRef("https://api.au1.cliniko.com/v1/practitioners/9001")
+        )
+
+        let domain = try dto.toDomainModel(parser: ClinikoDateParser())
+
+        #expect(domain.id == "5001")
+        #expect(domain.startsAt == ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z"))
+        #expect(domain.endsAt == ISO8601DateFormatter().date(from: "2026-04-25T09:30:00Z"))
+        #expect(domain.isCancelled == false)
+        #expect(domain.appointmentTypeID == "4321")
+        #expect(domain.practitionerID == "9001")
+    }
+
+    @Test("DTO derives isCancelled from any of cancelled_at, archived_at, did_not_arrive")
+    func dto_derivesIsCancelled() throws {
+        let parser = ClinikoDateParser()
+        let cancelled = ClinikoAppointmentDTO(
+            id: "1", startsAt: "2026-04-25T09:00:00Z", endsAt: nil,
+            cancelledAt: "2026-04-24T12:00:00Z", archivedAt: nil, didNotArrive: false,
+            patient: nil, appointmentType: nil, practitioner: nil
+        )
+        let archived = ClinikoAppointmentDTO(
+            id: "2", startsAt: "2026-04-25T09:00:00Z", endsAt: nil,
+            cancelledAt: nil, archivedAt: "2026-04-24T12:00:00Z", didNotArrive: false,
+            patient: nil, appointmentType: nil, practitioner: nil
+        )
+        let dna = ClinikoAppointmentDTO(
+            id: "3", startsAt: "2026-04-25T09:00:00Z", endsAt: nil,
+            cancelledAt: nil, archivedAt: nil, didNotArrive: true,
+            patient: nil, appointmentType: nil, practitioner: nil
+        )
+        let active = ClinikoAppointmentDTO(
+            id: "4", startsAt: "2026-04-25T09:00:00Z", endsAt: nil,
+            cancelledAt: nil, archivedAt: nil, didNotArrive: false,
+            patient: nil, appointmentType: nil, practitioner: nil
+        )
+        let nilDNA = ClinikoAppointmentDTO(
+            id: "5", startsAt: "2026-04-25T09:00:00Z", endsAt: nil,
+            cancelledAt: nil, archivedAt: nil, didNotArrive: nil,
+            patient: nil, appointmentType: nil, practitioner: nil
+        )
+
+        #expect(try cancelled.toDomainModel(parser: parser).isCancelled)
+        #expect(try archived.toDomainModel(parser: parser).isCancelled)
+        #expect(try dna.toDomainModel(parser: parser).isCancelled)
+        #expect(try !active.toDomainModel(parser: parser).isCancelled)
+        #expect(try !nilDNA.toDomainModel(parser: parser).isCancelled)
+    }
+
+    @Test("DTO endsAt parse failure degrades to nil rather than throwing")
+    func dto_endsAt_failureDegradesToNil() throws {
+        let dto = ClinikoAppointmentDTO(
+            id: "5001",
+            startsAt: "2026-04-25T09:00:00Z",
+            endsAt: "this is not a date",
+            cancelledAt: nil, archivedAt: nil, didNotArrive: false,
+            patient: nil, appointmentType: nil, practitioner: nil
+        )
+
+        let domain = try dto.toDomainModel(parser: ClinikoDateParser())
+
+        // startsAt must parse; endsAt failure degrades because Cliniko
+        // has been observed emitting incomplete end times on edge
+        // appointment-type configurations and the picker can render
+        // without one.
+        #expect(domain.endsAt == nil)
+    }
+
+    @Test("DTO startsAt parse failure throws ClinikoError.decoding")
+    func dto_startsAt_failureThrows() {
+        let dto = ClinikoAppointmentDTO(
+            id: "5001",
+            startsAt: "this is not a date",
+            endsAt: nil,
+            cancelledAt: nil, archivedAt: nil, didNotArrive: false,
+            patient: nil, appointmentType: nil, practitioner: nil
+        )
+
+        do {
+            _ = try dto.toDomainModel(parser: ClinikoDateParser())
+            Issue.record("expected ClinikoError.decoding to throw")
+        } catch ClinikoError.decoding(let typeName) {
+            #expect(typeName == "Date")
+        } catch {
+            Issue.record("expected ClinikoError.decoding, got \(error)")
+        }
+    }
+
+    @Test("LinkRef.trailingID extracts the last URL segment from links.self")
+    func linkRef_trailingID() {
+        let withID = ClinikoAppointmentDTO.LinkRef(
+            links: .init(self: "https://api.au1.cliniko.com/v1/practitioners/9001")
+        )
+        let empty = ClinikoAppointmentDTO.LinkRef(links: .init(self: nil))
+        let blank = ClinikoAppointmentDTO.LinkRef(links: .init(self: ""))
+        let noLinks = ClinikoAppointmentDTO.LinkRef(links: nil)
+
+        #expect(withID.trailingID == "9001")
+        #expect(empty.trailingID == nil)
+        #expect(blank.trailingID == nil)
+        #expect(noLinks.trailingID == nil)
+    }
+
+    @Test("LinkRef.trailingID strips trailing slash, query string, and fragment")
+    func linkRef_trailingID_handlesEdgeShapes() {
+        // Trailing slash — `URL.pathComponents` filters empty
+        // components so the real last segment is returned.
+        let withTrailingSlash = ClinikoAppointmentDTO.LinkRef(
+            links: .init(self: "https://api.au1.cliniko.com/v1/practitioners/9001/")
+        )
+        // Query string — `URL.pathComponents` only walks the path, so
+        // the query never lands in the result.
+        let withQuery = ClinikoAppointmentDTO.LinkRef(
+            links: .init(self: "https://api.au1.cliniko.com/v1/practitioners/9001?include=archived")
+        )
+        // Fragment — same path-only walk.
+        let withFragment = ClinikoAppointmentDTO.LinkRef(
+            links: .init(self: "https://api.au1.cliniko.com/v1/practitioners/9001#anchor")
+        )
+
+        #expect(withTrailingSlash.trailingID == "9001")
+        #expect(withQuery.trailingID == "9001")
+        #expect(withFragment.trailingID == "9001")
+    }
+
+    // MARK: - Most-likely-this-recording helper
+
+    @Test("mostLikelyMatch returns nil for empty input")
+    func mostLikely_empty() {
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(Appointment.mostLikelyMatch(in: [], for: recordingStart) == nil)
+    }
+
+    @Test("mostLikelyMatch returns the slot containing recordingStart even when another is closer to its startsAt")
+    func mostLikely_slotContainingWinsOutright() {
+        // The doctor presses record DURING the 09:00–09:30 slot. Even
+        // though the 11:00 slot is closer to recordingStart by absolute
+        // distance from its startsAt (e.g. 11:00 - 09:15 = 1h45m vs
+        // 09:00 - 09:15 = -15m), the slot-containing rule wins.
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_000 + 900)  // 09:15
+        let slot1 = Appointment(
+            id: "1",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000),               // 09:00
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 + 1800)           // 09:30
+        )
+        let slot2 = Appointment(
+            id: "2",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000 + 7200),        // 11:00
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 + 9000)           // 11:30
+        )
+        let result = Appointment.mostLikelyMatch(
+            in: [slot2, slot1],  // input order shouldn't matter
+            for: recordingStart
+        )
+        #expect(result?.id == "1")
+    }
+
+    @Test("mostLikelyMatch falls back to nearest startsAt when no slot contains recordingStart")
+    func mostLikely_nearestStartsAt() {
+        // Doctor pressed record at 10:30. Candidate slots: 09:00–09:30
+        // and 11:00–11:30. Nearest by startsAt is 11:00 (distance 30
+        // minutes vs 90 minutes for 09:00).
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_000 + 5400)  // 10:30
+        let earlier = Appointment(
+            id: "early",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000),
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 + 1800)
+        )
+        let later = Appointment(
+            id: "later",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000 + 7200),
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 + 9000)
+        )
+
+        let result = Appointment.mostLikelyMatch(in: [earlier, later], for: recordingStart)
+        #expect(result?.id == "later")
+    }
+
+    @Test("mostLikelyMatch returns nil when nearest is beyond the maxDistance threshold")
+    func mostLikely_beyondMaxDistance_returnsNil() {
+        // Doctor recorded today; the nearest appointment is 3 days away.
+        // Pre-selecting it would be wrong more often than right —
+        // the helper bails to nil so the picker leaves the choice to
+        // the user. Default threshold is 24h.
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let threeDaysAway = Appointment(
+            id: "far",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000 + 3 * 24 * 60 * 60),
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 + 3 * 24 * 60 * 60 + 1800)
+        )
+        let result = Appointment.mostLikelyMatch(in: [threeDaysAway], for: recordingStart)
+        #expect(result == nil)
+    }
+
+    @Test("mostLikelyMatch threshold can be overridden")
+    func mostLikely_thresholdOverride() {
+        // Same fixture as above — 3 days away — but override the
+        // threshold to 1 week. The match becomes valid again.
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let threeDaysAway = Appointment(
+            id: "far",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000 + 3 * 24 * 60 * 60),
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 + 3 * 24 * 60 * 60 + 1800)
+        )
+        let result = Appointment.mostLikelyMatch(
+            in: [threeDaysAway],
+            for: recordingStart,
+            maxDistance: 7 * 24 * 60 * 60
+        )
+        #expect(result?.id == "far")
+    }
+
+    @Test("mostLikelyMatch tie-breaker prefers the past-leaning slot")
+    func mostLikely_tiebreaker_prefersPastSlot() {
+        // Two appointments equidistant from the recording start, one
+        // 30 minutes before, one 30 minutes after. The doctor more
+        // commonly records during/after a slot, so the past slot
+        // wins the tie-break — making the helper independent of the
+        // caller's input ordering.
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let past = Appointment(
+            id: "past",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000 - 1800),
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 - 600)
+        )
+        let future = Appointment(
+            id: "future",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000 + 1800),
+            endsAt: Date(timeIntervalSince1970: 1_700_000_000 + 3600)
+        )
+        // Try both input orderings; result must be stable.
+        #expect(Appointment.mostLikelyMatch(in: [past, future], for: recordingStart)?.id == "past")
+        #expect(Appointment.mostLikelyMatch(in: [future, past], for: recordingStart)?.id == "past")
+    }
+
+    @Test("mostLikelyMatch tolerates appointments without endsAt")
+    func mostLikely_nilEndsAt_doesNotCrash() {
+        // An appointment without endsAt cannot be a slot-containing
+        // match (contiguity requires both bounds), so it falls
+        // through to the nearest-startsAt comparator.
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_000)
+        let openEnded = Appointment(
+            id: "open",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000 + 3600),  // 1h after
+            endsAt: nil
+        )
+        let result = Appointment.mostLikelyMatch(in: [openEnded], for: recordingStart)
+        #expect(result?.id == "open")
+    }
+
+    // MARK: - Helpers
+
+    private func linkRef(_ urlString: String) -> ClinikoAppointmentDTO.LinkRef {
+        ClinikoAppointmentDTO.LinkRef(
+            links: ClinikoAppointmentDTO.LinkRef.Links(self: urlString)
+        )
+    }
+}
+
+/// Standalone tests for `ClinikoDateParser` — pin every offset / fractional
+/// shape Cliniko has been observed to emit. The parser is the load-bearing
+/// piece of #129's date-handling story; if any of these regressed,
+/// populated-response decode would silently fail again.
+@Suite("ClinikoDateParser", .tags(.fast))
+struct ClinikoDateParserTests {
+
+    @Test("parses Z-form (UTC, no fractional seconds)")
+    func parses_Z_plain() throws {
+        let date = try ClinikoDateParser().parse("2026-04-25T09:00:00Z")
+        #expect(date == ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z"))
+    }
+
+    @Test("parses Z-form with fractional seconds")
+    func parses_Z_fractional() throws {
+        let date = try ClinikoDateParser().parse("2026-04-25T09:00:00.123Z")
+        let baseline = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")
+            .map { $0.timeIntervalSinceReferenceDate + 0.123 }
+        // `Date(timeIntervalSinceReferenceDate:) + addingTimeInterval`
+        // and direct ISO8601 parsing return values that may differ by
+        // sub-microsecond floating-point representation drift; use a
+        // tolerance check rather than exact equality.
+        let diff = (try #require(baseline)) - date.timeIntervalSinceReferenceDate
+        #expect(abs(diff) < 0.001)
+    }
+
+    @Test("parses +10:00 form (RFC3339 with colon)")
+    func parses_colonOffset_plain() throws {
+        let date = try ClinikoDateParser().parse("2026-04-25T19:00:00+10:00")
+        // 19:00 AEST (UTC+10) == 09:00 UTC.
+        #expect(date == ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z"))
+    }
+
+    @Test("parses +10:00 form with fractional seconds")
+    func parses_colonOffset_fractional() throws {
+        let date = try ClinikoDateParser().parse("2026-04-25T19:00:00.123+10:00")
+        let baseline = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")
+            .map { $0.timeIntervalSinceReferenceDate + 0.123 }
+        let diff = (try #require(baseline)) - date.timeIntervalSinceReferenceDate
+        #expect(abs(diff) < 0.001)
+    }
+
+    @Test("parses +1000 form (ISO8601 basic offset, NO colon)")
+    func parses_basicOffset_plain() throws {
+        // `ISO8601DateFormatter` rejects this regardless of options; the
+        // parser falls back to a `DateFormatter` with `ZZZZ` to handle
+        // it. This is the case the previous global `.iso8601` decoder
+        // strategy could not have parsed.
+        let date = try ClinikoDateParser().parse("2026-04-25T19:00:00+1000")
+        #expect(date == ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z"))
+    }
+
+    @Test("parses +1000 form with fractional seconds")
+    func parses_basicOffset_fractional() throws {
+        let date = try ClinikoDateParser().parse("2026-04-25T19:00:00.123+1000")
+        let baseline = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")
+            .map { $0.timeIntervalSinceReferenceDate + 0.123 }
+        let diff = (try #require(baseline)) - date.timeIntervalSinceReferenceDate
+        #expect(abs(diff) < 0.001)
+    }
+
+    @Test("throws ClinikoError.decoding on a malformed input")
+    func throws_onMalformed() {
+        do {
+            _ = try ClinikoDateParser().parse("definitely not a date")
+            Issue.record("expected throw")
+        } catch ClinikoError.decoding(let typeName) {
+            #expect(typeName == "Date")
+        } catch {
+            Issue.record("expected ClinikoError.decoding, got \(error)")
+        }
+    }
+
+    @Test("error description never echoes the input string (PHI guard)")
+    func errorDescription_doesNotEchoInput() {
+        // The input here would be PHI-adjacent in a real call (an
+        // appointment's start time + a known patient context). The
+        // parser must throw a typed error whose `localizedDescription`
+        // names the type only — never the value.
+        let leakyInput = "2026-04-25T19:00:00.SHOULD-NOT-LEAK"
+        do {
+            _ = try ClinikoDateParser().parse(leakyInput)
+            Issue.record("expected throw")
+        } catch let error {
+            let surface = error.localizedDescription
+            #expect(!surface.contains("SHOULD-NOT-LEAK"),
+                    "PHI sentinel leaked through error: \(surface)")
+        }
+    }
+}

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAppointmentServiceTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAppointmentServiceTests.swift
@@ -165,18 +165,28 @@ final class ClinikoAppointmentServiceTests: XCTestCase {
         // 4 rows, all decode. Each represents the same instant
         // (2026-04-25 09:00:00 UTC, AEST = UTC+10) modulo fractional
         // seconds.
-        XCTAssertEqual(appointments.count, 4)
-        let utcInstant = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")
-        let utcFractional = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")?
-            .addingTimeInterval(0.123)
         // 7001: +10:00 form (with colon) at 19:00 AEST = 09:00 UTC.
         // 7002: +1000 form (no colon) at 19:00 AEST = 09:00 UTC.
         // 7003: Z form with fractional seconds 09:00:00.123Z.
         // 7004: +10:00 form with fractional seconds 19:00:00.123+10:00.
+        XCTAssertEqual(appointments.count, 4)
+        let utcInstant = try XCTUnwrap(
+            ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")
+        )
+        let utcFractionalReference = utcInstant.timeIntervalSinceReferenceDate + 0.123
+
         XCTAssertEqual(appointments.first { $0.id == "7001" }?.startsAt, utcInstant)
         XCTAssertEqual(appointments.first { $0.id == "7002" }?.startsAt, utcInstant)
-        XCTAssertEqual(appointments.first { $0.id == "7003" }?.startsAt, utcFractional)
-        XCTAssertEqual(appointments.first { $0.id == "7004" }?.startsAt, utcFractional)
+        // Fractional-second equality compares with a tolerance because
+        // `addingTimeInterval(0.123)` and direct ISO8601 fractional
+        // parse return values that differ by sub-microsecond
+        // floating-point representation drift. The tolerance is
+        // 1ms — well below the sub-second precision we care about
+        // semantically (it's a clinical note, not a financial trade).
+        let fractional7003 = try XCTUnwrap(appointments.first { $0.id == "7003" }?.startsAt)
+        let fractional7004 = try XCTUnwrap(appointments.first { $0.id == "7004" }?.startsAt)
+        XCTAssertEqual(fractional7003.timeIntervalSinceReferenceDate, utcFractionalReference, accuracy: 0.001)
+        XCTAssertEqual(fractional7004.timeIntervalSinceReferenceDate, utcFractionalReference, accuracy: 0.001)
     }
 
     // MARK: - Window definition + URL filters
@@ -252,9 +262,32 @@ final class ClinikoAppointmentServiceTests: XCTestCase {
                        "/v1/individual_appointments")
         // URL absoluteString is percent-encoded; the literal id must
         // appear as the value half of a single q[]=patient_id:=... item.
+        // Per RFC 3986, `/` is permitted unencoded in query values
+        // (only `?` and `#` terminate the query component), so
+        // URLComponents leaves it as-is on every macOS version. The
+        // safety property is that `=` and `&` ARE encoded, which is
+        // what stops a tampered id from smuggling a sibling filter.
         let absolute = url.absoluteString
-        XCTAssertTrue(absolute.contains("q%5B%5D=patient_id:%3Dweird%20id%2Fwith%2Fslashes"),
-                      "expected encoded id in q[]=patient_id value, got: \(absolute)")
+        XCTAssertTrue(absolute.contains("q%5B%5D=patient_id:%3Dweird%20id/with/slashes"),
+                      "expected encoded id (space → %20, `/` left as-is per RFC 3986) in q[]=patient_id value, got: \(absolute)")
+        // Critical: `=` and `&` from the input must be encoded so a
+        // tampered id can't introduce a sibling query parameter.
+        let captured2 = CapturedRequestBox()
+        let service2 = try makeService { request in
+            captured2.set(request)
+            let body = try HTTPStubFixture.load("cliniko/responses/patient_appointments.json")
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil
+            )!
+            return (response, body)
+        }
+        _ = try await service2.recentAndTodayAppointments(
+            forPatientID: "id&extra=evil", reference: Date()
+        )
+        let evilURL = try XCTUnwrap(captured2.value?.url)
+        XCTAssertTrue(evilURL.absoluteString.contains("id%26extra%3Devil"),
+                      "expected `&` and `=` percent-encoded so a tampered id can't smuggle a sibling filter, got: \(evilURL.absoluteString)")
     }
 
     // MARK: - Error mapping

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAppointmentServiceTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAppointmentServiceTests.swift
@@ -56,14 +56,130 @@ final class ClinikoAppointmentServiceTests: XCTestCase {
             reference: reference
         )
 
+        // Fixture has 3 rows. None are cancelled / archived / DNA — all
+        // should reach the picker. Service applies a defensive descending
+        // sort by startsAt on top of Cliniko's server-side sort, so the
+        // 2026-04-25 slot lands at index 0.
         XCTAssertEqual(appointments.count, 3)
-        XCTAssertEqual(appointments.first?.id, 5001)
+        XCTAssertEqual(appointments[0].id, "5001")
+        XCTAssertEqual(appointments[1].id, "5002")
+        XCTAssertEqual(appointments[2].id, "5003")
         let firstStart = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")
         XCTAssertEqual(appointments.first?.startsAt, firstStart)
         XCTAssertNotNil(appointments.first?.endsAt)
+        // Nested ref extraction (DTO LinkRef.trailingID) — pin that the
+        // appointment-type / practitioner IDs flow through from the
+        // wire's `links.self` URL on the rows that carry them.
+        XCTAssertEqual(appointments[0].appointmentTypeID, "4321")
+        XCTAssertEqual(appointments[0].practitionerID, "9001")
+        // Row 5003 omits the nested objects entirely → both nil.
+        XCTAssertNil(appointments[2].appointmentTypeID)
+        XCTAssertNil(appointments[2].practitionerID)
+        // No cancelled / archived / DNA in this fixture.
+        XCTAssertFalse(appointments.contains { $0.isCancelled })
     }
 
-    // MARK: - Window definition
+    /// Regression pin for #129. Cliniko's `q[]=cancelled_at:!?`
+    /// server-side filter is what *should* drop cancelled rows, but the
+    /// service layer re-applies the wider `!isCancelled` filter
+    /// (`cancelled_at` OR `archived_at` OR `did_not_arrive == true`) so
+    /// a Cliniko regression in either filter or sort semantics doesn't
+    /// cascade into the picker.
+    func test_appointments_filtersCancelledArchivedAndDidNotArriveRows() async throws {
+        let service = try makeService { request in
+            let body = try HTTPStubFixture.load(
+                "cliniko/responses/patient_appointments_with_cancelled.json"
+            )
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+
+        let appointments = try await service.recentAndTodayAppointments(
+            forPatientID: "1001",
+            reference: Date()
+        )
+
+        // Fixture has 4 rows: 6001 active, 6002 cancelled, 6003 archived,
+        // 6004 did-not-arrive. Only 6001 should reach the picker.
+        XCTAssertEqual(appointments.count, 1)
+        XCTAssertEqual(appointments.first?.id, "6001")
+        XCTAssertFalse(appointments.first?.isCancelled ?? true)
+    }
+
+    /// Regression pin for #129. Defensive client-side sort (descending
+    /// by `startsAt`) is applied on top of Cliniko's server-side
+    /// `sort=starts_at&order=desc`. A future Cliniko sort regression
+    /// must not surface as out-of-order appointments in the picker.
+    func test_appointments_resultsAreSortedDescendingByStartsAt() async throws {
+        let service = try makeService { request in
+            let body = try HTTPStubFixture.load("cliniko/responses/patient_appointments.json")
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            return (response, body)
+        }
+
+        let appointments = try await service.recentAndTodayAppointments(
+            forPatientID: "1001",
+            reference: Date()
+        )
+
+        let starts = appointments.map(\.startsAt)
+        XCTAssertEqual(starts, starts.sorted(by: >))
+    }
+
+    /// Regression pin for #129. Cliniko AU shards return ISO8601 in
+    /// three distinct shapes: `+10:00` (RFC3339 with colon), `+1000`
+    /// (ISO8601 basic offset, NO colon — `ISO8601DateFormatter`
+    /// rejects this regardless of options), and either with optional
+    /// fractional seconds. `ClinikoDateParser` cascades through four
+    /// formatters to handle all of them; the previous global
+    /// `.iso8601` decoder strategy did not.
+    func test_appointments_decodesAUShardOffsetVariants() async throws {
+        let service = try makeService { request in
+            let body = try HTTPStubFixture.load(
+                "cliniko/responses/patient_appointments_au_with_offset.json"
+            )
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            )!
+            return (response, body)
+        }
+
+        let appointments = try await service.recentAndTodayAppointments(
+            forPatientID: "1001",
+            reference: Date()
+        )
+
+        // 4 rows, all decode. Each represents the same instant
+        // (2026-04-25 09:00:00 UTC, AEST = UTC+10) modulo fractional
+        // seconds.
+        XCTAssertEqual(appointments.count, 4)
+        let utcInstant = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")
+        let utcFractional = ISO8601DateFormatter().date(from: "2026-04-25T09:00:00Z")?
+            .addingTimeInterval(0.123)
+        // 7001: +10:00 form (with colon) at 19:00 AEST = 09:00 UTC.
+        // 7002: +1000 form (no colon) at 19:00 AEST = 09:00 UTC.
+        // 7003: Z form with fractional seconds 09:00:00.123Z.
+        // 7004: +10:00 form with fractional seconds 19:00:00.123+10:00.
+        XCTAssertEqual(appointments.first { $0.id == "7001" }?.startsAt, utcInstant)
+        XCTAssertEqual(appointments.first { $0.id == "7002" }?.startsAt, utcInstant)
+        XCTAssertEqual(appointments.first { $0.id == "7003" }?.startsAt, utcFractional)
+        XCTAssertEqual(appointments.first { $0.id == "7004" }?.startsAt, utcFractional)
+    }
+
+    // MARK: - Window definition + URL filters
 
     func test_appointments_emitsCorrectFromAndToWindowEdges() async throws {
         let captured = CapturedRequestBox()
@@ -91,14 +207,24 @@ final class ClinikoAppointmentServiceTests: XCTestCase {
 
         let url = try XCTUnwrap(captured.value?.url)
         let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-        let queryItems = components.queryItems ?? []
-        let from = queryItems.first { $0.name == "from" }?.value
-        let to = queryItems.first { $0.name == "to" }?.value
-        XCTAssertEqual(from, "2026-04-18T12:00:00Z")
-        XCTAssertEqual(to, "2026-04-26T12:00:00Z")
+        let qValues = (components.queryItems ?? [])
+            .filter { $0.name == "q[]" }
+            .compactMap(\.value)
+        // Window is [reference - 7d, reference + 1d). The service
+        // emits `q[]=starts_at:>=...` and `q[]=starts_at:<=...` rather
+        // than the bare `from=` / `to=` of the pre-#129 endpoint.
+        XCTAssertTrue(qValues.contains("starts_at:>=2026-04-18T12:00:00Z"),
+                      "expected >= window edge in q[] values, got \(qValues)")
+        XCTAssertTrue(qValues.contains("starts_at:<=2026-04-26T12:00:00Z"),
+                      "expected <= window edge in q[] values, got \(qValues)")
     }
 
-    func test_appointments_pathPercentEncodesPatientID() async throws {
+    /// Patient id moved into a q[] query value in #129; this test
+    /// previously asserted on percent-encoded path segments. Now it
+    /// verifies the encoding lands inside the q[]=patient_id:=...
+    /// value-half so a tampered id can't introduce a sibling query
+    /// parameter or otherwise smuggle filter syntax.
+    func test_appointments_percentEncodesPatientIDInQueryValue() async throws {
         let captured = CapturedRequestBox()
         let service = try makeService { request in
             captured.set(request)
@@ -112,17 +238,23 @@ final class ClinikoAppointmentServiceTests: XCTestCase {
             return (response, body)
         }
 
-        // ID containing characters that would otherwise split the path —
-        // not realistic for Cliniko (numeric IDs) but defence-in-depth.
+        // Adversarial id with characters that would otherwise split
+        // the URL — not realistic for Cliniko (numeric IDs) but
+        // defence-in-depth.
         _ = try await service.recentAndTodayAppointments(
             forPatientID: "weird id/with/slashes",
             reference: Date()
         )
 
         let url = try XCTUnwrap(captured.value?.url)
-        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
-        let template = "/v1/patients/weird%20id%2Fwith%2Fslashes/appointments"
-        XCTAssertEqual(components.percentEncodedPath, template)
+        // Path is the static template; the id is in the query string.
+        XCTAssertEqual(URLComponents(url: url, resolvingAgainstBaseURL: false)?.path,
+                       "/v1/individual_appointments")
+        // URL absoluteString is percent-encoded; the literal id must
+        // appear as the value half of a single q[]=patient_id:=... item.
+        let absolute = url.absoluteString
+        XCTAssertTrue(absolute.contains("q%5B%5D=patient_id:%3Dweird%20id%2Fwith%2Fslashes"),
+                      "expected encoded id in q[]=patient_id value, got: \(absolute)")
     }
 
     // MARK: - Error mapping
@@ -136,6 +268,36 @@ final class ClinikoAppointmentServiceTests: XCTestCase {
             status: 404,
             expected: .notFound(resource: .patient)
         )
+    }
+
+    func test_appointments_malformedJSON_mapsToDecoding() async throws {
+        // 200 with a body that doesn't decode into ClinikoAppointmentListDTO.
+        // Mirrors the patient-side test (`ClinikoPatientServiceTests.test_searchPatients_malformedJSON_mapsToDecoding`).
+        // Synthetic body, no PHI.
+        let body = Data(#"{"unexpected_envelope": true}"#.utf8)
+        let service = try makeService { request in
+            let response = HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, body)
+        }
+        do {
+            _ = try await service.recentAndTodayAppointments(
+                forPatientID: "1001",
+                reference: Date()
+            )
+            XCTFail("expected ClinikoError.decoding")
+        } catch ClinikoError.decoding(let typeName) {
+            XCTAssertTrue(
+                typeName.contains("ClinikoAppointmentListDTO"),
+                "typeName should identify the decoding target; got \(typeName)"
+            )
+        } catch {
+            XCTFail("expected .decoding, got \(error)")
+        }
     }
 
     private func assertAppointmentsError(

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoEndpointTests.swift
@@ -35,7 +35,7 @@ struct ClinikoEndpointTests {
         #expect(endpoint.resource == .patient)
     }
 
-    @Test("patientAppointments is a GET with id-template")
+    @Test("patientAppointments is a GET against /individual_appointments with no bound IDs in the template")
     func patientAppointmentsShape() {
         let endpoint = ClinikoEndpoint.patientAppointments(
             patientID: "12345",
@@ -43,7 +43,12 @@ struct ClinikoEndpointTests {
             to: Date(timeIntervalSince1970: 86_400)
         )
         #expect(endpoint.method == .get)
-        #expect(endpoint.pathTemplate == "/patients/:id/appointments")
+        // Path template flipped in #129. The patient id is no longer in
+        // the path; it lives in `q[]=patient_id:=...`. The template names
+        // the structural q[] keys present (`patient_id`, `starts_at`)
+        // without their values so logging at `privacy: .public` stays
+        // PHI-safe.
+        #expect(endpoint.pathTemplate == "/individual_appointments?q[]={patient_id}&q[]={starts_at}")
         // The bound id MUST NOT be in the template (PHI logging rule).
         #expect(!endpoint.pathTemplate.contains("12345"))
         #expect(endpoint.isIdempotent)
@@ -151,21 +156,34 @@ struct ClinikoEndpointTests {
         }
     }
 
-    @Test("patientAppointments URL embeds id + ISO8601 dates")
+    @Test("patientAppointments URL hits /individual_appointments with the full Cliniko filter set")
     func patientAppointmentsURL() {
         let from = Date(timeIntervalSince1970: 0)
         let to = Date(timeIntervalSince1970: 86_400)
         let url = ClinikoEndpoint.patientAppointments(patientID: "12345", from: from, to: to)
             .buildURL(against: baseURL)
-        let absolute = url?.absoluteString ?? ""
-        #expect(absolute.contains("/v1/patients/12345/appointments"))
-        #expect(absolute.contains("from="))
-        #expect(absolute.contains("to="))
-        // ISO8601 1970-01-01 / 1970-01-02 — exact format may include a "Z".
-        #expect(absolute.contains("1970-01-01T00%3A00%3A00Z") || absolute.contains("1970-01-01T00:00:00Z"))
+        let components = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+        let items = components?.queryItems ?? []
+
+        #expect(components?.path == "/v1/individual_appointments")
+
+        // Pin every q[] / sort / order / per_page query item present (one
+        // assertion per filter so a regression names the missing one). The
+        // server-side q[]=cancelled_at:!? is what keeps cancelled rows
+        // off the picker; archived_at + did_not_arrive are filtered
+        // client-side post-decode (see ClinikoAppointmentService).
+        let qValues = items.filter { $0.name == "q[]" }.compactMap(\.value)
+        #expect(qValues.contains("patient_id:=12345"), "got \(qValues)")
+        #expect(qValues.contains("starts_at:>=1970-01-01T00:00:00Z"), "got \(qValues)")
+        #expect(qValues.contains("starts_at:<=1970-01-02T00:00:00Z"), "got \(qValues)")
+        #expect(qValues.contains("cancelled_at:!?"), "got \(qValues)")
+
+        #expect(items.first { $0.name == "sort" }?.value == "starts_at")
+        #expect(items.first { $0.name == "order" }?.value == "desc")
+        #expect(items.first { $0.name == "per_page" }?.value == "50")
     }
 
-    @Test("patientAppointments percent-encodes weird patient IDs")
+    @Test("patientAppointments percent-encodes weird patient IDs in the q[]=patient_id query value")
     func patientAppointmentsPercentEncodesID() {
         let url = ClinikoEndpoint.patientAppointments(
             patientID: "12 345/abc",
@@ -173,10 +191,30 @@ struct ClinikoEndpointTests {
             to: Date(timeIntervalSince1970: 1)
         ).buildURL(against: baseURL)
         let absolute = url?.absoluteString ?? ""
-        // Space → %20 and slash → %2F, so the id stays a single path
-        // segment between `/patients/` and `/appointments`.
-        #expect(absolute.contains("/v1/patients/12%20345%2Fabc/appointments"),
+
+        // Patient id moved into the q[]=patient_id:=... query value in
+        // #129. URLComponents percent-encodes only the characters that
+        // would actually break the URL — `=` → `%3D`, `&` → `%26`, ` `
+        // → `%20`, `?` → `%3F`. Per RFC 3986, `/` is permitted unencoded
+        // in query values (only `?` and `#` terminate the query
+        // component), so URLComponents leaves it as-is. The safety
+        // property we care about is that no character can introduce a
+        // sibling query parameter or smuggle filter syntax — `=` and
+        // `&` are both encoded, which is what protects us.
+        #expect(absolute.contains("q%5B%5D=patient_id:%3D12%20345/abc"),
                 "got \(absolute)")
+        // The path stays the static template — the id can't sneak back
+        // into a `/patients/<id>/` segment.
+        #expect(!absolute.contains("/v1/patients/"), "patient id leaked into path")
+        // Critical: `=` and `&` from the input ARE encoded.
+        let withSibling = ClinikoEndpoint.patientAppointments(
+            patientID: "id&extra=evil",
+            from: Date(timeIntervalSince1970: 0),
+            to: Date(timeIntervalSince1970: 1)
+        ).buildURL(against: baseURL)
+        let evilAbsolute = withSibling?.absoluteString ?? ""
+        #expect(evilAbsolute.contains("id%26extra%3Devil"),
+                "expected `&` and `=` to be percent-encoded so a tampered id can't smuggle a sibling filter, got: \(evilAbsolute)")
     }
 
     @Test("createTreatmentNote URL is /v1/treatment_notes")

--- a/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
+++ b/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
@@ -206,6 +206,38 @@ struct ExportFlowViewModelTests {
         #expect(onSuccessCalled, "onSuccess hook fires on success")
     }
 
+    /// Regression pin for #129's `appointmentIDMalformed` guard. After
+    /// `Appointment.id` flipped to `String` (Cliniko's documented
+    /// `string($int64)` shape), a non-numeric `OpaqueClinikoID.rawValue`
+    /// could silently degrade the export to a general note (losing
+    /// the appointment linkage with no user-visible signal). Same
+    /// class of bug #127's `patientIDMalformed` guard closed off for
+    /// the patient boundary.
+    @Test("confirm with malformed appointment id fails with appointmentIDMalformed")
+    func confirm_malformedAppointmentID_fails() {
+        let store = SessionStore()
+        store.start(from: RecordingSession(language: "en", state: .completed))
+        store.setSelectedPatient(id: OpaqueClinikoID(1001), displayName: "Sample")
+        store.setDraftNotes(StructuredNotes(subjective: "s"))
+        // Appointment id with a non-numeric rawValue. Production never
+        // produces this (Cliniko emits numeric strings) but Codable
+        // round-trip from a tampered audit ledger or a future Cliniko
+        // shape change would. The `.appointment(...)` shape (vs
+        // `.unset` / `.general`) is what triggers the guard.
+        store.setSelectedAppointment(id: OpaqueClinikoID(rawValue: "not-numeric"))
+        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
+        let viewModel = makeViewModel(store: store, exporter: exporter)
+        viewModel.enterConfirming()
+
+        viewModel.confirm()
+
+        if case .failed(.sessionState(.appointmentIDMalformed)) = viewModel.state {
+            // expected
+        } else {
+            Issue.record("expected .failed(.sessionState(.appointmentIDMalformed)), got \(viewModel.state)")
+        }
+    }
+
     @Test("confirm with .unset appointment fails with appointmentUnresolved")
     func confirm_unsetAppointment_fails() {
         let store = SessionStore()

--- a/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
+++ b/Tests/SpeechToTextTests/Views/PatientPickerViewModelTests.swift
@@ -228,9 +228,14 @@ struct PatientPickerViewModelTests {
             debounceMillis: 0
         )
 
-        vm.selectAppointment(id: 5678)
-        #expect(store.active?.selectedAppointmentID == OpaqueClinikoID(5678))
-        #expect(vm.selectedAppointmentID == 5678)
+        vm.selectAppointment(id: "5678")
+        // `OpaqueClinikoID(5678)` (Int init, stringifies internally) and
+        // `OpaqueClinikoID("5678")` (String init) both produce
+        // `rawValue: "5678"`, so the equality holds across the #129
+        // boundary flip. The `String` literal documents the new
+        // wire-shape input.
+        #expect(store.active?.selectedAppointmentID == OpaqueClinikoID("5678"))
+        #expect(vm.selectedAppointmentID == "5678")
 
         vm.selectAppointment(id: nil)
         #expect(store.active?.selectedAppointmentID == nil)
@@ -245,7 +250,7 @@ struct PatientPickerViewModelTests {
         store.start(from: RecordingSession.empty())
 
         let appointment = Appointment(
-            id: 9000,
+            id: "9000",
             startsAt: Date(timeIntervalSince1970: 1_700_000_000),
             endsAt: Date(timeIntervalSince1970: 1_700_001_800)
         )
@@ -266,6 +271,106 @@ struct PatientPickerViewModelTests {
         } else {
             Issue.record("expected .loaded, got \(vm.appointmentPhase)")
         }
+    }
+
+    /// Regression pin for #129. After `.loaded` lands, the picker
+    /// pre-selects the appointment most likely to be the one the
+    /// recording is for: a slot containing the recording's start time
+    /// wins outright; otherwise the appointment whose `startsAt` is
+    /// nearest. Skips pre-selection if the user already picked
+    /// manually during the load.
+    @Test("after .loaded, the picker pre-selects the appointment most likely to be this recording's")
+    func appointmentPhase_preSelectsMostLikelyMatch() async throws {
+        let recordingStart = Date(timeIntervalSince1970: 1_700_000_900)  // 09:15
+        let store = SessionStore()
+        // RecordingSession's startTime is what the heuristic anchors
+        // on. Construct one explicitly so the test isn't subject to
+        // wall-clock drift.
+        store.start(from: RecordingSession(startTime: recordingStart))
+
+        let earlier = Appointment(
+            id: "earlier",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000),     // 09:00
+            endsAt: Date(timeIntervalSince1970: 1_700_001_800)        // 09:30 — contains 09:15
+        )
+        let later = Appointment(
+            id: "later",
+            startsAt: Date(timeIntervalSince1970: 1_700_007_200),     // 11:00
+            endsAt: Date(timeIntervalSince1970: 1_700_009_000)        // 11:30
+        )
+        let patients = FakePatientSearcher(result: .success([]))
+        let appointments = FakeAppointmentLoader(result: .success([later, earlier]))
+        let vm = PatientPickerViewModel(
+            patientService: patients,
+            appointmentService: appointments,
+            sessionStore: store,
+            debounceMillis: 0
+        )
+
+        vm.selectPatient(Patient(id: "1", firstName: "S", lastName: "P"))
+        await vm.currentAppointmentTaskForTests?.value
+
+        // Slot containing recordingStart wins — the doctor pressed
+        // record DURING the 09:00–09:30 slot, so that's the one the
+        // note attaches to.
+        #expect(vm.selectedAppointmentID == "earlier")
+        #expect(store.active?.selectedAppointmentID == OpaqueClinikoID("earlier"))
+    }
+
+    /// Mirror pin: with no slot containing `recordingStart`, the
+    /// nearest-startsAt appointment wins.
+    @Test("after .loaded, fallback to nearest-startsAt when no slot contains recordingStart")
+    func appointmentPhase_preSelects_nearestStartsAt() async throws {
+        let recordingStart = Date(timeIntervalSince1970: 1_700_005_400)  // 10:30
+        let store = SessionStore()
+        store.start(from: RecordingSession(startTime: recordingStart))
+
+        let earlier = Appointment(
+            id: "earlier",
+            startsAt: Date(timeIntervalSince1970: 1_700_000_000),     // 09:00
+            endsAt: Date(timeIntervalSince1970: 1_700_001_800)        // 09:30
+        )
+        let later = Appointment(
+            id: "later",
+            startsAt: Date(timeIntervalSince1970: 1_700_007_200),     // 11:00 — closer to 10:30
+            endsAt: Date(timeIntervalSince1970: 1_700_009_000)        // 11:30
+        )
+        let patients = FakePatientSearcher(result: .success([]))
+        let appointments = FakeAppointmentLoader(result: .success([earlier, later]))
+        let vm = PatientPickerViewModel(
+            patientService: patients,
+            appointmentService: appointments,
+            sessionStore: store,
+            debounceMillis: 0
+        )
+
+        vm.selectPatient(Patient(id: "1", firstName: "S", lastName: "P"))
+        await vm.currentAppointmentTaskForTests?.value
+
+        #expect(vm.selectedAppointmentID == "later")
+    }
+
+    /// Negative pin: with an empty `.loaded` array, no pre-selection
+    /// happens. The picker stays "no appointment / general note" by
+    /// default.
+    @Test("after .loaded with empty list, no pre-selection happens")
+    func appointmentPhase_emptyList_noPreSelection() async throws {
+        let store = SessionStore()
+        store.start(from: RecordingSession(startTime: Date(timeIntervalSince1970: 1_700_000_000)))
+
+        let patients = FakePatientSearcher(result: .success([]))
+        let appointments = FakeAppointmentLoader(result: .success([]))
+        let vm = PatientPickerViewModel(
+            patientService: patients,
+            appointmentService: appointments,
+            sessionStore: store,
+            debounceMillis: 0
+        )
+
+        vm.selectPatient(Patient(id: "1", firstName: "S", lastName: "P"))
+        await vm.currentAppointmentTaskForTests?.value
+
+        #expect(vm.selectedAppointmentID == nil)
     }
 
     @Test("appointment service error surfaces as .error")
@@ -305,7 +410,7 @@ struct PatientPickerViewModelTests {
         )
 
         vm.selectPatient(Patient(id: "1", firstName: "S", lastName: "P"))
-        vm.selectAppointment(id: 9)
+        vm.selectAppointment(id: "9")
         vm.clearSelection()
 
         #expect(vm.selectedPatient == nil)

--- a/Tests/SpeechToTextTests/Views/PatientPickerViewRenderTests.swift
+++ b/Tests/SpeechToTextTests/Views/PatientPickerViewRenderTests.swift
@@ -144,7 +144,7 @@ final class PatientPickerViewRenderTests: XCTestCase {
 
     func test_picker_appointmentLoadedPhase_rendersWithoutCrash() async throws {
         let appointment = Appointment(
-            id: 9000,
+            id: "9000",
             startsAt: Date(timeIntervalSince1970: 1_700_000_000),
             endsAt: Date(timeIntervalSince1970: 1_700_001_800)
         )


### PR DESCRIPTION
## Summary

Fixes #129. The Cliniko appointment-list payload was failing to decode for any patient with appointments because of **four** independent wire-shape divergences. Same root-cause family as #127 but bigger in scope. The fix mirrors [`CloudbrokerAz/epc-letter-generation`](https://github.com/CloudbrokerAz/epc-letter-generation/blob/main/Sources/Services/Cliniko/ClinikoAppointmentService.swift) verbatim on the wire shape, with #127's identity-based equality and the issue's performance/filtering/UX requirements layered on top.

## What changed (axes of divergence, all corrected)

| # | Axis | Was | Now |
|---|---|---|---|
| 1 | Envelope key | `appointments` | `individual_appointments` (new `ClinikoAppointmentListDTO`) |
| 2 | Endpoint path | `GET /patients/{id}/appointments?from=&to=` | `GET /individual_appointments?q[]=patient_id:=...&q[]=starts_at:>=...&q[]=cancelled_at:!?&sort=starts_at&order=desc&per_page=50` |
| 3 | `id` type | `Int` | `String` (matches Cliniko's documented `string($int64)`) |
| 4 | Date format | `JSONDecoder` `.iso8601` strategy uniformly | DTO holds raw `String`; new `ClinikoDateParser` four-pass cascade — plain ISO, fractional ISO, plain basic-offset, fractional basic-offset |

## Files

**New**: `Sources/Models/ClinikoAppointmentDTO.swift`, `Sources/Services/Cliniko/ClinikoDateParser.swift`, plus three test fixtures (`patient_appointments_with_cancelled.json`, `patient_appointments_au_with_offset.json`, regenerated `patient_appointments.json`) and `Tests/SpeechToTextTests/Models/AppointmentTests.swift`.

**Reshaped**: `Sources/Models/Appointment.swift` (id: String, derived `isCancelled`, optional `appointmentTypeID`/`practitionerID` extracted from nested `links.self`, identity-based equality, static `mostLikelyMatch(in:for:maxDistance:)` helper).

**Endpoint flip**: `Sources/Services/Cliniko/ClinikoEndpoint.swift` (path + query items + path-template + percent-encoding-via-query-value).

**Service**: `Sources/Services/Cliniko/ClinikoAppointmentService.swift` — DTO decode + domain map + defensive `!isCancelled` filter + descending re-sort + truncation log when `total_entries > 50`.

**Picker**: `Sources/Views/ClinicalNotes/PatientPickerViewModel.swift` — `selectedAppointmentID: String?`, pre-selection on `.loaded` via the new helper.

**Symmetry guard**: `Sources/Views/ClinicalNotes/ExportFlowViewModel.swift` gets `appointmentIDMalformed` (mirrors #127's `patientIDMalformed`).

**Doc updates**: `Sources/Services/Cliniko/AGENTS.md` gains a "Cliniko date offsets" pitfall section so the `.iso8601` strategy gotcha is checklist-visible to future devs.

## Performance + filtering + UX (per the issue's ask)

- **Server-side**: `q[]=cancelled_at:!?` drops cancelled rows in Cliniko's planner; `sort=starts_at&order=desc` puts the most-recent slot first; `per_page=50` bounds a single round-trip.
- **Client-side defence**: re-applies `!isCancelled` (which also covers `archived_at` and `did_not_arrive`) and the descending sort, so a Cliniko-side regression in either filter or sort doesn't cascade.
- **Most-likely-this-recording pre-selection**: `Appointment.mostLikelyMatch(in:for:maxDistance:)` is a pure helper. Slot containing `recordingStart` wins outright. Otherwise nearest by `startsAt` within 24h, with a past-leaning tie-breaker (clinically a doctor records during/after a slot, not before). Beyond 24h: bail to nil so a stale recording doesn't auto-pick a wildly-distant appointment. Non-blocking — user can always pick differently.
- **Truncation log**: `notice`-level log when `total_entries > 50` so ops can spot tenants where the cap matters. Counts only — no PHI.
- **No eager fan-out**: unlike upstream's letter-generation flow, we don't fetch practitioner names / attendee IDs per row. The picker doesn't display them today; lazy-fetch later only if the UX needs it.

## Pre-PR review

Three Opus subagents in parallel: `code-reviewer`, `silent-failure-hunter`, `type-design-analyzer`. Substantive findings folded in:
- `LinkRef.trailingID` switched to `URL.pathComponents.last` (handles trailing slash, query string, fragment).
- `mostLikelyMatch` got an explicit tie-breaker + 24h `maxDistance` threshold.
- Truncation log and `endsAt` parse-failure structural log added (no PHI).
- Parser cascade reordered (plain ISO before fractional — happy path).
- `DateFormatter.isLenient = false` defensively pinned.
- AGENTS.md `.iso8601` clarification (don't rely, don't remove).
- `appointmentIDMalformed` guard mirroring #127's `patientIDMalformed`.

Deferred to a separate PR: dedicated `ClinikoError.dateMalformed` case (touches every `ClinikoError` consumer — out of scope here).

## Test plan

- [x] `swift build` clean.
- [x] `swift test --parallel` — **443 tests in 42 suites pass** (was 416 pre-#129; +27 for new appointment / DTO / parser / pre-selection / guard tests).
- [x] `pre-commit run --files <staged>` — SwiftLint strict + gitleaks + format hooks all pass.
- [ ] CI green on this PR (awaiting).
- [ ] Pre-merge: address Gemini Code Assist's review.
- [ ] Post-merge: verify `main` CI run before declaring done.
- [ ] Manual smoke: tap a patient with appointments → picker should show recent + today's slots, most-recent first, with the slot-matching-recording-time pre-selected. Cancelled / archived / DNA rows should never appear.

References: `AGENTS.md`, `.claude/references/cliniko-api.md`, `.claude/references/phi-handling.md`, `Sources/Services/Cliniko/AGENTS.md`. Reference impl: [`epc-letter-generation/.../ClinikoAppointmentService.swift`](https://github.com/CloudbrokerAz/epc-letter-generation/blob/main/Sources/Services/Cliniko/ClinikoAppointmentService.swift).

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)