### PR TITLE
Add URLProtocolStubGate to serialize cross-suite HTTP stubs

### DIFF
--- a/.claude/references/testing-conventions.md
+++ b/.claude/references/testing-conventions.md
@@ -60,12 +60,71 @@ section).
 | Dependency | Test-only replacement | File |
 |---|---|---|
 | HTTP (`URLSession`) | `URLProtocolStub.install(_:)` returning a `URLSessionConfiguration` | `Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift` |
+| HTTP cross-suite serialisation | `URLProtocolStubGate.shared.withGate(_:)` (Swift Testing only) | `Tests/SpeechToTextTests/Utilities/URLProtocolStubGate.swift` |
 | HTTP response fixtures | `HTTPStubFixture.load(_:)` / `loadJSON(_:,_:)` loading from `Tests/SpeechToTextTests/Fixtures/` | `Tests/SpeechToTextTests/Utilities/HTTPStubFixture.swift` |
 | Keychain (`SecureStore`) | `InMemorySecureStore` — actor-isolated `[String: Data]`, never imports `Security` | `Tests/SpeechToTextTests/Utilities/InMemorySecureStore.swift` |
 | LLM (`LLMProvider` — once #3 lands) | `MockLLMProvider` with canned prompt-hash → response lookup | pending #3 |
 
 Real Keychain / real LLM inference are **never** exercised in CI. They
 run locally or pre-push on a real Mac.
+
+---
+
+## URLProtocolStub process-wide gate
+
+`URLProtocolStub` keeps a single global `currentResponder`. Swift
+Testing's `.serialized` trait is **suite-local** — two Swift Testing
+suites that both stub HTTP race across the suite boundary because the
+scheduler still parallelises between suites. The race manifests as one
+suite's `defer { reset() }` clobbering another suite's responder
+mid-flight (PR #84 CI commit `964d877`: a Hugging Face 401 against
+`ModelDownloaderTests.happyPathDownload`).
+
+`URLProtocolStubGate` (issue #85) is the authoritative process-wide
+serialisation point. Adoption rule:
+
+- **Always** wrap a Swift Testing `@Test` body in
+  `try await URLProtocolStubGate.shared.withGate { ... }` if it calls
+  `URLProtocolStub.install(_:)` / `installScoped(_:)`.
+- **Never** rely on `.serialized` alone for HTTP-stubbed Swift Testing
+  suites. Suite-local serialisation does not protect against
+  cross-suite races.
+- XCTest test classes do **not** need to adopt the gate — XCTest
+  scheduling has empirically coexisted with Swift Testing since #20
+  without flakes. Mixing frameworks is fine; mixing Swift Testing
+  suites is not (until both have the gate).
+
+```swift
+@Suite("My HTTP suite", .tags(.fast))
+struct MyHTTPSuite {
+    @Test func happyPath() async throws {
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install { request in
+                // ...build response...
+            }
+            defer { URLProtocolStub.reset() }
+            // ...exercise SUT...
+        }
+    }
+}
+```
+
+The gate is non-reentrant and not cancellation-aware (test-only
+utility). See `URLProtocolStubGate.swift` for the rationale.
+
+Reference adopters:
+
+- `Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift`
+- `Tests/SpeechToTextTests/Services/Cliniko/ClinikoStatusThreadingTests.swift`
+
+**Known gap:**
+`Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift` is
+also a Swift Testing `@Suite` that installs `URLProtocolStub`, but it
+is `@MainActor`-isolated and migrating it requires resolving the
+`@MainActor` × `@Sendable` interaction across 22 test bodies. Tracked
+as a follow-up to #85 — until the migration lands, the suite is
+protected only by its `.serialized` trait and remains a cross-suite
+race candidate against the gated suites above.
 
 ---
 

--- a/Sources/Services/Cliniko/AGENTS.md
+++ b/Sources/Services/Cliniko/AGENTS.md
@@ -157,6 +157,17 @@ route — auto-detection is a possible follow-up.
   hand-rolled, zero-dependency `Sendable` `URLProtocol` subclass.
   Fixtures live under
   `Tests/SpeechToTextTests/Fixtures/cliniko/{requests,responses}/`.
+- **HTTP from a Swift Testing `@Suite`**: also wrap each `@Test` body
+  in `try await URLProtocolStubGate.shared.withGate { ... }`
+  (`Tests/SpeechToTextTests/Utilities/URLProtocolStubGate.swift`).
+  `URLProtocolStub` is a process-wide singleton and Swift Testing's
+  `.serialized` trait is suite-local, so without the gate two HTTP-
+  stubbed Swift Testing suites race across the suite boundary (PR #84
+  CI commit `964d877`). XCTest classes here (`ClinikoClientTests`,
+  `TreatmentNoteExporterTests`) do **not** need the gate; XCTest
+  scheduling has coexisted with Swift Testing safely since #20.
+  `Tests/SpeechToTextTests/Services/Cliniko/ClinikoStatusThreadingTests.swift`
+  is the reference adopter — issue #85.
 - **Credentials**: use `InMemorySecureStore` (actor fake, never imports
   `Security`) for `ClinikoCredentialStore` tests.
 - **Real Cliniko / real Keychain**: **never** in CI. Goldens that need

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoClientTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoClientTests.swift
@@ -95,84 +95,13 @@ final class ClinikoClientTests: XCTestCase {
     }
 
     // MARK: - sendWithStatus surfaces the actual 2xx code (#58)
-
-    /// Pin that `sendWithStatus(_:)` returns the observed HTTP status
-    /// alongside the decoded body. Today the audit ledger row is the
-    /// only consumer, but the contract belongs on the client itself: any
-    /// 2xx is success, and the *specific* 2xx code must reach the caller
-    /// rather than being smashed to a documented constant.
-    ///
-    /// This test set lives in this XCTest file (rather than a separate
-    /// Swift Testing `@Suite`) on purpose: `URLProtocolStub` is a
-    /// process-wide singleton and Swift Testing's `.serialized` trait is
-    /// suite-local, so adding a second Swift Testing suite that stubs
-    /// HTTP triggers cross-suite races against `ModelDownloaderTests`
-    /// (the singleton's `currentResponder` gets clobbered mid-flight).
-    /// Reverting to the XCTest pattern keeps these alongside the rest of
-    /// the file and avoids the race surface until a process-wide
-    /// `URLProtocolStubGate` lands.
-    func test_sendWithStatus_returnsActualStatusFromResponse() async throws {
-        let session = makeSession { request in
-            let body = try HTTPStubFixture.load("cliniko/responses/user.json")
-            // 200 — the documented status for /user.
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: "HTTP/1.1",
-                headerFields: ["Content-Type": "application/json"]
-            )!
-            return (response, body)
-        }
-        let client = makeClient(session: session)
-
-        let (user, status): (UsersMeResponse, Int) = try await client.sendWithStatus(.usersMe)
-
-        XCTAssertEqual(status, 200)
-        XCTAssertEqual(user.id, 12345)
-    }
-
-    /// Pin the 201 path too so the exporter's audit row always reflects the
-    /// real status — would catch a regression that hardcoded `200` somewhere
-    /// in the success path.
-    func test_sendWithStatus_returns201WhenServerReturns201() async throws {
-        let session = makeSession { request in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 201,
-                httpVersion: "HTTP/1.1",
-                headerFields: ["Content-Type": "application/json"]
-            )!
-            return (response, Data("{\"id\":42}".utf8))
-        }
-        let client = makeClient(session: session)
-
-        struct CreatedID: Decodable, Sendable, Equatable { let id: Int }
-        let (created, status): (CreatedID, Int) = try await client.sendWithStatus(
-            .createTreatmentNote(body: Data("{}".utf8))
-        )
-
-        XCTAssertEqual(status, 201)
-        XCTAssertEqual(created.id, 42)
-    }
-
-    /// `send(_:)` is now a thin forwarder over `sendWithStatus(_:)`. Pin
-    /// that it still drops the status cleanly — call sites that opt out of
-    /// the tuple shouldn't get a different value than they did before.
-    func test_send_stillDecodesBody_whenCallerIgnoresStatus() async throws {
-        let session = makeSession { request in
-            let body = try HTTPStubFixture.load("cliniko/responses/user.json")
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: 200,
-                httpVersion: "HTTP/1.1",
-                headerFields: ["Content-Type": "application/json"]
-            )!
-            return (response, body)
-        }
-        let client = makeClient(session: session)
-        let user: UsersMeResponse = try await client.send(.usersMe)
-        XCTAssertEqual(user.id, 12345)
-    }
+    //
+    // The three tests that pin `sendWithStatus(_:)` for issue #58 live
+    // in `ClinikoStatusThreadingTests.swift` as a Swift Testing `@Suite`
+    // gated through `URLProtocolStubGate.shared.withGate(_:)`. They
+    // briefly lived in this XCTest file as a workaround for the
+    // cross-suite `URLProtocolStub` race; once issue #85 introduced
+    // the process-wide gate the migration was safe.
 
     // MARK: - Status mapping
 

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoStatusThreadingTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoStatusThreadingTests.swift
@@ -1,0 +1,221 @@
+import Foundation
+import Testing
+@testable import SpeechToText
+
+/// Issue #58 contract tests — the actual HTTP status the server
+/// returned must thread through `ClinikoClient.sendWithStatus(_:)`
+/// to `TreatmentNoteExporter` so the audit ledger reflects what
+/// happened, not a documented constant.
+///
+/// These four tests originally landed in PR #84 as a Swift Testing
+/// suite, but had to be reverted to XCTest siblings because two
+/// Swift Testing suites that both stub HTTP raced against each other
+/// across the suite boundary (`ModelDownloaderTests` vs this file).
+/// Issue #85 introduces `URLProtocolStubGate` to serialise stub
+/// installs process-wide; with the gate adopted the migration is
+/// safe. See `.claude/references/testing-conventions.md`
+/// §"URLProtocolStub process-wide gate" and PR #84 review for the
+/// full history.
+@Suite("Cliniko status threading", .tags(.fast))
+struct ClinikoStatusThreadingTests {
+
+    // MARK: - Helpers
+
+    /// Hand-rolled "current `URLRequest`" recorder. The responder
+    /// closure is `@Sendable` so a plain `var` won't suffice; an
+    /// actor-backed implementation would force every read site to
+    /// `await`, which is unnecessary here because the responder fires
+    /// once per request.
+    private final class CapturedRequest: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stored: URLRequest?
+
+        func set(_ request: URLRequest) {
+            lock.lock(); defer { lock.unlock() }
+            stored = request
+        }
+
+        var value: URLRequest? {
+            lock.lock(); defer { lock.unlock() }
+            return stored
+        }
+    }
+
+    private struct UsersMeResponse: Decodable, Sendable, Equatable {
+        let id: Int
+        let firstName: String
+        let lastName: String
+        let email: String
+    }
+
+    private static func makeCredentials() throws -> ClinikoCredentials {
+        try ClinikoCredentials(apiKey: "MS-test-au1", shard: .au1)
+    }
+
+    private static func makeClient(
+        session: URLSession,
+        retryPolicy: ClinikoClient.RetryPolicy = .immediate
+    ) throws -> ClinikoClient {
+        ClinikoClient(
+            credentials: try makeCredentials(),
+            session: session,
+            userAgent: "status-threading-tests/1.0",
+            retryPolicy: retryPolicy
+        )
+    }
+
+    private static func makeManipulations() -> ManipulationsRepository {
+        ManipulationsRepository(all: [
+            Manipulation(id: "diversified_hvla", displayName: "Diversified HVLA", clinikoCode: nil),
+            Manipulation(id: "drop_table", displayName: "Drop-Table Technique", clinikoCode: nil)
+        ])
+    }
+
+    private static func makeNotes() -> StructuredNotes {
+        StructuredNotes(
+            subjective: "Patient reports lower-back pain after gardening.",
+            objective: "ROM reduced; tender at L4-L5.",
+            assessment: "Mechanical low back pain.",
+            plan: "Diversified HVLA + home stretching plan.",
+            selectedManipulationIDs: ["diversified_hvla", "drop_table"]
+        )
+    }
+
+    // MARK: - sendWithStatus surfaces the actual 2xx code (#58)
+
+    /// Pin that `sendWithStatus(_:)` returns the observed HTTP status
+    /// alongside the decoded body. The audit ledger row consumes this;
+    /// the contract is on the client itself so any 2xx is success and
+    /// the *specific* 2xx code reaches the caller rather than being
+    /// smashed to a documented constant.
+    @Test("sendWithStatus_returnsActualStatusFromResponse")
+    func sendWithStatus_returnsActualStatusFromResponse() async throws {
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install { request in
+                let body = try HTTPStubFixture.load("cliniko/responses/user.json")
+                // 200 — the documented status for /user.
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (response, body)
+            }
+            defer { URLProtocolStub.reset() }
+            let session = URLSession(configuration: config)
+            let client = try Self.makeClient(session: session)
+
+            let (user, status): (UsersMeResponse, Int) = try await client.sendWithStatus(.usersMe)
+
+            #expect(status == 200)
+            #expect(user.id == 12345)
+        }
+    }
+
+    /// Pin the 201 path too so the exporter's audit row always reflects
+    /// the real status — would catch a regression that hardcoded `200`
+    /// somewhere in the success path.
+    @Test("sendWithStatus_returns201_fromCreateTreatmentNote")
+    func sendWithStatus_returns201_fromCreateTreatmentNote() async throws {
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install { request in
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 201,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (response, Data("{\"id\":42}".utf8))
+            }
+            defer { URLProtocolStub.reset() }
+            let session = URLSession(configuration: config)
+            let client = try Self.makeClient(session: session)
+
+            struct CreatedID: Decodable, Sendable, Equatable { let id: Int }
+            let (created, status): (CreatedID, Int) = try await client.sendWithStatus(
+                .createTreatmentNote(body: Data("{}".utf8))
+            )
+
+            #expect(status == 201)
+            #expect(created.id == 42)
+        }
+    }
+
+    /// `send(_:)` is now a thin forwarder over `sendWithStatus(_:)`.
+    /// Pin that it still drops the status cleanly — call sites that
+    /// opt out of the tuple shouldn't get a different value than they
+    /// did before.
+    @Test("send_stillDecodesBody_whenCallerIgnoresStatus")
+    func send_stillDecodesBody_whenCallerIgnoresStatus() async throws {
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install { request in
+                let body = try HTTPStubFixture.load("cliniko/responses/user.json")
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: ["Content-Type": "application/json"]
+                )!
+                return (response, body)
+            }
+            defer { URLProtocolStub.reset() }
+            let session = URLSession(configuration: config)
+            let client = try Self.makeClient(session: session)
+
+            let user: UsersMeResponse = try await client.send(.usersMe)
+            #expect(user.id == 12345)
+        }
+    }
+
+    // MARK: - Exporter audit row reflects observed status
+
+    /// The audit ledger must reflect the actual HTTP status the server
+    /// returned, not a documented constant. Today Cliniko documents 201
+    /// for `POST /treatment_notes`; if a future endpoint variant returns
+    /// a different 2xx (e.g. 200 for the same logical create, or a 202
+    /// for a queued processing model), the audit row would lie under
+    /// the previous hardcoded literal. This test would have failed
+    /// against the pre-#58 `clinikoStatus: 201` hardcoding.
+    @Test("export_audit_clinikoStatus_reflectsActualHTTPStatus_not201Literal")
+    func export_audit_clinikoStatus_reflectsActualHTTPStatus_not201Literal() async throws {
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install { request in
+                let body = Data("{\"id\":42}".utf8)
+                // Stub 200 (not 201) to prove the exporter threads the
+                // observed status — would mis-record as 201 under the old
+                // hardcoded path.
+                let response = HTTPURLResponse(
+                    url: request.url!,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                return (response, body)
+            }
+            defer { URLProtocolStub.reset() }
+            let session = URLSession(configuration: config)
+            let client = try Self.makeClient(session: session)
+            let auditStore = InMemoryAuditStore()
+            let exporter = TreatmentNoteExporter(
+                client: client,
+                auditStore: auditStore,
+                manipulations: Self.makeManipulations(),
+                appVersion: "0.3.0-test",
+                now: { Date(timeIntervalSince1970: 1_777_320_000) }
+            )
+
+            let outcome = try await exporter.export(
+                notes: Self.makeNotes(),
+                patientID: 1001,
+                appointmentID: nil
+            )
+
+            #expect(outcome.created.id == 42)
+            #expect(outcome.auditPersisted)
+            let audit = try await auditStore.loadAll()
+            #expect(audit.count == 1)
+            #expect(audit.first?.clinikoStatus == 200)
+        }
+    }
+}

--- a/Tests/SpeechToTextTests/Services/Cliniko/TreatmentNoteExporterTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/TreatmentNoteExporterTests.swift
@@ -123,39 +123,12 @@ final class TreatmentNoteExporterTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
-    /// Issue #58 — the audit ledger must reflect the actual HTTP status the
-    /// server returned, not a documented constant. Today Cliniko documents
-    /// 201 for `POST /treatment_notes`; if a future endpoint variant returns
-    /// a different 2xx (e.g. 200 for the same logical create, or a 202 for a
-    /// queued processing model), the audit row would lie under the old
-    /// hardcoded literal. This test would have failed against the previous
-    /// `clinikoStatus: 201` hardcoding.
-    ///
-    /// Lives alongside its XCTest siblings (rather than as a Swift Testing
-    /// `@Suite`) because `URLProtocolStub` is a process-wide singleton and
-    /// Swift Testing's `.serialized` trait is suite-local — adding a new
-    /// Swift Testing suite that stubs HTTP races against `ModelDownloaderTests`.
-    /// See the parallel comment in `ClinikoClientTests` for the full rationale.
-    func test_export_audit_clinikoStatus_reflectsActualHTTPStatus_not201Literal() async throws {
-        let session = makeSession { request in
-            let body = Data("{\"id\":42}".utf8)
-            // Stub 200 (not 201) to prove the exporter threads the
-            // observed status — would mis-record as 201 under the old
-            // hardcoded path.
-            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            return (response, body)
-        }
-        let auditStore = InMemoryAuditStore()
-        let exporter = makeExporter(session: session, auditStore: auditStore)
-
-        let outcome = try await exporter.export(notes: makeNotes(), patientID: 1001, appointmentID: nil)
-
-        XCTAssertEqual(outcome.created.id, 42)
-        XCTAssertTrue(outcome.auditPersisted)
-        let audit = try await auditStore.loadAll()
-        XCTAssertEqual(audit.count, 1)
-        XCTAssertEqual(try XCTUnwrap(audit.first).clinikoStatus, 200)
-    }
+    // The issue-#58 audit-status pin (`test_export_audit_clinikoStatus_…`)
+    // lives in `ClinikoStatusThreadingTests.swift` as a Swift Testing
+    // suite gated through `URLProtocolStubGate.shared.withGate(_:)`.
+    // It briefly lived here as a cross-suite-race workaround; once
+    // issue #85 introduced the process-wide gate the migration was
+    // safe.
 
     func test_export_201_withoutAppointmentID_recordsNilAppointment() async throws {
         let session = makeSession { request in

--- a/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
+++ b/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
@@ -3,17 +3,22 @@ import Testing
 import CryptoKit
 @testable import SpeechToText
 
-@Suite("ModelDownloader", .tags(.fast), .serialized)
+@Suite("ModelDownloader", .tags(.fast))
 struct ModelDownloaderTests {
     // MARK: - Serialisation note
     //
-    // `.serialized` is load-bearing: `URLProtocolStub` keeps a single
-    // global `currentResponder`, and `URLProtocolStub.install` /
-    // `URLProtocolStub.reset` mutate it. Tests running in parallel
-    // would race — one's `defer { reset() }` would null the responder
-    // mid-flight in another test, falling through to the real network
-    // (HF, which 401s unauthenticated requests). Per-suite serialisation
-    // scopes the global cleanly.
+    // Every test that installs `URLProtocolStub` wraps its body in
+    // `URLProtocolStubGate.shared.withGate { ... }`. The stub keeps a
+    // single global `currentResponder`; without the gate, parallel
+    // tests would race — one's `defer { reset() }` would null the
+    // responder mid-flight in another test, falling through to the
+    // real network (HF, which 401s unauthenticated requests). Earlier
+    // versions of this suite carried `.serialized` to scope the race
+    // *within* the suite, but Swift Testing's `.serialized` trait is
+    // suite-local and didn't protect against cross-suite races (PR #84
+    // CI commit 964d877). The process-wide gate is the authoritative
+    // mechanism — see issue #85 and `.claude/references/testing-conventions.md`
+    // §"URLProtocolStub process-wide gate".
     // MARK: - Test scaffolding
 
     /// Per-test temp directory. Each test creates a fresh sub-folder so the
@@ -85,20 +90,22 @@ struct ModelDownloaderTests {
             to: modelDir.appendingPathComponent("weights.bin")
         )
 
-        // The responder should NEVER fire — if it does, the test fails.
-        let config = URLProtocolStub.install { _ in
-            Issue.record("Downloader should not have made any requests")
-            throw URLError(.cancelled)
-        }
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            // The responder should NEVER fire — if it does, the test fails.
+            let config = URLProtocolStub.install { _ in
+                Issue.record("Downloader should not have made any requests")
+                throw URLError(.cancelled)
+            }
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        let resolved = try await downloader.ensureModelDownloaded()
-        #expect(resolved == modelDir)
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            let resolved = try await downloader.ensureModelDownloaded()
+            #expect(resolved == modelDir)
+        }
     }
 
     @Test("emits .completed exactly once on the no-download path")
@@ -114,25 +121,27 @@ struct ModelDownloaderTests {
             to: modelDir.appendingPathComponent("weights.bin")
         )
 
-        let events = EventCollector()
-        let config = URLProtocolStub.install { _ in
-            Issue.record("Should not request anything")
-            throw URLError(.cancelled)
-        }
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            let events = EventCollector()
+            let config = URLProtocolStub.install { _ in
+                Issue.record("Should not request anything")
+                throw URLError(.cancelled)
+            }
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        _ = try await downloader.ensureModelDownloaded { events.append($0) }
-        let captured = await events.snapshot()
-        // Single .completed — no .starting / .fileStarted because the
-        // pre-flight loop short-circuited.
-        #expect(captured.count == 1)
-        if case .completed = captured.first {} else {
-            Issue.record("expected .completed first, got \(String(describing: captured.first))")
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            _ = try await downloader.ensureModelDownloaded { events.append($0) }
+            let captured = await events.snapshot()
+            // Single .completed — no .starting / .fileStarted because the
+            // pre-flight loop short-circuited.
+            #expect(captured.count == 1)
+            if case .completed = captured.first {} else {
+                Issue.record("expected .completed first, got \(String(describing: captured.first))")
+            }
         }
     }
 
@@ -143,19 +152,21 @@ struct ModelDownloaderTests {
         let base = try Self.makeTempBase()
         defer { try? FileManager.default.removeItem(at: base) }
 
-        let config = URLProtocolStub.install(Self.makeOKResponder())
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install(Self.makeOKResponder())
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        let resolved = try await downloader.ensureModelDownloaded()
-        let written = try Data(
-            contentsOf: resolved.appendingPathComponent("weights.bin")
-        )
-        #expect(written == Self.helloPayload)
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            let resolved = try await downloader.ensureModelDownloaded()
+            let written = try Data(
+                contentsOf: resolved.appendingPathComponent("weights.bin")
+            )
+            #expect(written == Self.helloPayload)
+        }
     }
 
     @Test("happy path emits .starting → .fileStarted → .fileVerified → .completed")
@@ -163,37 +174,39 @@ struct ModelDownloaderTests {
         let base = try Self.makeTempBase()
         defer { try? FileManager.default.removeItem(at: base) }
 
-        let events = EventCollector()
-        let config = URLProtocolStub.install(Self.makeOKResponder())
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            let events = EventCollector()
+            let config = URLProtocolStub.install(Self.makeOKResponder())
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        _ = try await downloader.ensureModelDownloaded { events.append($0) }
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            _ = try await downloader.ensureModelDownloaded { events.append($0) }
 
-        let captured = await events.snapshot()
-        // Loose check on event sequence — .bytesReceived may or may not
-        // fire for a 4-byte file depending on the chunk-flush threshold,
-        // so we assert structure not exact count.
-        guard captured.count >= 3 else {
-            Issue.record("expected ≥3 events, got \(captured.count)")
-            return
+            let captured = await events.snapshot()
+            // Loose check on event sequence — .bytesReceived may or may not
+            // fire for a 4-byte file depending on the chunk-flush threshold,
+            // so we assert structure not exact count.
+            guard captured.count >= 3 else {
+                Issue.record("expected ≥3 events, got \(captured.count)")
+                return
+            }
+            if case .starting = captured.first {} else {
+                Issue.record("first event should be .starting")
+            }
+            let last = captured.last
+            if case .completed = last {} else {
+                Issue.record("last event should be .completed; got \(String(describing: last))")
+            }
+            // .fileVerified must appear once for our single file.
+            let verifiedCount = captured.filter {
+                if case .fileVerified = $0 { return true } else { return false }
+            }.count
+            #expect(verifiedCount == 1)
         }
-        if case .starting = captured.first {} else {
-            Issue.record("first event should be .starting")
-        }
-        let last = captured.last
-        if case .completed = last {} else {
-            Issue.record("last event should be .completed; got \(String(describing: last))")
-        }
-        // .fileVerified must appear once for our single file.
-        let verifiedCount = captured.filter {
-            if case .fileVerified = $0 { return true } else { return false }
-        }.count
-        #expect(verifiedCount == 1)
     }
 
     // MARK: - Error paths
@@ -203,25 +216,27 @@ struct ModelDownloaderTests {
         let base = try Self.makeTempBase()
         defer { try? FileManager.default.removeItem(at: base) }
 
-        let config = URLProtocolStub.install { request in
-            let url = request.url ?? URL(string: "https://huggingface.co/")!
-            let response = HTTPURLResponse(
-                url: url,
-                statusCode: 404,
-                httpVersion: "HTTP/1.1",
-                headerFields: nil
-            )!
-            return (response, Data())
-        }
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install { request in
+                let url = request.url ?? URL(string: "https://huggingface.co/")!
+                let response = HTTPURLResponse(
+                    url: url,
+                    statusCode: 404,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: nil
+                )!
+                return (response, Data())
+            }
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        await #expect(throws: ModelDownloader.DownloaderError.self) {
-            _ = try await downloader.ensureModelDownloaded()
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            await #expect(throws: ModelDownloader.DownloaderError.self) {
+                _ = try await downloader.ensureModelDownloaded()
+            }
         }
     }
 
@@ -230,34 +245,36 @@ struct ModelDownloaderTests {
         let base = try Self.makeTempBase()
         defer { try? FileManager.default.removeItem(at: base) }
 
-        // Manifest expects 4 bytes; we serve 8.
-        let config = URLProtocolStub.install(
-            Self.makeOKResponder(body: Data("hellworld".utf8))
-        )
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            // Manifest expects 4 bytes; we serve 8.
+            let config = URLProtocolStub.install(
+                Self.makeOKResponder(body: Data("hellworld".utf8))
+            )
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        do {
-            _ = try await downloader.ensureModelDownloaded()
-            Issue.record("expected sizeMismatch; succeeded instead")
-        } catch let err as ModelDownloader.DownloaderError {
-            if case .sizeMismatch = err {} else {
-                Issue.record("expected .sizeMismatch; got \(err)")
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            do {
+                _ = try await downloader.ensureModelDownloaded()
+                Issue.record("expected sizeMismatch; succeeded instead")
+            } catch let err as ModelDownloader.DownloaderError {
+                if case .sizeMismatch = err {} else {
+                    Issue.record("expected .sizeMismatch; got \(err)")
+                }
             }
+            // No file at the final destination, no `.partial` lingering.
+            let dest = base
+                .appendingPathComponent("hello-model")
+                .appendingPathComponent("weights.bin")
+            let partial = base
+                .appendingPathComponent("hello-model")
+                .appendingPathComponent("weights.bin.partial")
+            #expect(!FileManager.default.fileExists(atPath: dest.path))
+            #expect(!FileManager.default.fileExists(atPath: partial.path))
         }
-        // No file at the final destination, no `.partial` lingering.
-        let dest = base
-            .appendingPathComponent("hello-model")
-            .appendingPathComponent("weights.bin")
-        let partial = base
-            .appendingPathComponent("hello-model")
-            .appendingPathComponent("weights.bin.partial")
-        #expect(!FileManager.default.fileExists(atPath: dest.path))
-        #expect(!FileManager.default.fileExists(atPath: partial.path))
     }
 
     @Test("hash mismatch raises .hashMismatch")
@@ -265,23 +282,25 @@ struct ModelDownloaderTests {
         let base = try Self.makeTempBase()
         defer { try? FileManager.default.removeItem(at: base) }
 
-        // Right size (4 bytes), wrong content.
-        let config = URLProtocolStub.install(
-            Self.makeOKResponder(body: Data("XXXX".utf8))
-        )
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            // Right size (4 bytes), wrong content.
+            let config = URLProtocolStub.install(
+                Self.makeOKResponder(body: Data("XXXX".utf8))
+            )
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        do {
-            _ = try await downloader.ensureModelDownloaded()
-            Issue.record("expected hashMismatch; succeeded instead")
-        } catch let err as ModelDownloader.DownloaderError {
-            if case .hashMismatch = err {} else {
-                Issue.record("expected .hashMismatch; got \(err)")
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            do {
+                _ = try await downloader.ensureModelDownloaded()
+                Issue.record("expected hashMismatch; succeeded instead")
+            } catch let err as ModelDownloader.DownloaderError {
+                if case .hashMismatch = err {} else {
+                    Issue.record("expected .hashMismatch; got \(err)")
+                }
             }
         }
     }
@@ -291,24 +310,26 @@ struct ModelDownloaderTests {
         let base = try Self.makeTempBase()
         defer { try? FileManager.default.removeItem(at: base) }
 
-        // Wrong content but right size, manifest doesn't carry a hash.
-        let config = URLProtocolStub.install(
-            Self.makeOKResponder(body: Data("XXXX".utf8))
-        )
-        defer { URLProtocolStub.reset() }
+        try await URLProtocolStubGate.shared.withGate {
+            // Wrong content but right size, manifest doesn't carry a hash.
+            let config = URLProtocolStub.install(
+                Self.makeOKResponder(body: Data("XXXX".utf8))
+            )
+            defer { URLProtocolStub.reset() }
 
-        let downloader = ModelDownloader(
-            manifest: Self.helloManifest(includeHash: false),
-            baseDirectory: base,
-            session: URLSession(configuration: config)
-        )
-        _ = try await downloader.ensureModelDownloaded()
-        let written = try Data(
-            contentsOf: base
-                .appendingPathComponent("hello-model")
-                .appendingPathComponent("weights.bin")
-        )
-        #expect(written == Data("XXXX".utf8))
+            let downloader = ModelDownloader(
+                manifest: Self.helloManifest(includeHash: false),
+                baseDirectory: base,
+                session: URLSession(configuration: config)
+            )
+            _ = try await downloader.ensureModelDownloaded()
+            let written = try Data(
+                contentsOf: base
+                    .appendingPathComponent("hello-model")
+                    .appendingPathComponent("weights.bin")
+            )
+            #expect(written == Data("XXXX".utf8))
+        }
     }
 
     // MARK: - URL composition

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStubGate.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStubGate.swift
@@ -1,0 +1,124 @@
+import Foundation
+
+/// Process-wide gate for tests that install `URLProtocolStub`.
+///
+/// Wrap a test body in `withGate { ... }` so it acquires exclusive access
+/// to the singleton's `currentResponder` before installing, and releases
+/// when the body exits.
+///
+/// ## Why this exists
+///
+/// `URLProtocolStub` keeps a single process-wide `currentResponder`.
+/// Swift Testing's `.serialized` trait is **suite-local** — two Swift
+/// Testing suites that both stub HTTP race against each other across the
+/// suite boundary because the scheduler still parallelises between
+/// suites. The race manifests as one suite's `defer { reset() }`
+/// clobbering another suite's responder mid-flight, producing
+/// `URLError(-2000)` or fall-through to the real network (e.g. PR #84
+/// CI commit `964d877`: a Hugging Face 401 against
+/// `ModelDownloaderTests.happyPathDownload`).
+///
+/// XCTest scheduling has empirically coexisted with Swift Testing since
+/// #20 without flakes, so XCTest test classes that use `URLProtocolStub`
+/// (e.g. `ClinikoClientTests`, `TreatmentNoteExporterTests`) do **not**
+/// need to adopt the gate. The gate is only required for Swift Testing
+/// `@Test` bodies.
+///
+/// ## Adoption status
+///
+/// Adopters as of issue #85:
+/// - `Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift`
+/// - `Tests/SpeechToTextTests/Services/Cliniko/ClinikoStatusThreadingTests.swift`
+///
+/// `Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift`
+/// is a third Swift Testing `@Suite` that calls `URLProtocolStub.install`
+/// from a `@MainActor`-isolated context. Migration is tracked separately
+/// (the `@MainActor` + `@Sendable` interaction needs a wider refactor
+/// than #85's scope) — until that lands, the suite remains protected
+/// only by its `.serialized` trait, which is suite-local and therefore
+/// still races against gated suites. Treat this as a known gap.
+///
+/// See `.claude/references/testing-conventions.md` §"URLProtocolStub
+/// process-wide gate" and `Sources/Services/Cliniko/AGENTS.md`
+/// §Testing for adoption rules. Issue #85.
+///
+/// ## Usage
+///
+/// ```swift
+/// @Suite("Cliniko status threading", .tags(.fast))
+/// struct ClinikoStatusThreadingTests {
+///     @Test func sendWithStatus_returns200() async throws {
+///         try await URLProtocolStubGate.shared.withGate {
+///             let config = URLProtocolStub.install { request in
+///                 // ...build response...
+///             }
+///             defer { URLProtocolStub.reset() }
+///             // ...exercise SUT...
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Cancellation
+///
+/// Tests do not typically cancel mid-run; if a Task is cancelled while
+/// waiting on the gate the queued continuation will never resume and
+/// the waiter slot leaks. Acceptable in a test-only utility — production
+/// code must not depend on this gate.
+///
+/// ## Reentrancy
+///
+/// Non-reentrant: a `withGate` body that recurses into another
+/// `withGate` call on the same actor instance will deadlock. Tests
+/// should never need this.
+actor URLProtocolStubGate {
+    /// The singleton every test acquires through.
+    static let shared = URLProtocolStubGate()
+
+    /// `true` while a `withGate` body is in flight. Mutated only on the
+    /// actor's executor, so no external locking is required.
+    private var busy = false
+
+    /// FIFO queue of tasks suspended in `acquire()` waiting for the
+    /// gate to free up. `release()` resumes the head waiter directly,
+    /// keeping `busy == true` — a hand-off that avoids the
+    /// thundering-herd race where every waiter would re-check `busy`
+    /// and contend.
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Acquire the gate, run `body`, release the gate. Re-throws any
+    /// error from `body` after the gate has been released, so a
+    /// failing test cannot starve subsequent suites.
+    func withGate<T: Sendable>(
+        _ body: @Sendable () async throws -> T
+    ) async rethrows -> T {
+        await acquire()
+        // `release()` is sync from inside the actor; the `defer` runs
+        // after the `await body()` continuation re-enters via the
+        // actor's executor, so calling release() in a `defer` is safe
+        // even when `body` throws.
+        defer { release() }
+        return try await body()
+    }
+
+    private func acquire() async {
+        if busy {
+            await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                waiters.append(cont)
+            }
+            // Resumed via `release()` direct hand-off — `busy` is
+            // already `true` for us, so no further mutation is needed.
+            return
+        }
+        busy = true
+    }
+
+    private func release() {
+        if waiters.isEmpty {
+            busy = false
+            return
+        }
+        let next = waiters.removeFirst()
+        next.resume()
+    }
+}

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStubGateTests.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStubGateTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+
+/// Pins the `URLProtocolStubGate` contract: serialised access across
+/// concurrent tasks and gate release on a throwing body. The gate is
+/// the only mechanism keeping cross-suite Swift Testing tests from
+/// clobbering each other's `URLProtocolStub` responder, so a regression
+/// here would re-open the race observed in PR #84 CI commit
+/// `964d877`. See issue #85.
+///
+/// FIFO ordering of queued waiters is *not* asserted: the use case
+/// (URLProtocolStub callers needing exclusive responder access) only
+/// requires mutual exclusion, not order, and asserting order without
+/// internal-state visibility is flake bait under CI scheduling jitter.
+@Suite("URLProtocolStubGate", .tags(.fast))
+struct URLProtocolStubGateTests {
+
+    /// Sendable scratchpad for tests that hand work between concurrent
+    /// tasks and the body being asserted on.
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [String] = []
+
+        func append(_ value: String) {
+            lock.lock(); defer { lock.unlock() }
+            values.append(value)
+        }
+
+        var snapshot: [String] {
+            lock.lock(); defer { lock.unlock() }
+            return values
+        }
+    }
+
+    @Test("single task can acquire the gate without contention")
+    func singleAcquire_runsBody() async throws {
+        let gate = URLProtocolStubGate()
+        let result: Int = try await gate.withGate { 42 }
+        #expect(result == 42)
+    }
+
+    /// The core serialisation pin. Two tasks both call `withGate`; the
+    /// gate must guarantee their bodies do **not** interleave. Uses
+    /// `AsyncStream` signals rather than `Task.sleep` so the test is
+    /// deterministic regardless of scheduler jitter — the failure mode
+    /// of a sleep-based variant would be the exact kind of CI flake
+    /// the gate exists to prevent.
+    @Test("concurrent acquirers do not interleave bodies")
+    func concurrentAcquirers_areSerialised() async throws {
+        let gate = URLProtocolStubGate()
+        let recorder = Recorder()
+
+        // A signals when it's holding the gate; the test signals A to
+        // release. This makes A's hold deterministic without timing.
+        let (aHoldingStream, aHoldingCont) = AsyncStream<Void>.makeStream()
+        let (aReleaseStream, aReleaseCont) = AsyncStream<Void>.makeStream()
+
+        let aTask = Task {
+            await gate.withGate {
+                recorder.append("A-start")
+                aHoldingCont.yield(())
+                aHoldingCont.finish()
+                for await _ in aReleaseStream { break }
+                recorder.append("A-end")
+            }
+        }
+
+        // Block until A is actually holding the gate. Pin that we
+        // saw the signal — a future refactor that forgets the
+        // `yield` would make `aHoldingStream` finish without a
+        // value, the for-loop would exit silently, and the test
+        // would race forward and pass for the wrong reason. The
+        // explicit flag makes that regression fail loudly.
+        var sawAHolding = false
+        for await _ in aHoldingStream {
+            sawAHolding = true
+            break
+        }
+        #expect(sawAHolding, "A should have signalled it was holding the gate")
+
+        // Spawn B *after* A is holding. Whether B queues on the
+        // continuation list or arrives just-in-time after A releases,
+        // the gate must serialise B's body behind A's body. Both code
+        // paths through `acquire()` (busy vs not-busy) satisfy the
+        // assertion, so the test is robust without observing internal
+        // state.
+        let bTask = Task {
+            await gate.withGate {
+                recorder.append("B-start")
+                recorder.append("B-end")
+            }
+        }
+
+        // Release A. B's body proceeds — never before this point.
+        aReleaseCont.yield(())
+        aReleaseCont.finish()
+
+        await aTask.value
+        await bTask.value
+
+        #expect(recorder.snapshot == ["A-start", "A-end", "B-start", "B-end"])
+    }
+
+    @Test("throwing body still releases the gate so subsequent acquirers proceed")
+    func throwingBody_releasesGate() async throws {
+        struct BoomError: Error {}
+        let gate = URLProtocolStubGate()
+
+        await #expect(throws: BoomError.self) {
+            try await gate.withGate { throw BoomError() }
+        }
+
+        // Second acquirer must not deadlock — runs to completion.
+        let didRun = Recorder()
+        try await gate.withGate {
+            didRun.append("ran")
+        }
+        #expect(didRun.snapshot == ["ran"])
+    }
+}


### PR DESCRIPTION
## Summary

Introduces `URLProtocolStubGate`, a process-wide actor-based gate that serializes access to `URLProtocolStub` across concurrent Swift Testing suites. This fixes race conditions where multiple test suites stubbing HTTP would clobber each other's responders mid-flight.

## Problem

Swift Testing's `.serialized` trait is suite-local, not process-wide. When two suites both call `URLProtocolStub.install()`, their `defer { reset() }` blocks race: one suite's cleanup nulls the responder while another suite's request is in-flight, causing the request to fall through to the real network (e.g., Hugging Face 401 errors in PR #84 CI).

## Solution

- **`URLProtocolStubGate`** (`Tests/SpeechToTextTests/Utilities/URLProtocolStubGate.swift`): An actor providing `withGate(_:)` that acquires exclusive access before a test body runs and releases after it completes, even on error. Uses a FIFO continuation queue to serialize concurrent acquirers without thundering-herd contention.

- **`URLProtocolStubGateTests`** (`Tests/SpeechToTextTests/Utilities/URLProtocolStubGateTests.swift`): Pins the gate's contract—single-task acquisition, concurrent serialization, and gate release on throwing bodies—using deterministic `AsyncStream` signals instead of timing-dependent sleeps.

## Key Changes

- **`ModelDownloaderTests.swift`**: Removed `.serialized` trait (suite-local, insufficient). Wrapped all 8 test bodies that call `URLProtocolStub.install()` in `try await URLProtocolStubGate.shared.withGate { ... }`.

- **`ClinikoStatusThreadingTests.swift`** (new): Migrated 4 status-threading tests from XCTest (`ClinikoClientTests` / `TreatmentNoteExporterTests`) to a new Swift Testing `@Suite`, now safe to run in parallel thanks to the gate. These tests verify issue #58 (audit ledger reflects actual HTTP status, not hardcoded constants).

- **`ClinikoClientTests.swift` & `TreatmentNoteExporterTests.swift`**: Removed the 4 XCTest methods that tested `sendWithStatus(_:)` and audit status threading; they now live in the gated Swift Testing suite.

- **`.claude/references/testing-conventions.md`**: Documented the gate adoption rule: always wrap Swift Testing `@Test` bodies that stub HTTP in `withGate { ... }`. Never rely on `.serialized` alone. XCTest classes do not need the gate.

- **`Sources/Services/Cliniko/AGENTS.md`**: Added guidance for HTTP testing from Swift Testing suites.

## Implementation Details

- **Non-reentrant**: A `withGate` body that recurses into another `withGate` call deadlocks. Tests should never need this.
- **Cancellation-aware**: If a task is cancelled while waiting, the continuation leaks. Acceptable for test-only code.
- **Hand-off semantics**: `release()` resumes the next waiter directly, keeping `busy == true`, avoiding a thundering-herd race where all waiters re-check `busy`.
- **Error propagation**: Throwing bodies still release the gate, so a failing test cannot starve subsequent suites.

Fixes issue #85 and resolves the cross-suite race observed in PR #84 CI commit `964d877`.

https://claude.ai/code/session_018AHfG6JcF2HTuvEzhjsTRH