### PR TITLE
test(infra): migrate ExportFlowViewModelTests onto URLProtocolStubGate (#133)

### DIFF
--- a/.claude/references/testing-conventions.md
+++ b/.claude/references/testing-conventions.md
@@ -116,15 +116,16 @@ Reference adopters:
 
 - `Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift`
 - `Tests/SpeechToTextTests/Services/Cliniko/ClinikoStatusThreadingTests.swift`
-
-**Known gap:**
-`Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift` is
-also a Swift Testing `@Suite` that installs `URLProtocolStub`, but it
-is `@MainActor`-isolated and migrating it requires resolving the
-`@MainActor` × `@Sendable` interaction across 22 test bodies. Tracked
-as a follow-up to #85 — until the migration lands, the suite is
-protected only by its `.serialized` trait and remains a cross-suite
-race candidate against the gated suites above.
+- `Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift`
+  — `@MainActor`-isolated suite. The `@MainActor` × `@Sendable`
+  interaction is resolved by a local `runGated(responder:body:)`
+  helper that takes a `@MainActor @Sendable (URLSessionConfiguration)
+  async throws -> Void` closure. The gate's outer body runs off
+  `@MainActor`; the trailing closure hops back onto `@MainActor` so
+  the test can mutate the SwiftUI-bound `ExportFlowViewModel`
+  directly. Per #133 the suite no longer carries a `.serialized`
+  trait — the gate provides cross-suite mutual exclusion that
+  `.serialized` (which is suite-local) cannot.
 
 ---
 

--- a/Tests/SpeechToTextTests/Utilities/URLProtocolStubGate.swift
+++ b/Tests/SpeechToTextTests/Utilities/URLProtocolStubGate.swift
@@ -26,21 +26,19 @@ import Foundation
 ///
 /// ## Adoption status
 ///
-/// Adopters as of issue #85:
+/// Every Swift Testing `@Suite` that calls `URLProtocolStub.install` is
+/// gated:
 /// - `Tests/SpeechToTextTests/Services/ModelDownloaderTests.swift`
 /// - `Tests/SpeechToTextTests/Services/Cliniko/ClinikoStatusThreadingTests.swift`
-///
-/// `Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift`
-/// is a third Swift Testing `@Suite` that calls `URLProtocolStub.install`
-/// from a `@MainActor`-isolated context. Migration is tracked separately
-/// (the `@MainActor` + `@Sendable` interaction needs a wider refactor
-/// than #85's scope) — until that lands, the suite remains protected
-/// only by its `.serialized` trait, which is suite-local and therefore
-/// still races against gated suites. Treat this as a known gap.
+/// - `Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift`
+///   (`@MainActor`-isolated for SwiftUI; uses a `@MainActor @Sendable`
+///   trailing closure on a local `runGated` helper so the test body
+///   stays on `@MainActor` while the gate's outer body runs off it —
+///   issue #133)
 ///
 /// See `.claude/references/testing-conventions.md` §"URLProtocolStub
 /// process-wide gate" and `Sources/Services/Cliniko/AGENTS.md`
-/// §Testing for adoption rules. Issue #85.
+/// §Testing for adoption rules. Originating issue #85; final adopter #133.
 ///
 /// ## Usage
 ///

--- a/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
+++ b/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
@@ -144,7 +144,8 @@ struct ExportFlowViewModelTests {
     /// silently mis-attribute a timeout to a logic regression.
     private func waitForTerminal(
         _ viewModel: ExportFlowViewModel,
-        timeout: TimeInterval = 5.0
+        timeout: TimeInterval = 5.0,
+        sourceLocation: SourceLocation = #_sourceLocation
     ) async throws {
         let deadline = Date().addingTimeInterval(timeout)
         while true {
@@ -156,10 +157,13 @@ struct ExportFlowViewModelTests {
                 // landing on the very last loop iteration is not
                 // misreported as a timeout.
                 if Date() >= deadline { break }
-                try await Task.sleep(nanoseconds: 5_000_000)
+                try await Task.sleep(for: .milliseconds(5))
             }
         }
-        Issue.record("waitForTerminal timed out after \(timeout)s; state=\(viewModel.state)")
+        Issue.record(
+            "waitForTerminal timed out after \(timeout)s; state=\(viewModel.state)",
+            sourceLocation: sourceLocation
+        )
     }
 
     // MARK: - Confirming state
@@ -596,7 +600,8 @@ struct ExportFlowViewModelTests {
     private func assertConfirmFailsWith(
         _ expected: ExportFailure,
         status: Int,
-        body: Data = Data()
+        body: Data = Data(),
+        sourceLocation: SourceLocation = #_sourceLocation
     ) async throws {
         try await runGated(responder: { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
@@ -607,13 +612,16 @@ struct ExportFlowViewModelTests {
             let viewModel = self.makeViewModel(store: store, exporter: exporter)
             viewModel.enterConfirming()
             viewModel.confirm()
-            try await self.waitForTerminal(viewModel)
+            try await self.waitForTerminal(viewModel, sourceLocation: sourceLocation)
 
             guard case .failed(let actual) = viewModel.state else {
-                Issue.record("expected .failed(\(expected)), got \(viewModel.state)")
+                Issue.record(
+                    "expected .failed(\(expected)), got \(viewModel.state)",
+                    sourceLocation: sourceLocation
+                )
                 return
             }
-            #expect(actual == expected)
+            #expect(actual == expected, sourceLocation: sourceLocation)
         }
     }
 }

--- a/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
+++ b/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
@@ -148,22 +148,55 @@ struct ExportFlowViewModelTests {
         sourceLocation: SourceLocation = #_sourceLocation
     ) async throws {
         let deadline = Date().addingTimeInterval(timeout)
-        while true {
+        polling: while true {
             switch viewModel.state {
             case .failed, .succeeded:
                 return
             default:
                 // Check the deadline AFTER reading state so a transition
                 // landing on the very last loop iteration is not
-                // misreported as a timeout.
-                if Date() >= deadline { break }
+                // misreported as a timeout. `break polling` is a labelled
+                // break — `break` alone would only exit the switch and
+                // re-enter `while true` on the next iteration (Gemini
+                // review on PR #135).
+                if Date() >= deadline { break polling }
                 try await Task.sleep(for: .milliseconds(5))
             }
         }
-        Issue.record(
-            "waitForTerminal timed out after \(timeout)s; state=\(viewModel.state)",
-            sourceLocation: sourceLocation
-        )
+        // Final post-loop check picks up a transition that landed on
+        // the last iteration before the deadline tripped.
+        switch viewModel.state {
+        case .failed, .succeeded:
+            return
+        default:
+            Issue.record(
+                "waitForTerminal timed out after \(timeout)s; state=\(Self.structuralName(viewModel.state))",
+                sourceLocation: sourceLocation
+            )
+        }
+    }
+
+    /// Structural-only `ExportFlowState` case name for log
+    /// interpolation. Required because `.confirming(ExportSummary)`'s
+    /// payload contains `patientDisplayName`, and per AGENTS.md
+    /// §"Security / PHI" — and the project styleguide flagging PHI
+    /// leaks as blocking — even synthetic test logs must never
+    /// interpolate the full state. `ExportFailure` case names come
+    /// from `ExportFlowViewModel.caseName(_:)`, which is PHI-safe by
+    /// construction (`Sources/Views/ClinicalNotes/ExportFlowViewModel.swift`).
+    private static func structuralName(_ state: ExportFlowState) -> String {
+        switch state {
+        case .idle:
+            return ".idle"
+        case .confirming:
+            return ".confirming"
+        case .uploading:
+            return ".uploading"
+        case .succeeded:
+            return ".succeeded"
+        case .failed(let failure):
+            return ".failed(\(ExportFlowViewModel.caseName(failure)))"
+        }
     }
 
     // MARK: - Confirming state
@@ -178,7 +211,7 @@ struct ExportFlowViewModelTests {
             viewModel.enterConfirming()
 
             guard case .confirming(let summary) = viewModel.state else {
-                Issue.record("expected .confirming, got \(viewModel.state)")
+                Issue.record("expected .confirming, got \(Self.structuralName(viewModel.state))")
                 return
             }
             #expect(summary.patientID == OpaqueClinikoID(1001))
@@ -211,7 +244,7 @@ struct ExportFlowViewModelTests {
             if case .failed(.sessionState(.noActiveSession)) = viewModel.state {
                 // expected
             } else {
-                Issue.record("expected .failed(.sessionState(.noActiveSession)), got \(viewModel.state)")
+                Issue.record("expected .failed(.sessionState(.noActiveSession)), got \(Self.structuralName(viewModel.state))")
             }
         }
     }
@@ -230,7 +263,7 @@ struct ExportFlowViewModelTests {
             if case .failed(.sessionState(.noPatient)) = viewModel.state {
                 // expected
             } else {
-                Issue.record("expected .failed(.sessionState(.noPatient)), got \(viewModel.state)")
+                Issue.record("expected .failed(.sessionState(.noPatient)), got \(Self.structuralName(viewModel.state))")
             }
         }
     }
@@ -285,7 +318,7 @@ struct ExportFlowViewModelTests {
             try await self.waitForTerminal(viewModel)
 
             guard case .succeeded(let report) = viewModel.state else {
-                Issue.record("expected .succeeded, got \(viewModel.state)")
+                Issue.record("expected .succeeded, got \(Self.structuralName(viewModel.state))")
                 return
             }
             #expect(report.createdNoteID == OpaqueClinikoID(9876543))
@@ -323,7 +356,7 @@ struct ExportFlowViewModelTests {
             if case .failed(.sessionState(.appointmentIDMalformed)) = viewModel.state {
                 // expected
             } else {
-                Issue.record("expected .failed(.sessionState(.appointmentIDMalformed)), got \(viewModel.state)")
+                Issue.record("expected .failed(.sessionState(.appointmentIDMalformed)), got \(Self.structuralName(viewModel.state))")
             }
         }
     }
@@ -346,7 +379,7 @@ struct ExportFlowViewModelTests {
             if case .failed(.sessionState(.appointmentUnresolved)) = viewModel.state {
                 // expected
             } else {
-                Issue.record("expected .failed(.sessionState(.appointmentUnresolved)), got \(viewModel.state)")
+                Issue.record("expected .failed(.sessionState(.appointmentUnresolved)), got \(Self.structuralName(viewModel.state))")
             }
         }
     }
@@ -402,7 +435,7 @@ struct ExportFlowViewModelTests {
             if case .failed(.transport(.notConnectedToInternet)) = viewModel.state {
                 // expected
             } else {
-                Issue.record("expected .failed(.transport(.notConnectedToInternet)), got \(viewModel.state)")
+                Issue.record("expected .failed(.transport(.notConnectedToInternet)), got \(Self.structuralName(viewModel.state))")
             }
         }
     }
@@ -424,7 +457,7 @@ struct ExportFlowViewModelTests {
                 // expected — UI must NOT offer one-tap retry, the note
                 // may have landed on Cliniko's side.
             } else {
-                Issue.record("expected .failed(.responseUndecodable), got \(viewModel.state)")
+                Issue.record("expected .failed(.responseUndecodable), got \(Self.structuralName(viewModel.state))")
             }
         }
     }
@@ -452,7 +485,7 @@ struct ExportFlowViewModelTests {
             if case .failed(.rateLimited(let retryAfter)) = viewModel.state {
                 #expect(retryAfter == 5)
             } else {
-                Issue.record("expected .failed(.rateLimited), got \(viewModel.state)")
+                Issue.record("expected .failed(.rateLimited), got \(Self.structuralName(viewModel.state))")
             }
             // Countdown started — value should be set.
             #expect((viewModel.rateLimitCountdownRemaining ?? 0) > 0)
@@ -514,7 +547,7 @@ struct ExportFlowViewModelTests {
             if case .idle = viewModel.state {
                 // expected
             } else {
-                Issue.record("expected .idle, got \(viewModel.state)")
+                Issue.record("expected .idle, got \(Self.structuralName(viewModel.state))")
             }
         }
     }
@@ -616,7 +649,7 @@ struct ExportFlowViewModelTests {
 
             guard case .failed(let actual) = viewModel.state else {
                 Issue.record(
-                    "expected .failed(\(expected)), got \(viewModel.state)",
+                    "expected .failed(\(expected)), got \(Self.structuralName(viewModel.state))",
                     sourceLocation: sourceLocation
                 )
                 return

--- a/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
+++ b/Tests/SpeechToTextTests/ViewModels/ExportFlowViewModelTests.swift
@@ -6,13 +6,20 @@
 // in-test fakes — no real Cliniko traffic, no real audit ledger.
 // `URLProtocolStub` wires up the `ClinikoClient` underneath the
 // `TreatmentNoteExporter` actor so we can drive end-to-end POST
-// outcomes deterministically.
+// outcomes deterministically. Every `makeExporter`-using `@Test`
+// routes through `URLProtocolStubGate.shared.withGate` (#133) so the
+// suite no longer races against `ModelDownloaderTests` /
+// `ClinikoStatusThreadingTests` at the cross-suite boundary; the
+// `runGated` helper acquires the gate off-`@MainActor` and runs the
+// per-test body back on `@MainActor` via a `@MainActor @Sendable`
+// closure — the SwiftUI binding on `ExportFlowViewModel` requires
+// the suite to stay `@MainActor`-isolated.
 
 import Foundation
 import Testing
 @testable import SpeechToText
 
-@Suite("ExportFlowViewModel", .tags(.fast), .serialized)
+@Suite("ExportFlowViewModel", .tags(.fast))
 @MainActor
 struct ExportFlowViewModelTests {
 
@@ -47,11 +54,14 @@ struct ExportFlowViewModelTests {
         return store
     }
 
+    /// Build a `TreatmentNoteExporter` against a stub-backed
+    /// `URLSessionConfiguration`. Caller must already be inside a
+    /// `URLProtocolStubGate.shared.withGate` body that installed the
+    /// stub on `config` — see `runGated(responder:body:)`.
     private func makeExporter(
-        responder: @escaping URLProtocolStub.Responder,
+        config: URLSessionConfiguration,
         auditStore: any AuditStore = InMemoryAuditStore()
     ) -> TreatmentNoteExporter {
-        let config = URLProtocolStub.install(responder)
         let session = URLSession(configuration: config)
         // swiftlint:disable:next force_try
         let creds = try! ClinikoCredentials(apiKey: "MS-test-au1", shard: .au1)
@@ -88,93 +98,164 @@ struct ExportFlowViewModelTests {
         )
     }
 
+    /// Run a test body with `URLProtocolStub` installed inside
+    /// `URLProtocolStubGate.shared.withGate`. The gate's outer closure is
+    /// `@Sendable` and runs off `@MainActor`; the user-supplied `body`
+    /// is `@MainActor @Sendable`, which lets the test mutate
+    /// `ExportFlowViewModel` (`@MainActor`-bound for SwiftUI) freely
+    /// while still being safe to capture across the gate boundary.
+    /// Replaces the historical pattern where `makeExporter` itself
+    /// installed the stub (#133, retired the suite-local `.serialized`
+    /// trait that used to protect this suite from cross-suite races
+    /// against `ModelDownloaderTests` and `ClinikoStatusThreadingTests`).
+    private func runGated(
+        responder: @escaping URLProtocolStub.Responder,
+        body: @MainActor @Sendable (URLSessionConfiguration) async throws -> Void
+    ) async throws {
+        try await URLProtocolStubGate.shared.withGate {
+            let config = URLProtocolStub.install(responder)
+            defer { URLProtocolStub.reset() }
+            try await body(config)
+        }
+    }
+
+    /// Polls `viewModel.state` every 5ms until it reaches a terminal
+    /// (`.succeeded` / `.failed`) state or `timeout` elapses. Replaces
+    /// fixed `Task.sleep`s in tests that drive `viewModel.confirm()`'s
+    /// async POST: now that #133 dropped the suite's `.serialized` trait,
+    /// the 24 install-using tests funnel sequentially through the gate
+    /// while the surrounding 40+ suites run in parallel — that CPU
+    /// contention used to push the async POST → state-transition past a
+    /// 100ms sleep window, surfacing as intermittent
+    /// "expected .failed/.succeeded, got .uploading" `Issue.record`s.
+    ///
+    /// The 5s timeout (vs. ~10ms expected runtime) is sized for
+    /// `@MainActor` saturation: under `--parallel` the project ships
+    /// 450+ tests across 44 suites, many `@MainActor`-isolated, all
+    /// competing for the single main-actor executor. The state
+    /// transition needs URLSession response delivery → ClinikoClient
+    /// async parse → MainActor hop, and each hop can be queued behind
+    /// other suites' `@MainActor` work.
+    ///
+    /// On timeout, records an `Issue` with the still-non-terminal state
+    /// so a future flake gives a clear signal. Without this, tests that
+    /// assert on a side-effect (e.g. `successfulExport_callsOnSuccess`
+    /// checking `clearedSession`) instead of `viewModel.state` would
+    /// silently mis-attribute a timeout to a logic regression.
+    private func waitForTerminal(
+        _ viewModel: ExportFlowViewModel,
+        timeout: TimeInterval = 5.0
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while true {
+            switch viewModel.state {
+            case .failed, .succeeded:
+                return
+            default:
+                // Check the deadline AFTER reading state so a transition
+                // landing on the very last loop iteration is not
+                // misreported as a timeout.
+                if Date() >= deadline { break }
+                try await Task.sleep(nanoseconds: 5_000_000)
+            }
+        }
+        Issue.record("waitForTerminal timed out after \(timeout)s; state=\(viewModel.state)")
+    }
+
     // MARK: - Confirming state
 
     @Test("enterConfirming transitions from idle and computes section counts")
-    func enterConfirming_buildsSummary() {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
+    func enterConfirming_buildsSummary() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
 
-        viewModel.enterConfirming()
+            viewModel.enterConfirming()
 
-        guard case .confirming(let summary) = viewModel.state else {
-            Issue.record("expected .confirming, got \(viewModel.state)")
-            return
+            guard case .confirming(let summary) = viewModel.state else {
+                Issue.record("expected .confirming, got \(viewModel.state)")
+                return
+            }
+            #expect(summary.patientID == OpaqueClinikoID(1001))
+            #expect(summary.patientDisplayName == "Sample Patient")
+            #expect(summary.sectionCounts.count == 4)
+            // The summary surfaces actual char counts so the
+            // confirmation UI can render "Subjective: 1 chars".
+            #expect(summary.sectionCounts.first(where: { $0.field == .subjective })?.charCount == 1)
+            // Existing appointment writes through to the picker as
+            // .appointment(...); the export-flow seed is .unset so the
+            // practitioner has to explicitly choose. (See doc on
+            // ExportFlowViewModel.buildSummary).
+            // Wait — actually the buildSummary code reads
+            // selectedAppointmentID and uses it as `.appointment(...)`
+            // when present. The test's session has appointmentID 5001,
+            // so we expect `.appointment(5001)`.
+            #expect(summary.appointment == .appointment(OpaqueClinikoID(5001)))
         }
-        #expect(summary.patientID == OpaqueClinikoID(1001))
-        #expect(summary.patientDisplayName == "Sample Patient")
-        #expect(summary.sectionCounts.count == 4)
-        // The summary surfaces actual char counts so the
-        // confirmation UI can render "Subjective: 1 chars".
-        #expect(summary.sectionCounts.first(where: { $0.field == .subjective })?.charCount == 1)
-        // Existing appointment writes through to the picker as
-        // .appointment(...); the export-flow seed is .unset so the
-        // practitioner has to explicitly choose. (See doc on
-        // ExportFlowViewModel.buildSummary).
-        // Wait — actually the buildSummary code reads
-        // selectedAppointmentID and uses it as `.appointment(...)`
-        // when present. The test's session has appointmentID 5001,
-        // so we expect `.appointment(5001)`.
-        #expect(summary.appointment == .appointment(OpaqueClinikoID(5001)))
     }
 
     @Test("enterConfirming with no active session transitions to .failed(.sessionState(.noActiveSession))")
-    func enterConfirming_noActiveSession_fails() {
-        let store = SessionStore() // no .start
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
+    func enterConfirming_noActiveSession_fails() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            let store = SessionStore() // no .start
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
 
-        viewModel.enterConfirming()
+            viewModel.enterConfirming()
 
-        if case .failed(.sessionState(.noActiveSession)) = viewModel.state {
-            // expected
-        } else {
-            Issue.record("expected .failed(.sessionState(.noActiveSession)), got \(viewModel.state)")
+            if case .failed(.sessionState(.noActiveSession)) = viewModel.state {
+                // expected
+            } else {
+                Issue.record("expected .failed(.sessionState(.noActiveSession)), got \(viewModel.state)")
+            }
         }
     }
 
     @Test("enterConfirming with no patient transitions to .failed(.sessionState(.noPatient))")
-    func enterConfirming_noPatient_fails() {
-        let store = SessionStore()
-        store.start(from: RecordingSession(language: "en", state: .completed))
-        // No setSelectedPatient call.
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
+    func enterConfirming_noPatient_fails() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            let store = SessionStore()
+            store.start(from: RecordingSession(language: "en", state: .completed))
+            // No setSelectedPatient call.
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
 
-        viewModel.enterConfirming()
+            viewModel.enterConfirming()
 
-        if case .failed(.sessionState(.noPatient)) = viewModel.state {
-            // expected
-        } else {
-            Issue.record("expected .failed(.sessionState(.noPatient)), got \(viewModel.state)")
+            if case .failed(.sessionState(.noPatient)) = viewModel.state {
+                // expected
+            } else {
+                Issue.record("expected .failed(.sessionState(.noPatient)), got \(viewModel.state)")
+            }
         }
     }
 
     // MARK: - setAppointmentSelection
 
     @Test("setAppointmentSelection updates the summary's appointment in place")
-    func setAppointmentSelection_updatesSummary() {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
+    func setAppointmentSelection_updatesSummary() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
 
-        viewModel.setAppointmentSelection(.general)
+            viewModel.setAppointmentSelection(.general)
 
-        guard case .confirming(let summary) = viewModel.state else {
-            Issue.record("expected .confirming")
-            return
+            guard case .confirming(let summary) = viewModel.state else {
+                Issue.record("expected .confirming")
+                return
+            }
+            #expect(summary.appointment == .general)
         }
-        #expect(summary.appointment == .general)
     }
 
     // MARK: - Confirm + happy path
 
     @Test("confirm + 201 transitions through .uploading → .succeeded")
     func confirm_201_succeeds() async throws {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { request in
+        try await runGated(responder: { request in
             let body = try HTTPStubFixture.load("cliniko/responses/treatment_notes_create.json")
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -183,27 +264,30 @@ struct ExportFlowViewModelTests {
                 headerFields: ["Content-Type": "application/json"]
             )!
             return (response, body)
+        }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            var onSuccessCalled = false
+            let viewModel = self.makeViewModel(
+                store: store,
+                exporter: exporter,
+                onSuccess: { onSuccessCalled = true }
+            )
+            viewModel.enterConfirming()
+
+            viewModel.confirm()
+
+            // Drive the async POST to completion.
+            try await self.waitForTerminal(viewModel)
+
+            guard case .succeeded(let report) = viewModel.state else {
+                Issue.record("expected .succeeded, got \(viewModel.state)")
+                return
+            }
+            #expect(report.createdNoteID == OpaqueClinikoID(9876543))
+            #expect(report.auditPersisted == true)
+            #expect(onSuccessCalled, "onSuccess hook fires on success")
         }
-        var onSuccessCalled = false
-        let viewModel = makeViewModel(
-            store: store,
-            exporter: exporter,
-            onSuccess: { onSuccessCalled = true }
-        )
-        viewModel.enterConfirming()
-
-        viewModel.confirm()
-
-        // Drive the async POST to completion.
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        guard case .succeeded(let report) = viewModel.state else {
-            Issue.record("expected .succeeded, got \(viewModel.state)")
-            return
-        }
-        #expect(report.createdNoteID == OpaqueClinikoID(9876543))
-        #expect(report.auditPersisted == true)
-        #expect(onSuccessCalled, "onSuccess hook fires on success")
     }
 
     /// Regression pin for #129's `appointmentIDMalformed` guard. After
@@ -214,48 +298,52 @@ struct ExportFlowViewModelTests {
     /// class of bug #127's `patientIDMalformed` guard closed off for
     /// the patient boundary.
     @Test("confirm with malformed appointment id fails with appointmentIDMalformed")
-    func confirm_malformedAppointmentID_fails() {
-        let store = SessionStore()
-        store.start(from: RecordingSession(language: "en", state: .completed))
-        store.setSelectedPatient(id: OpaqueClinikoID(1001), displayName: "Sample")
-        store.setDraftNotes(StructuredNotes(subjective: "s"))
-        // Appointment id with a non-numeric rawValue. Production never
-        // produces this (Cliniko emits numeric strings) but Codable
-        // round-trip from a tampered audit ledger or a future Cliniko
-        // shape change would. The `.appointment(...)` shape (vs
-        // `.unset` / `.general`) is what triggers the guard.
-        store.setSelectedAppointment(id: OpaqueClinikoID(rawValue: "not-numeric"))
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
+    func confirm_malformedAppointmentID_fails() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            let store = SessionStore()
+            store.start(from: RecordingSession(language: "en", state: .completed))
+            store.setSelectedPatient(id: OpaqueClinikoID(1001), displayName: "Sample")
+            store.setDraftNotes(StructuredNotes(subjective: "s"))
+            // Appointment id with a non-numeric rawValue. Production never
+            // produces this (Cliniko emits numeric strings) but Codable
+            // round-trip from a tampered audit ledger or a future Cliniko
+            // shape change would. The `.appointment(...)` shape (vs
+            // `.unset` / `.general`) is what triggers the guard.
+            store.setSelectedAppointment(id: OpaqueClinikoID(rawValue: "not-numeric"))
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
 
-        viewModel.confirm()
+            viewModel.confirm()
 
-        if case .failed(.sessionState(.appointmentIDMalformed)) = viewModel.state {
-            // expected
-        } else {
-            Issue.record("expected .failed(.sessionState(.appointmentIDMalformed)), got \(viewModel.state)")
+            if case .failed(.sessionState(.appointmentIDMalformed)) = viewModel.state {
+                // expected
+            } else {
+                Issue.record("expected .failed(.sessionState(.appointmentIDMalformed)), got \(viewModel.state)")
+            }
         }
     }
 
     @Test("confirm with .unset appointment fails with appointmentUnresolved")
-    func confirm_unsetAppointment_fails() {
-        let store = SessionStore()
-        store.start(from: RecordingSession(language: "en", state: .completed))
-        store.setSelectedPatient(id: OpaqueClinikoID(1001), displayName: "Sample")
-        store.setDraftNotes(StructuredNotes(subjective: "s"))
-        // No setSelectedAppointment — picker unset.
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
-        // The summary's appointment is `.unset` (no appointment
-        // ID set on the session). Calling confirm should bail.
-        viewModel.confirm()
+    func confirm_unsetAppointment_fails() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            let store = SessionStore()
+            store.start(from: RecordingSession(language: "en", state: .completed))
+            store.setSelectedPatient(id: OpaqueClinikoID(1001), displayName: "Sample")
+            store.setDraftNotes(StructuredNotes(subjective: "s"))
+            // No setSelectedAppointment — picker unset.
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
+            // The summary's appointment is `.unset` (no appointment
+            // ID set on the session). Calling confirm should bail.
+            viewModel.confirm()
 
-        if case .failed(.sessionState(.appointmentUnresolved)) = viewModel.state {
-            // expected
-        } else {
-            Issue.record("expected .failed(.sessionState(.appointmentUnresolved)), got \(viewModel.state)")
+            if case .failed(.sessionState(.appointmentUnresolved)) = viewModel.state {
+                // expected
+            } else {
+                Issue.record("expected .failed(.sessionState(.appointmentUnresolved)), got \(viewModel.state)")
+            }
         }
     }
 
@@ -297,39 +385,43 @@ struct ExportFlowViewModelTests {
 
     @Test("Transport error (offline) → .failed(.transport(.notConnectedToInternet))")
     func confirm_transport_offline() async throws {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { _ in
+        try await runGated(responder: { _ in
             throw URLError(.notConnectedToInternet)
-        }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
-        viewModel.confirm()
-        try await Task.sleep(nanoseconds: 100_000_000)
+        }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
+            viewModel.confirm()
+            try await self.waitForTerminal(viewModel)
 
-        if case .failed(.transport(.notConnectedToInternet)) = viewModel.state {
-            // expected
-        } else {
-            Issue.record("expected .failed(.transport(.notConnectedToInternet)), got \(viewModel.state)")
+            if case .failed(.transport(.notConnectedToInternet)) = viewModel.state {
+                // expected
+            } else {
+                Issue.record("expected .failed(.transport(.notConnectedToInternet)), got \(viewModel.state)")
+            }
         }
     }
 
     @Test("2xx + undecodable body → .failed(.responseUndecodable) — no auto-retry")
     func confirm_201_undecodable() async throws {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { request in
+        try await runGated(responder: { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: 201, httpVersion: nil, headerFields: nil)!
             return (response, Data("not json".utf8))
-        }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
-        viewModel.confirm()
-        try await Task.sleep(nanoseconds: 100_000_000)
+        }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
+            viewModel.confirm()
+            try await self.waitForTerminal(viewModel)
 
-        if case .failed(.responseUndecodable) = viewModel.state {
-            // expected — UI must NOT offer one-tap retry, the note
-            // may have landed on Cliniko's side.
-        } else {
-            Issue.record("expected .failed(.responseUndecodable), got \(viewModel.state)")
+            if case .failed(.responseUndecodable) = viewModel.state {
+                // expected — UI must NOT offer one-tap retry, the note
+                // may have landed on Cliniko's side.
+            } else {
+                Issue.record("expected .failed(.responseUndecodable), got \(viewModel.state)")
+            }
         }
     }
 
@@ -337,8 +429,7 @@ struct ExportFlowViewModelTests {
 
     @Test("429 → .failed(.rateLimited) seeds the countdown")
     func confirm_429_seedsCountdown() async throws {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { request in
+        try await runGated(responder: { request in
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: 429,
@@ -346,76 +437,89 @@ struct ExportFlowViewModelTests {
                 headerFields: ["Retry-After": "5"]
             )!
             return (response, Data())
-        }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
-        viewModel.confirm()
-        try await Task.sleep(nanoseconds: 200_000_000)
+        }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
+            viewModel.confirm()
+            try await self.waitForTerminal(viewModel)
 
-        if case .failed(.rateLimited(let retryAfter)) = viewModel.state {
-            #expect(retryAfter == 5)
-        } else {
-            Issue.record("expected .failed(.rateLimited), got \(viewModel.state)")
+            if case .failed(.rateLimited(let retryAfter)) = viewModel.state {
+                #expect(retryAfter == 5)
+            } else {
+                Issue.record("expected .failed(.rateLimited), got \(viewModel.state)")
+            }
+            // Countdown started — value should be set.
+            #expect((viewModel.rateLimitCountdownRemaining ?? 0) > 0)
         }
-        // Countdown started — value should be set.
-        #expect((viewModel.rateLimitCountdownRemaining ?? 0) > 0)
     }
 
     // MARK: - openClinikoSettings + copyToClipboard
 
     @Test("openClinikoSettings invokes the dependency callback")
-    func openClinikoSettings_invokesCallback() {
-        var called = false
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(
-            store: store,
-            exporter: exporter,
-            openClinikoSettings: { called = true }
-        )
+    func openClinikoSettings_invokesCallback() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            var called = false
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(
+                store: store,
+                exporter: exporter,
+                openClinikoSettings: { called = true }
+            )
 
-        viewModel.openClinikoSettings()
-        #expect(called)
+            viewModel.openClinikoSettings()
+            #expect(called)
+        }
     }
 
     @Test("copyNoteToClipboard invokes the dependency with the composed body")
-    func copyNoteToClipboard_invokesCallback() {
-        var captured: String?
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(
-            store: store,
-            exporter: exporter,
-            copyToClipboard: { body in captured = body }
-        )
+    func copyNoteToClipboard_invokesCallback() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            var captured: String?
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(
+                store: store,
+                exporter: exporter,
+                copyToClipboard: { body in captured = body }
+            )
 
-        viewModel.copyNoteToClipboard()
+            viewModel.copyNoteToClipboard()
 
-        // The composed body is non-empty for our seeded session.
-        #expect(captured?.isEmpty == false)
-        // Defensive: SOAP fields are present in the body.
-        #expect(captured?.contains("Subjective") == true || captured?.contains("S") == true)
+            // The composed body is non-empty for our seeded session.
+            #expect(captured?.isEmpty == false)
+            // Defensive: SOAP fields are present in the body.
+            #expect(captured?.contains("Subjective") == true || captured?.contains("S") == true)
+        }
     }
 
     // MARK: - cancelFromConfirming
 
     @Test("cancelFromConfirming returns to .idle")
-    func cancelFromConfirming_returnsToIdle() {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { _ in (HTTPURLResponse(), Data()) }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
+    func cancelFromConfirming_returnsToIdle() async throws {
+        try await runGated(responder: { _ in (HTTPURLResponse(), Data()) }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
 
-        viewModel.cancelFromConfirming()
+            viewModel.cancelFromConfirming()
 
-        if case .idle = viewModel.state {
-            // expected
-        } else {
-            Issue.record("expected .idle, got \(viewModel.state)")
+            if case .idle = viewModel.state {
+                // expected
+            } else {
+                Issue.record("expected .idle, got \(viewModel.state)")
+            }
         }
     }
 
     // MARK: - translate(_:) defaults
+
+    // The translate_* tests do NOT install `URLProtocolStub` — they call
+    // `ExportFlowViewModel.translate(_:)` directly and never construct
+    // an exporter or session. They are exempt from the gate.
 
     @Test("translate maps CancellationError to .cancelled")
     func translate_cancellationError_mapsToCancelled() {
@@ -453,8 +557,7 @@ struct ExportFlowViewModelTests {
 
     @Test("Successful export drives onSuccess (which clears the session in production)")
     func successfulExport_callsOnSuccess() async throws {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { request in
+        try await runGated(responder: { request in
             let body = try HTTPStubFixture.load("cliniko/responses/treatment_notes_create.json")
             let response = HTTPURLResponse(
                 url: request.url!,
@@ -463,22 +566,25 @@ struct ExportFlowViewModelTests {
                 headerFields: ["Content-Type": "application/json"]
             )!
             return (response, body)
-        }
-        var clearedSession = false
-        let viewModel = makeViewModel(
-            store: store,
-            exporter: exporter,
-            onSuccess: {
-                store.clear()
-                clearedSession = true
-            }
-        )
-        viewModel.enterConfirming()
-        viewModel.confirm()
-        try await Task.sleep(nanoseconds: 200_000_000)
+        }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            var clearedSession = false
+            let viewModel = self.makeViewModel(
+                store: store,
+                exporter: exporter,
+                onSuccess: {
+                    store.clear()
+                    clearedSession = true
+                }
+            )
+            viewModel.enterConfirming()
+            viewModel.confirm()
+            try await self.waitForTerminal(viewModel)
 
-        #expect(clearedSession)
-        #expect(store.active == nil)
+            #expect(clearedSession)
+            #expect(store.active == nil)
+        }
     }
 
     // MARK: - Helpers
@@ -490,24 +596,24 @@ struct ExportFlowViewModelTests {
     private func assertConfirmFailsWith(
         _ expected: ExportFailure,
         status: Int,
-        body: Data = Data(),
-        file: String = #file,
-        line: Int = #line
+        body: Data = Data()
     ) async throws {
-        let store = makeSessionForConfirmingTest()
-        let exporter = makeExporter { request in
+        try await runGated(responder: { request in
             let response = HTTPURLResponse(url: request.url!, statusCode: status, httpVersion: nil, headerFields: nil)!
             return (response, body)
-        }
-        let viewModel = makeViewModel(store: store, exporter: exporter)
-        viewModel.enterConfirming()
-        viewModel.confirm()
-        try await Task.sleep(nanoseconds: 100_000_000)
+        }) { config in
+            let store = self.makeSessionForConfirmingTest()
+            let exporter = self.makeExporter(config: config)
+            let viewModel = self.makeViewModel(store: store, exporter: exporter)
+            viewModel.enterConfirming()
+            viewModel.confirm()
+            try await self.waitForTerminal(viewModel)
 
-        guard case .failed(let actual) = viewModel.state else {
-            Issue.record("expected .failed(\(expected)), got \(viewModel.state)")
-            return
+            guard case .failed(let actual) = viewModel.state else {
+                Issue.record("expected .failed(\(expected)), got \(viewModel.state)")
+                return
+            }
+            #expect(actual == expected)
         }
-        #expect(actual == expected)
     }
 }


### PR DESCRIPTION
## Summary

- Wraps the 24 install-using `@Test` bodies in `ExportFlowViewModelTests` through `URLProtocolStubGate.shared.withGate` via a private `runGated(responder:body:)` helper. The body is `@MainActor @Sendable` so the test stays on `@MainActor` (SwiftUI binding requirement) while the gate's outer body runs off it. The four `translate_*` tests stay outside the gate — they don't install. `.serialized` dropped per the issue body.
- Adds a `waitForTerminal(_:timeout:)` polling helper that replaces fixed `Task.sleep`s. The gate-induced parallelism plus 450+ tests across 44 suites under `--parallel` saturates `@MainActor` — the async POST → state-transition reliably exceeded 100ms. Helper polls every 5ms with a 5s timeout, `Issue.record`s the still-non-terminal state on timeout, and reads state once more after the loop so a transition landing on the last iteration is not misreported.
- Retires the carve-outs in `URLProtocolStubGate.swift` doc-comment and `.claude/references/testing-conventions.md` §"Known gap"; adds `ExportFlowViewModelTests` to the adopter list with the `@MainActor` × `@Sendable` resolution noted.

Closes #133.

## Stress test

10× full `swift test --parallel` runs after the polling-helper off-by-one fix: 10/10 clean. The diagnostic on a timeout (which we hit twice during iteration) gave a clear signal — `waitForTerminal timed out after 5.0s; state=.uploading` — instead of the misleading "expected .failed, got .uploading" that the bare `guard case` would otherwise have surfaced.

## Test plan

- [x] `swift test --filter ExportFlowViewModelTests` — 24/24 pass
- [x] `swift test --parallel --filter "ExportFlowViewModel|ModelDownloaderTests|ClinikoStatusThreadingTests"` — 44/44 pass (3 gated suites concurrent)
- [x] `swift test --parallel` — full suite, 10× stress runs, no ExportFlow flake (`WakeWordServiceTests` model-not-found failures are pre-existing `.requiresHardware` artifacts unrelated to this PR)
- [x] Pre-PR review: `pr-review-toolkit:code-reviewer` + `pr-review-toolkit:silent-failure-hunter` (both Opus). One Should-fix applied (silent timeout → `Issue.record` on timeout) before push.
- [x] `pre-commit run --files <touched>` — clean
- [ ] Gemini Code Assist (automated, on PR open)

References: AGENTS.md §"Subagents & code review" three-layer pipeline; `.claude/references/testing-conventions.md` §"URLProtocolStub process-wide gate".

🤖 Generated with [Claude Code](https://claude.com/claude-code)