### PR TITLE
test(stub): per-installation URLProtocolStub responder eliminates cross-suite race (#87)

### DIFF
--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAppointmentServiceTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAppointmentServiceTests.swift
@@ -6,9 +6,9 @@ import XCTest
 /// payload decoding, the 7-day-back / 1-day-forward window definition, and
 /// error pass-through from `ClinikoClient`.
 ///
-/// Why XCTest (not Swift Testing): see `ClinikoPatientServiceTests` —
-/// `URLProtocolStub` is a process-wide singleton; XCTest serialises within
-/// a class while Swift Testing parallelises. Refactor tracked in #30.
+/// Stays on XCTest for now; #87 made `URLProtocolStub` per-installation
+/// safe (Swift Testing's parallel suites no longer race the stub), so a
+/// future migration to Swift Testing is unblocked but not required.
 final class ClinikoAppointmentServiceTests: XCTestCase {
 
     override func tearDown() {

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoClientTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoClientTests.swift
@@ -102,15 +102,11 @@ final class ClinikoClientTests: XCTestCase {
     /// 2xx is success, and the *specific* 2xx code must reach the caller
     /// rather than being smashed to a documented constant.
     ///
-    /// This test set lives in this XCTest file (rather than a separate
-    /// Swift Testing `@Suite`) on purpose: `URLProtocolStub` is a
-    /// process-wide singleton and Swift Testing's `.serialized` trait is
-    /// suite-local, so adding a second Swift Testing suite that stubs
-    /// HTTP triggers cross-suite races against `ModelDownloaderTests`
-    /// (the singleton's `currentResponder` gets clobbered mid-flight).
-    /// Reverting to the XCTest pattern keeps these alongside the rest of
-    /// the file and avoids the race surface until a process-wide
-    /// `URLProtocolStubGate` lands.
+    /// Lives in this XCTest file alongside the rest of `ClinikoClient`'s
+    /// behaviour tests for cohesion. (The historical reason was a
+    /// `URLProtocolStub` cross-suite race that made Swift Testing's
+    /// parallel suites unsafe; #87 fixed that with per-installation
+    /// dispatch, so future Cliniko tests can adopt Swift Testing freely.)
     func test_sendWithStatus_returnsActualStatusFromResponse() async throws {
         let session = makeSession { request in
             let body = try HTTPStubFixture.load("cliniko/responses/user.json")

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoPatientServiceTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoPatientServiceTests.swift
@@ -6,10 +6,9 @@ import XCTest
 /// `URLProtocolStub`. Scoped to what the picker UI cares about:
 /// query-item shape, decoded payload, error pass-through, cancellation.
 ///
-/// Why XCTest (and not Swift Testing): `URLProtocolStub` keeps a single
-/// process-wide responder. XCTest serialises test methods within a class
-/// by default; Swift Testing parallelises them, so two `@Test`s would
-/// race the responder. Refactor tracked in #30.
+/// Stays on XCTest for now; #87 made `URLProtocolStub` per-installation
+/// safe (Swift Testing's parallel suites no longer race the stub), so a
+/// future migration to Swift Testing is unblocked but not required.
 final class ClinikoPatientServiceTests: XCTestCase {
 
     override func tearDown() {
@@ -447,8 +446,10 @@ final class ClinikoPatientServiceTests: XCTestCase {
 }
 
 /// Counts how many times a URLProtocolStub responder is invoked. Mirrors
-/// the helper of the same name in `ClinikoClientTests` (kept private per
-/// file to dodge `URLProtocolStub` cross-suite races — see #30).
+/// the helper of the same name in `ClinikoClientTests`. (Was historically
+/// kept private per file to dodge `URLProtocolStub` cross-suite races;
+/// #87 fixed those, so consolidation into a shared test util is now safe
+/// — left split for now to keep this PR scoped to the stub itself.)
 private final class CallCounter: @unchecked Sendable {
     private let lock = NSLock()
     private var count = 0

--- a/Tests/SpeechToTextTests/Services/Cliniko/TreatmentNoteExporterTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/TreatmentNoteExporterTests.swift
@@ -131,11 +131,12 @@ final class TreatmentNoteExporterTests: XCTestCase {
     /// hardcoded literal. This test would have failed against the previous
     /// `clinikoStatus: 201` hardcoding.
     ///
-    /// Lives alongside its XCTest siblings (rather than as a Swift Testing
-    /// `@Suite`) because `URLProtocolStub` is a process-wide singleton and
-    /// Swift Testing's `.serialized` trait is suite-local — adding a new
-    /// Swift Testing suite that stubs HTTP races against `ModelDownloaderTests`.
-    /// See the parallel comment in `ClinikoClientTests` for the full rationale.
+    /// Lives alongside its XCTest siblings for cohesion with the rest of
+    /// the exporter behaviour tests. (The historical motivation was a
+    /// `URLProtocolStub` cross-suite race; #87 fixed that with
+    /// per-installation dispatch, so this test could move to Swift Testing
+    /// without races — kept here only because the surrounding sibs haven't
+    /// migrated yet.)
     func test_export_audit_clinikoStatus_reflectsActualHTTPStatus_not201Literal() async throws {
         let session = makeSession { request in
             let body = Data("{\"id\":42}".utf8)

--- a/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
+++ b/Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift
@@ -7,13 +7,20 @@ import CryptoKit
 struct ModelDownloaderTests {
     // MARK: - Serialisation note
     //
-    // `.serialized` is load-bearing: `URLProtocolStub` keeps a single
-    // global `currentResponder`, and `URLProtocolStub.install` /
-    // `URLProtocolStub.reset` mutate it. Tests running in parallel
-    // would race — one's `defer { reset() }` would null the responder
-    // mid-flight in another test, falling through to the real network
-    // (HF, which 401s unauthenticated requests). Per-suite serialisation
-    // scopes the global cleanly.
+    // `.serialized` is no longer load-bearing for `URLProtocolStub`
+    // safety: as of #87, `URLProtocolStub` dispatches by a per-install
+    // header token and `URLProtocolStub.reset()` is a no-op, so a
+    // parallel suite cannot null the responder used by this one. It's
+    // kept on the suite anyway because each test mints a unique temp
+    // directory under `model-downloader-tests/` and serial execution
+    // makes failure traces easier to read when one of the integration
+    // assertions trips.
+    //
+    // The historical failure mode (`sizeMismatch(expected: 4, got: 0)`
+    // when another suite's `defer { reset() }` raced this one's
+    // `URLSession.download(for:)`) is regression-tested directly in
+    // `URLProtocolStubTests.test_concurrentInstallations_dispatchToOwnResponderOnly`
+    // and `URLProtocolStubTests.test_droppingOneInstallation_doesNotAffectOther`.
     // MARK: - Test scaffolding
 
     /// Per-test temp directory. Each test creates a fresh sub-folder so the

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStub.swift
@@ -2,8 +2,11 @@ import Foundation
 
 /// Thread-safe `URLProtocol` stub for testing network code without hitting the network.
 ///
-/// Install once per test, route all URL requests through the supplied closure, then call
-/// `reset()` in tearDown.
+/// Each `install(_:)` mints a unique installation token, registers the supplied responder
+/// in a token-keyed registry, and tags the returned `URLSessionConfiguration` with that
+/// token via `httpAdditionalHeaders[stubTokenHeader]`. Every request that flows through a
+/// session built from that configuration carries the header; `startLoading()` reads the
+/// header to dispatch back to the right responder.
 ///
 /// ```swift
 /// let config = URLProtocolStub.install { request in
@@ -19,78 +22,141 @@ import Foundation
 /// }
 /// let session = URLSession(configuration: config)
 /// // ...use session...
-/// URLProtocolStub.reset()
 /// ```
 ///
-/// `@unchecked Sendable` is safe because the only mutable static (`currentResponder`) is
-/// always accessed under `lock`. `nonisolated(unsafe)` is required for Swift 6 concurrency
-/// checking since `URLProtocol` callbacks do not come with actor isolation — SwiftLint's
+/// ## Concurrent suites are isolated (#87)
+///
+/// Earlier versions kept a single global `currentResponder` slot. Suites that ran in
+/// parallel (e.g. `ModelDownloaderTests` + Cliniko networking suites) would race: one
+/// suite's `defer { URLProtocolStub.reset() }` could null the slot mid-flight while
+/// another suite's request was still in motion, surfacing as a misleading
+/// `sizeMismatch(expected: 4, got: 0)` because the responder fell through to nothing.
+///
+/// The token-keyed registry makes that race impossible: each `install(_:)` writes to its
+/// own slot, and only `Installation.deinit` (RAII) ever removes a slot — the per-test
+/// `defer { URLProtocolStub.reset() }` pattern is now a documented no-op kept only so
+/// existing call sites keep compiling. New tests should prefer `installScoped(_:)` and
+/// let the handle's `deinit` clean up its slot.
+///
+/// ## Threading
+///
+/// `@unchecked Sendable` is safe because every access to the `responders` dict goes
+/// through `lock`. `nonisolated(unsafe)` is required for Swift 6 concurrency checking
+/// since `URLProtocol` callbacks come without actor isolation — SwiftLint's
 /// `nonisolated_unsafe_warning` custom rule calls these usages out for review.
 final class URLProtocolStub: URLProtocol, @unchecked Sendable {
     typealias Responder = @Sendable (URLRequest) throws -> (HTTPURLResponse, Data)
 
+    /// HTTP header name carrying the per-installation dispatch token. Tests should not
+    /// set this header on outgoing requests — `URLSessionConfiguration.httpAdditionalHeaders`
+    /// is responsible for stamping it on every request through a stub session, and a
+    /// per-request override would defeat the dispatch.
+    static let stubTokenHeader = "X-URLProtocolStub-Token"
+
     private static let lock = NSLock()
-    nonisolated(unsafe) private static var currentResponder: Responder?
-    /// Generation token for the responder currently installed via
-    /// `installScoped(_:)` / `installScoped(routes:)`. `Installation.deinit`
-    /// clears `currentResponder` only when its captured token still matches —
-    /// stops a stale handle from clobbering a newer install. The closure-form
-    /// `install(_:)` clears the token (it has no RAII partner anyway).
-    nonisolated(unsafe) private static var currentInstallationToken: UUID?
+    nonisolated(unsafe) private static var responders: [String: Responder] = [:]
 
-    /// Install the stub as the first protocol class in a new `URLSessionConfiguration`.
-    /// Callers create a `URLSession` from the returned config; every request through
-    /// that session will be intercepted until `reset()` is called.
+    // MARK: - Installation
+
+    /// Install a responder; returns a `URLSessionConfiguration` tagged with a fresh
+    /// per-installation token. Every request through a session built from the returned
+    /// config will be intercepted and dispatched to `responder`.
+    ///
+    /// The responder slot persists for the test process lifetime (a few hundred bytes per
+    /// test, garbage-collected at process exit). Tests that want deterministic cleanup
+    /// should prefer `installScoped(_:)` instead.
     static func install(_ responder: @escaping Responder) -> URLSessionConfiguration {
-        lock.lock()
-        defer { lock.unlock() }
-        currentResponder = responder
-        currentInstallationToken = nil
-
-        let config = URLSessionConfiguration.ephemeral
-        config.protocolClasses = [URLProtocolStub.self] + (config.protocolClasses ?? [])
-        return config
+        let (configuration, _) = makeConfiguration(responder: responder)
+        return configuration
     }
 
-    /// Clear the current responder. Call from `tearDown` so tests don't leak state.
+    /// Routed install: dispatches each request to the first matching `Route`. The
+    /// single-closure `install(_:)` form remains available unchanged for tests that only
+    /// stub one endpoint.
+    static func install(routes: [Route]) -> URLSessionConfiguration {
+        install(makeRoutedResponder(routes))
+    }
+
+    /// RAII variant of `install(_:)`. Returns an `Installation` whose `deinit` removes
+    /// its responder from the registry. Always assign the return value to a `let` —
+    /// discarding it would let ARC tear the responder down before the test runs.
+    static func installScoped(_ responder: @escaping Responder) -> Installation {
+        let (configuration, token) = makeConfiguration(responder: responder)
+        return Installation(configuration: configuration, token: token)
+    }
+
+    /// RAII variant of `install(routes:)`. Same dispatch semantics, lifetime tied to the
+    /// returned handle. Always assign to a `let`.
+    static func installScoped(routes: [Route]) -> Installation {
+        let (configuration, token) = makeConfiguration(responder: makeRoutedResponder(routes))
+        return Installation(configuration: configuration, token: token)
+    }
+
+    /// **No-op kept for back-compat** with the pre-#87 `defer { URLProtocolStub.reset() }`
+    /// pattern. The per-installation registry makes per-test cleanup unnecessary, and
+    /// clearing the entire registry mid-test is the exact bug #87 fixed (a parallel
+    /// suite's reset would null another suite's responder mid-flight).
+    ///
+    /// Tests that genuinely want every responder gone can call `resetAll()` — but that
+    /// is dangerous in a parallel-suite test runner and should only be used at process
+    /// boundaries. Prefer `installScoped(_:)` for deterministic cleanup.
     static func reset() {
-        lock.lock()
-        defer { lock.unlock() }
-        currentResponder = nil
-        currentInstallationToken = nil
+        // Deliberately no-op. See doc comment.
     }
 
-    /// Internal: install with a generation token so `Installation.deinit` can
-    /// no-op if a newer install has already replaced this one.
-    fileprivate static func installWithToken(
-        _ responder: @escaping Responder,
-        token: UUID
-    ) -> URLSessionConfiguration {
+    /// Hard-clear the entire responder registry. Dangerous in a parallel-suite runner;
+    /// prefer `installScoped(_:)` for per-test cleanup. Exposed only so a future
+    /// process-level fixture (`@MainActor` `setUpAll` / `tearDownAll`) has an explicit
+    /// escape hatch when one is genuinely needed.
+    static func resetAll() {
         lock.lock()
         defer { lock.unlock() }
-        currentResponder = responder
-        currentInstallationToken = token
+        responders.removeAll()
+    }
+
+    // MARK: - Internals
+
+    private static func makeConfiguration(
+        responder: @escaping Responder
+    ) -> (URLSessionConfiguration, String) {
+        let token = UUID().uuidString
+        lock.lock()
+        responders[token] = responder
+        lock.unlock()
 
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [URLProtocolStub.self] + (config.protocolClasses ?? [])
-        return config
+        // Merge with any existing additional headers the caller might have set on a
+        // shared base config (none today, but defensive against future callers).
+        var headers: [AnyHashable: Any] = config.httpAdditionalHeaders ?? [:]
+        headers[stubTokenHeader] = token
+        config.httpAdditionalHeaders = headers
+        return (config, token)
     }
 
-    /// Internal: reset only if the installation token still matches. Lets a
-    /// stale `Installation.deinit` no-op when a later install has taken over.
-    fileprivate static func resetIfTokenMatches(_ token: UUID) {
+    fileprivate static func unregister(token: String) {
         lock.lock()
         defer { lock.unlock() }
-        guard currentInstallationToken == token else { return }
-        currentResponder = nil
-        currentInstallationToken = nil
+        responders.removeValue(forKey: token)
+    }
+
+    private static func responder(for request: URLRequest) -> Responder? {
+        guard let token = request.value(forHTTPHeaderField: stubTokenHeader) else { return nil }
+        lock.lock()
+        defer { lock.unlock() }
+        return responders[token]
     }
 
     // MARK: - URLProtocol overrides
 
+    /// Claim based on header *presence*, not registration. A request through a
+    /// stub-tagged session whose `Installation` has already deinit'd would
+    /// otherwise silently fall through to the real network — better to claim
+    /// it and let `startLoading()` surface the descriptive "no responder"
+    /// failure so the test author sees the lifetime bug at the point of harm.
+    /// Untagged requests (e.g. `URLSession.shared` traffic) are unaffected.
     override class func canInit(with request: URLRequest) -> Bool {
-        lock.lock(); defer { lock.unlock() }
-        return currentResponder != nil
+        request.value(forHTTPHeaderField: stubTokenHeader) != nil
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
@@ -98,11 +164,20 @@ final class URLProtocolStub: URLProtocol, @unchecked Sendable {
     }
 
     override func startLoading() {
-        Self.lock.lock()
-        let responder = Self.currentResponder
-        Self.lock.unlock()
-        guard let responder else {
-            client?.urlProtocol(self, didFailWithError: URLError(.cannotLoadFromNetwork))
+        guard let responder = Self.responder(for: request) else {
+            // (c) — fail loudly with a diagnostic so a future regression surfaces as
+            // "no responder for token X" rather than e.g. `sizeMismatch(expected: 4, got: 0)`
+            // from the request falling through to nothing.
+            let token = request.value(forHTTPHeaderField: Self.stubTokenHeader) ?? "<missing>"
+            let error = URLError(
+                .cannotLoadFromNetwork,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "URLProtocolStub: no responder registered for token \(token). "
+                        + "Did the Installation handle deinit before the request fired?"
+                ]
+            )
+            client?.urlProtocol(self, didFailWithError: error)
             return
         }
         do {
@@ -123,10 +198,9 @@ final class URLProtocolStub: URLProtocol, @unchecked Sendable {
 // MARK: - Routed installation + RAII handle
 
 extension URLProtocolStub {
-    /// One leg of a routed stub. The first `Route` in the array whose
-    /// `matches` returns true serves the request. If none match,
-    /// `install(routes:)` throws a descriptive `URLError` so a typo in a
-    /// test path fails loudly instead of silently returning a
+    /// One leg of a routed stub. The first `Route` in the array whose `matches` returns
+    /// true serves the request. If none match, `install(routes:)` throws a descriptive
+    /// `URLError` so a typo in a test path fails loudly instead of silently returning a
     /// `cannotLoadFromNetwork`.
     struct Route: Sendable {
         let matches: @Sendable (URLRequest) -> Bool
@@ -140,12 +214,11 @@ extension URLProtocolStub {
             self.respond = respond
         }
 
-        /// Convenience for the common HTTP method + URL path case (most
-        /// Cliniko service tests). Defaults to `GET`. The method and path
-        /// are normalized once at Route construction (uppercased / leading
-        /// slash enforced) so the per-request match is a pair of plain
-        /// string equality checks — also makes a missing leading slash in
-        /// the call site (`"v1/users"` vs `"/v1/users"`) a non-issue.
+        /// Convenience for the common HTTP method + URL path case (most Cliniko service
+        /// tests). Defaults to `GET`. The method and path are normalized once at Route
+        /// construction (uppercased / leading slash enforced) so the per-request match
+        /// is a pair of plain string equality checks — also makes a missing leading
+        /// slash in the call site (`"v1/users"` vs `"/v1/users"`) a non-issue.
         static func path(
             _ path: String,
             method: String = "GET",
@@ -163,26 +236,25 @@ extension URLProtocolStub {
         }
     }
 
-    /// RAII handle returned from `installScoped(_:)` / `installScoped(routes:)`.
-    /// On `deinit` the handle conditionally clears the stub — only if its
-    /// captured installation token is still current — so a stale handle that
-    /// outlives a newer install will no-op rather than nuke the active stub.
+    /// RAII handle returned from `installScoped(_:)` / `installScoped(routes:)`. On
+    /// `deinit` the handle removes only its own responder from the registry — it cannot
+    /// affect a parallel suite's installation.
     ///
-    /// Assign the return value to a `let`; discarding it would let ARC tear
-    /// the stub down before the test runs. `@unchecked Sendable` mirrors
-    /// `URLProtocolStub`; `deinit` may run on an arbitrary thread but only
-    /// touches lock-protected static state.
+    /// Assign the return value to a `let`; discarding it would let ARC tear the
+    /// responder down before the test runs. `@unchecked Sendable` mirrors
+    /// `URLProtocolStub`; `deinit` may run on an arbitrary thread but only touches
+    /// lock-protected static state.
     final class Installation: @unchecked Sendable {
         let configuration: URLSessionConfiguration
-        private let token: UUID
+        private let token: String
 
-        fileprivate init(configuration: URLSessionConfiguration, token: UUID) {
+        fileprivate init(configuration: URLSessionConfiguration, token: String) {
             self.configuration = configuration
             self.token = token
         }
 
         deinit {
-            URLProtocolStub.resetIfTokenMatches(token)
+            URLProtocolStub.unregister(token: token)
         }
     }
 
@@ -205,30 +277,5 @@ extension URLProtocolStub {
                 ]
             )
         }
-    }
-
-    /// Routed install: dispatches each request to the first matching `Route`.
-    /// The single-closure `install(_:)` form remains available unchanged for
-    /// tests that only stub one endpoint.
-    static func install(routes: [Route]) -> URLSessionConfiguration {
-        install(makeRoutedResponder(routes))
-    }
-
-    /// RAII variant of `install(_:)`. Returns an `Installation` whose `deinit`
-    /// calls `reset()` — drop the manual `tearDown { URLProtocolStub.reset() }`
-    /// when adopting this form. Always assign to a `let`; discarding the
-    /// return value would let ARC tear the stub down immediately.
-    static func installScoped(_ responder: @escaping Responder) -> Installation {
-        let token = UUID()
-        let configuration = installWithToken(responder, token: token)
-        return Installation(configuration: configuration, token: token)
-    }
-
-    /// RAII variant of `install(routes:)`. Same dispatch semantics, lifetime
-    /// tied to the returned handle. Always assign to a `let`.
-    static func installScoped(routes: [Route]) -> Installation {
-        let token = UUID()
-        let configuration = installWithToken(makeRoutedResponder(routes), token: token)
-        return Installation(configuration: configuration, token: token)
     }
 }

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStubTests.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStubTests.swift
@@ -5,6 +5,10 @@ import XCTest
 /// network-client tests.
 final class URLProtocolStubTests: XCTestCase {
     override func tearDown() {
+        // No-op since #87 — `URLProtocolStub.reset()` is a documented no-op
+        // because each `install(_:)` registers under its own token. The call
+        // is left here so anyone copying this teardown shape from older code
+        // sees that it's harmless rather than missing.
         URLProtocolStub.reset()
         super.tearDown()
     }
@@ -74,22 +78,163 @@ final class URLProtocolStubTests: XCTestCase {
         }
     }
 
-    func test_reset_clearsInterception() {
-        _ = URLProtocolStub.install { request in
-            guard let url = request.url else { throw URLError(.badURL) }
-            let response = HTTPURLResponse(
-                url: url,
-                statusCode: 200,
-                httpVersion: nil,
+    // MARK: - reset() is a no-op (#87)
+
+    /// `URLProtocolStub.reset()` is a documented no-op since #87 — the
+    /// per-installation registry makes "clear the global slot" both unnecessary
+    /// and unsafe (a parallel suite's `defer { reset() }` would have nuked
+    /// another suite's responder mid-flight). This test pins that behaviour so
+    /// a regression that re-introduces a global clear surfaces here, not as a
+    /// flaky cross-suite race in CI.
+    func test_reset_isNoOp_liveInstallationStillIntercepts() async throws {
+        let config = URLProtocolStub.install { request in
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? URL(string: "https://example.test")!,
+                statusCode: 204,
+                httpVersion: "HTTP/1.1",
                 headerFields: nil
-            )!
+            ))
             return (response, Data())
         }
+        let session = URLSession(configuration: config)
+
+        // Reset BEFORE the request fires — under pre-#87 semantics this would
+        // null the responder slot and the request would 500 / fail.
         URLProtocolStub.reset()
 
-        let request = URLRequest(url: URL(string: "https://example.test/")!)
-        XCTAssertFalse(URLProtocolStub.canInit(with: request),
-                       "canInit must return false after reset()")
+        let url = try XCTUnwrap(URL(string: "https://example.test/probe"))
+        let (_, response) = try await session.data(from: url)
+        XCTAssertEqual(
+            (response as? HTTPURLResponse)?.statusCode,
+            204,
+            "reset() must not affect a live installation; the per-installation registry"
+                + " keeps each install's responder under its own token"
+        )
+    }
+
+    /// A bare `URLRequest` with no `X-URLProtocolStub-Token` header must not be
+    /// claimed by `URLProtocolStub.canInit(with:)`, even when other
+    /// installations are alive in the registry. This is the property that lets
+    /// arbitrary `URLSession.shared` traffic in the test process pass through
+    /// untouched (only sessions built from `install()`'s configuration carry
+    /// the dispatch token).
+    func test_canInit_returnsFalseForRequestsWithoutToken() {
+        // A live registry entry — its token is not on `request` below. Use
+        // `withExtendedLifetime` rather than `defer { _ = installation }` —
+        // the latter is not honoured by Release-mode ARC, which is free to
+        // release `installation` immediately after the property read.
+        let installation = URLProtocolStub.installScoped { _ in
+            (HTTPURLResponse(), Data())
+        }
+        withExtendedLifetime(installation) {
+            let request = URLRequest(url: URL(string: "https://example.test/")!)
+            XCTAssertFalse(
+                URLProtocolStub.canInit(with: request),
+                "URLProtocolStub must only claim requests carrying its dispatch header,"
+                    + " so untagged URLSession traffic in the test process is unaffected"
+            )
+        }
+    }
+
+    // MARK: - Cross-suite isolation regression (#87)
+
+    /// The dispatch property at the heart of #87: two installations alive at
+    /// the same time each carry their own token, and each request lands on
+    /// the responder registered for *its* token regardless of which
+    /// installation came second.
+    ///
+    /// Pre-#87 this would have failed deterministically: both installations
+    /// shared a single global `currentResponder` slot, the second `install`
+    /// always clobbered the first, and both sessions' requests would have
+    /// landed on the second responder. The `async let` interleaves the
+    /// requests for stress (and to mimic the real race shape) but the
+    /// per-token dispatch is what the assertions actually pin.
+    func test_concurrentInstallations_dispatchToOwnResponderOnly() async throws {
+        let firstURL = try XCTUnwrap(URL(string: "https://first.test/probe"))
+        let secondURL = try XCTUnwrap(URL(string: "https://second.test/probe"))
+
+        let firstStub = URLProtocolStub.installScoped { request in
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? firstURL,
+                statusCode: 201,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            ))
+            return (response, Data("FIRST".utf8))
+        }
+        let secondStub = URLProtocolStub.installScoped { request in
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? secondURL,
+                statusCode: 202,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            ))
+            return (response, Data("SECOND".utf8))
+        }
+        let firstSession = URLSession(configuration: firstStub.configuration)
+        let secondSession = URLSession(configuration: secondStub.configuration)
+
+        // Interleave requests through both sessions concurrently. If the
+        // installations shared a global responder slot, results would be
+        // non-deterministic (whichever install ran most recently wins).
+        async let firstResult: (Data, URLResponse) = firstSession.data(from: firstURL)
+        async let secondResult: (Data, URLResponse) = secondSession.data(from: secondURL)
+        let (firstData, firstResponse) = try await firstResult
+        let (secondData, secondResponse) = try await secondResult
+
+        XCTAssertEqual((firstResponse as? HTTPURLResponse)?.statusCode, 201)
+        XCTAssertEqual(firstData, Data("FIRST".utf8))
+        XCTAssertEqual((secondResponse as? HTTPURLResponse)?.statusCode, 202)
+        XCTAssertEqual(secondData, Data("SECOND".utf8))
+    }
+
+    /// Companion to the concurrent-installations test. ARC-driven cleanup of
+    /// one installation (here: the inner installation's deinit at function
+    /// return) must not unregister another installation's responder — each
+    /// `Installation.deinit` knows only its own token, so it can only ever
+    /// remove its own slot from the registry. Pre-#87 the inner install
+    /// would have *replaced* the outer's `currentResponder` and the inner's
+    /// teardown would have left the outer's session pointing at nothing —
+    /// the exact `sizeMismatch(expected: 4, got: 0)` failure mode.
+    func test_droppingOneInstallation_doesNotAffectOther() async throws {
+        // Outer installation alive for the whole test.
+        let outerStub = URLProtocolStub.installScoped { request in
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? URL(string: "https://outer.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            ))
+            return (response, Data("outer-ok".utf8))
+        }
+        let outerSession = URLSession(configuration: outerStub.configuration)
+
+        // Inner installation lives only for the duration of `runInner`. When
+        // the function returns, ARC releases its `Installation` and the
+        // responder slot is unregistered — but only its slot, not the outer's.
+        try await runInner()
+
+        // After the inner installation deinit'd, outer must still intercept.
+        let url = try XCTUnwrap(URL(string: "https://outer.test/probe"))
+        let (data, response) = try await outerSession.data(from: url)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        XCTAssertEqual(data, Data("outer-ok".utf8))
+    }
+
+    private func runInner() async throws {
+        let innerStub = URLProtocolStub.installScoped { request in
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? URL(string: "https://inner.test")!,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            ))
+            return (response, Data("inner-ok".utf8))
+        }
+        let innerSession = URLSession(configuration: innerStub.configuration)
+        let url = try XCTUnwrap(URL(string: "https://inner.test/probe"))
+        let (data, _) = try await innerSession.data(from: url)
+        XCTAssertEqual(data, Data("inner-ok".utf8))
     }
 
     // MARK: - Fixture loading (not-found + edge cases)
@@ -319,80 +464,111 @@ final class URLProtocolStubTests: XCTestCase {
     // MARK: - RAII (`installScoped`)
 
     /// Exemplar for `URLProtocolStub.installScoped(_:)`. The returned handle's
-    /// `deinit` calls `reset()` (token-gated) when the handle goes out of
-    /// scope. We delegate to a separate async helper so the handle's lifetime
-    /// ends deterministically at the helper's return — `do { let x = … }`
-    /// blocks do NOT guarantee ARC release at the closing brace, so the
-    /// helper-function form is the reliable shape.
-    func test_installScoped_resetsOnHandleDeinit() async throws {
-        let probeURL = try XCTUnwrap(URL(string: "https://example.test/"))
-        let request = URLRequest(url: probeURL)
+    /// `deinit` removes its responder slot from the per-installation registry
+    /// (not a global "currentResponder" — see #87). We verify by:
+    ///   1. firing a request through the configuration's session while the
+    ///      handle is alive — expect 200,
+    ///   2. dropping the handle inside a helper so ARC actually releases it
+    ///      at function return,
+    ///   3. firing the same request again through the same (still-alive)
+    ///      session — expect the loud "no responder" failure that proves the
+    ///      registry slot was removed (rather than a silent network call).
+    func test_installScoped_unregistersResponderOnHandleDeinit() async throws {
+        let probeURL = try XCTUnwrap(URL(string: "https://example.test/probe"))
 
-        try await runWithScopedInstallation(probeRequest: request)
+        // Helper builds + returns a session whose configuration was tagged
+        // with an Installation that's released the moment the helper returns.
+        let session = try await runWithScopedInstallationReturningSession(probeURL: probeURL)
 
-        // The helper has returned, its `installation` local has been released,
-        // deinit ran, the token-gated reset cleared the responder.
-        XCTAssertFalse(
-            URLProtocolStub.canInit(with: request),
-            "Installation deinit must call URLProtocolStub.reset()"
-        )
+        // Handle has deinit'd; the session still carries the dispatch header
+        // but the registry slot is gone — startLoading() should surface the
+        // descriptive "no responder" URLError.
+        do {
+            _ = try await session.data(from: probeURL)
+            XCTFail("expected loud failure after Installation.deinit removed the responder slot")
+        } catch {
+            let nsError = error as NSError
+            XCTAssertTrue(
+                nsError.localizedDescription.contains("no responder registered for token"),
+                "expected the descriptive URLError from URLProtocolStub.startLoading; got \(nsError.localizedDescription)"
+            )
+        }
     }
 
-    private func runWithScopedInstallation(probeRequest: URLRequest) async throws {
-        let fallback = try XCTUnwrap(URL(string: "https://example.test"))
+    private func runWithScopedInstallationReturningSession(probeURL: URL) async throws -> URLSession {
         let installation = URLProtocolStub.installScoped { request in
             let response = try XCTUnwrap(HTTPURLResponse(
-                url: request.url ?? fallback,
+                url: request.url ?? probeURL,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: nil
+            ))
+            return (response, Data())
+        }
+        let session = URLSession(configuration: installation.configuration)
+
+        // Fire one successful request to prove the responder is wired up
+        // before the handle deinits.
+        let (_, response) = try await session.data(from: probeURL)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+        return session
+        // installation released here at function return → deinit unregisters.
+    }
+
+    /// Stale `Installation` deinit must not affect a parallel installation's
+    /// responder. Pre-#87 this was a token-gated reset of a single shared
+    /// slot; under the per-installation registry it is automatic — each handle
+    /// only ever knows its own token and so can only ever remove its own
+    /// entry. This test pins the property by exercising the dispatch path.
+    func test_installScoped_droppingOneHandle_doesNotAffectAnother() async throws {
+        let firstURL = try XCTUnwrap(URL(string: "https://stale.test/first"))
+        let secondURL = try XCTUnwrap(URL(string: "https://stale.test/second"))
+
+        var firstHandle: URLProtocolStub.Installation? = URLProtocolStub.installScoped { request in
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? firstURL,
                 statusCode: 200,
                 httpVersion: nil,
                 headerFields: nil
             ))
             return (response, Data())
         }
+        // Explicit read so the compiler doesn't flag `firstHandle` as
+        // write-only — the test's whole point is the var-then-nil shape.
+        XCTAssertNotNil(firstHandle, "installScoped must return a handle")
 
-        // Stub is live while the handle is in scope.
-        XCTAssertTrue(URLProtocolStub.canInit(with: probeRequest))
-
-        let dataURL = try XCTUnwrap(URL(string: "https://example.test/"))
-        let session = URLSession(configuration: installation.configuration)
-        let (_, response) = try await session.data(from: dataURL)
-        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
-    }
-
-    /// Stale `Installation` deinit must NOT clobber a newer installation that
-    /// has already taken over the responder. The token-gating in
-    /// `Installation.deinit` is what makes `installScoped` safe even if a
-    /// caller accidentally keeps an old handle alive past the install of the
-    /// next one (e.g. captured in a Task).
-    func test_installScoped_staleHandleDeinit_doesNotClobberNewerInstall() throws {
-        let probeURL = try XCTUnwrap(URL(string: "https://example.test/"))
-        let probe = URLRequest(url: probeURL)
-        let responseURL = try XCTUnwrap(URL(string: "https://example.test"))
-
-        let firstResponse = try makeHTTPResponse(url: responseURL, statusCode: 200, httpVersion: nil)
-        let secondResponse = try makeHTTPResponse(url: responseURL, statusCode: 201, httpVersion: nil)
-
-        var firstHandle: URLProtocolStub.Installation? = URLProtocolStub.installScoped { _ in
-            (firstResponse, Data())
-        }
-        XCTAssertNotNil(firstHandle)
-
-        // A second `installScoped` takes over (different token).
-        let secondHandle = URLProtocolStub.installScoped { _ in
-            (secondResponse, Data())
+        let secondHandle = URLProtocolStub.installScoped { request in
+            let response = try XCTUnwrap(HTTPURLResponse(
+                url: request.url ?? secondURL,
+                statusCode: 201,
+                httpVersion: nil,
+                headerFields: nil
+            ))
+            return (response, Data())
         }
 
-        // Drop the first handle — its deinit's reset is token-gated, so it
-        // should observe a token mismatch and no-op rather than clearing
-        // the second handle's responder.
+        // Need to keep the second session reference around so we can make a
+        // request against it after the first handle goes away.
+        let secondSession = URLSession(configuration: secondHandle.configuration)
+
+        // `withExtendedLifetime` does not have an `async` overload, so use it
+        // inside a `defer` whose synchronous body runs `_fixLifetime` at scope
+        // exit. This is the only optimizer-respected lifetime extension that
+        // composes with `await`. Without it, the optimizer is free to release
+        // `secondHandle` after its last syntactic use (the property read on
+        // the previous line), which would let `Installation.deinit` race the
+        // in-flight request below.
+        defer { withExtendedLifetime(secondHandle) {} }
+
+        // Drop the first handle — its deinit removes only the first
+        // responder slot, leaving second's registry entry intact.
         firstHandle = nil
 
-        XCTAssertTrue(
-            URLProtocolStub.canInit(with: probe),
-            "Stale Installation.deinit must not reset a newer installation's responder"
+        let (_, response) = try await secondSession.data(from: secondURL)
+        XCTAssertEqual(
+            (response as? HTTPURLResponse)?.statusCode,
+            201,
+            "Dropping firstHandle must not unregister secondHandle's responder"
         )
-
-        // Touch the second handle so the optimizer cannot pre-deinit it.
-        _ = secondHandle.configuration
     }
 }


### PR DESCRIPTION
## Summary

- **Root-cause fix for #87.** Replace `URLProtocolStub`'s single global `currentResponder` slot with a per-installation registry keyed by a UUID token carried in `URLSessionConfiguration.httpAdditionalHeaders`. Each `install(_:)` mints its own slot; `Installation.deinit` removes only its own slot. `URLProtocolStub.reset()` becomes a documented no-op so existing `defer { URLProtocolStub.reset() }` call sites keep compiling without the cross-suite clobber that surfaced as `sizeMismatch(expected: 4, got: 0)` after the post-merge CI re-run on PR #86.
- **`canInit` now claims based on header presence** rather than registration. A request through a stub-tagged session whose `Installation` already deinit'd surfaces a descriptive `URLError` from `startLoading()` instead of silently falling through to the real network. Diagnostic interpolates only the dispatch UUID — no PHI from the request URL (per `AGENTS.md` PHI rules).
- **New regression tests** (`test_concurrentInstallations_dispatchToOwnResponderOnly`, `test_droppingOneInstallation_doesNotAffectOther`, `test_canInit_returnsFalseForRequestsWithoutToken`, `test_reset_isNoOp_liveInstallationStillIntercepts`) directly pin the cross-suite isolation property. The existing `installScoped` tests were rewritten to exercise the dispatch path through real sessions rather than `canInit` against bare URLRequests (which became vacuous post-#87).
- **Stale comment cleanup.** `ModelDownloaderTests` `.serialized` block updated to note it's no longer load-bearing for stub safety. Stale rationale comments in `ClinikoClientTests`, `TreatmentNoteExporterTests`, `ClinikoPatientServiceTests`, `ClinikoAppointmentServiceTests` (referencing the now-fixed singleton race / the never-landed `URLProtocolStubGate`) updated to reflect the new state.

**Why this design and not the alternatives in the issue body:**
- (a) per-installation responder via `URLSessionConfiguration` tag → **picked**. The header-token + token-keyed registry keeps each installation's responder strictly isolated; `Installation.deinit` cleans up its own slot only.
- (b) global serialization trait on every stub-using suite → rejected. Slows CI for every parallel suite to fix one race surface; doesn't address the underlying fragility.
- (c) loud failure when responder is `nil` → **folded in**. The new `startLoading()` produces "URLProtocolStub: no responder registered for token …" rather than `sizeMismatch` from a 0-byte body.

**Pre-PR review pipeline (per AGENTS.md):**
- `pr-review-toolkit:code-reviewer` (Opus) — verdict REQUEST CHANGES, all 3 blockers folded in this branch (stale `ClinikoClientTests` comment, `withExtendedLifetime` for ARC lifetime extension in two tests, docstring overclaim about "mid-flight" race).
- `pr-review-toolkit:silent-failure-hunter` (Opus) — verdict SAFE.

## Test plan

- [x] `swift test --parallel --filter "URLProtocolStubTests|ModelDownloaderTests|ClinikoClientTests|ClinikoAuthProbeTests|ClinikoPatientServiceTests|ClinikoAppointmentServiceTests|TreatmentNoteExporterTests|ExportFlowViewModelTests|ExportFlowViewRenderTests|ClinicalNotesSectionViewModelTests"` — 40 Swift Testing tests + 117 XCTest cases, all green
- [x] 5x consecutive stress run of the same filter — 5/5 clean, no flakes
- [x] `pre-commit run --files <touched>` — all hooks pass (SwiftLint strict + autocorrect + secrets + EOF + whitespace)
- [x] Verified no production code sets `X-URLProtocolStub-Token` header (`grep -rn "X-URLProtocolStub-Token" Sources/` returns empty)
- [ ] CI on PR + post-merge `main` workflow run

Awaiting CI.

Closes #87