### PR TITLE
fix(cliniko): make User-Agent contact email configurable from settings (#89)

### DIFF
--- a/.claude/references/cliniko-api.md
+++ b/.claude/references/cliniko-api.md
@@ -18,14 +18,35 @@ and the [official Cliniko API docs](https://docs.api.cliniko.com/).
   - `SecureStore` service identifier: `"com.speechtotext.cliniko"`.
   - Account: `"api_key"`.
   - Accessibility: `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` (no iCloud sync).
-- **Shard / subdomain** (non-secret): stored in `UserDefaults`.
+- **Shard / subdomain** (non-secret): stored in `UserDefaults` under
+  `cliniko.shard`.
   - Example values: `au1`, `au2`, `au3`, `au4`, `uk1`, `uk2`, `ca1`, `us1`.
   - Used to build the base URL: `https://api.{shard}.cliniko.com/v1`.
+- **Contact email** (non-secret, #89): stored in `UserDefaults` under
+  `cliniko.contactEmail`. The practitioner enters this in the Clinical
+  Notes settings UI; `ClinikoUserAgent.defaultProvider()` reads it on every
+  request to build the `User-Agent`. Not in Keychain — it's a contact
+  reference Cliniko ops can reach the integration owner on, not
+  authentication material.
 - **Auth scheme**: HTTP Basic with `"{api_key}:"` (the empty password is
   deliberate — Cliniko uses the API key as the username).
 - **Required headers** (per Cliniko docs):
-  - `User-Agent: mac-speech-to-text/<version> (contact@example.test)` —
-    Cliniko requires a contact email; plumb through a setting if needed.
+  - `User-Agent`: built by [`ClinikoUserAgent.make(contactEmail:)`](../../Sources/Services/Cliniko/ClinikoUserAgent.swift).
+    Cliniko requires "a name and valid contact email" or they reserve the
+    right to auto-block. Two emitted shapes:
+    - **Configured (preferred):** `mac-speech-to-text (user@example.test)`
+      — matches Cliniko's docs example + the sibling `epc-letter-generation`
+      reference. The practitioner enters their own email in
+      Clinical Notes settings (#89); it lives in `UserDefaults` under
+      `cliniko.contactEmail` and is read per-request via
+      `ClinikoUserAgent.defaultProvider()`, so a settings change takes
+      effect on the next request without re-instantiating `ClinikoClient`
+      / `ClinikoAuthProbe`.
+    - **Fallback (no email yet):**
+      `mac-speech-to-text/<version> (https://github.com/CloudbrokerAz/mac-speech-to-text)`.
+      Keeps the structural name + contact-reference contract satisfied
+      until the doctor sets an email; the latent auto-block risk only
+      applies in the un-configured window.
   - `Accept: application/json`.
 
 ---
@@ -132,5 +153,6 @@ Every successful export writes a metadata-only line to
 - `Sources/Services/Cliniko/ClinikoClient.swift` — actor + URLSession.
 - `Sources/Services/Cliniko/ClinikoEndpoint.swift` — endpoint enum.
 - `Sources/Services/Cliniko/ClinikoError.swift` — typed errors.
+- `Sources/Services/Cliniko/ClinikoUserAgent.swift` — `User-Agent` builder + provider closure (#89).
 - `Sources/Services/Cliniko/AuditStore.swift` — metadata-only audit log.
 - `Tests/SpeechToTextTests/Fixtures/cliniko/` — request + response goldens.

--- a/Sources/Services/Cliniko/ClinikoAuthProbe.swift
+++ b/Sources/Services/Cliniko/ClinikoAuthProbe.swift
@@ -42,22 +42,31 @@ public enum ClinikoAuthProbeError: Error, Sendable, Equatable, CustomStringConve
 /// the response body is non-PHI. Logs still avoid the response body and any
 /// URL details — only the structural status / error case is emitted.
 public actor ClinikoAuthProbe {
-    /// Default `User-Agent` exposed for tests. Cliniko requires the header to
-    /// be non-empty and to embed a contact reference per their docs (see
-    /// `.claude/references/cliniko-api.md`); we publish the app version plus
-    /// the public repository URL so Cliniko ops can reach the project on
-    /// abuse / incident.
-    public static var defaultUserAgent: String {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-        return "mac-speech-to-text/\(version) (https://github.com/CloudbrokerAz/mac-speech-to-text)"
+    private let session: URLSession
+    /// `@Sendable () -> String` so the UA is resolved per request rather
+    /// than frozen at init. The doctor edits their contact email in the
+    /// Clinical Notes settings UI (#89); the default provider reads
+    /// `ClinikoCredentialStore.contactEmailUserDefaultsKey` from
+    /// `UserDefaults.standard`, so an email change takes effect on the
+    /// next probe without re-instantiating the actor.
+    private let userAgentProvider: @Sendable () -> String
+
+    public init(
+        session: URLSession = .shared,
+        userAgentProvider: @escaping @Sendable () -> String = ClinikoUserAgent.defaultProvider()
+    ) {
+        self.session = session
+        self.userAgentProvider = userAgentProvider
     }
 
-    private let session: URLSession
-    private let userAgent: String
-
-    public init(session: URLSession = .shared, userAgent: String? = nil) {
-        self.session = session
-        self.userAgent = userAgent ?? Self.defaultUserAgent
+    /// Convenience init for tests that pin a specific `User-Agent` string.
+    /// Wraps the literal in a `@Sendable` closure so call sites that don't
+    /// care about runtime UA reconfiguration stay terse.
+    public init(
+        session: URLSession = .shared,
+        userAgent: String
+    ) {
+        self.init(session: session, userAgentProvider: { userAgent })
     }
 
     /// Issue `GET /user` against Cliniko using `credentials`. Returns
@@ -68,7 +77,7 @@ public actor ClinikoAuthProbe {
         var request = URLRequest(url: credentials.baseURL.appendingPathComponent("user"))
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue(userAgentProvider(), forHTTPHeaderField: "User-Agent")
         request.setValue(credentials.basicAuthHeaderValue, forHTTPHeaderField: "Authorization")
         request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
 

--- a/Sources/Services/Cliniko/ClinikoClient.swift
+++ b/Sources/Services/Cliniko/ClinikoClient.swift
@@ -20,15 +20,6 @@ import os.log
 ///   (anything from another framework that might embed PHI) are **never**
 ///   logged.
 public actor ClinikoClient {
-    /// Default `User-Agent`. Mirrors `ClinikoAuthProbe.defaultUserAgent`
-    /// — Cliniko requires the header to be non-empty and include a contact
-    /// reference. We use the public repo URL so Cliniko ops can reach the
-    /// project for abuse / incident.
-    public static var defaultUserAgent: String {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
-        return "mac-speech-to-text/\(version) (https://github.com/CloudbrokerAz/mac-speech-to-text)"
-    }
-
     /// Default JSON decoder: snake_case → camelCase + ISO8601 dates. Suitable
     /// for the documented Cliniko response shapes; consumers can supply a
     /// custom decoder for endpoints that need different strategies.
@@ -80,7 +71,15 @@ public actor ClinikoClient {
 
     private let credentials: ClinikoCredentials
     private let session: URLSession
-    private let userAgent: String
+    /// `@Sendable () -> String` so the UA is resolved per request rather
+    /// than frozen at init. The doctor edits their contact email in the
+    /// Clinical Notes settings UI (#89); the default provider reads
+    /// `ClinikoCredentialStore.contactEmailUserDefaultsKey` from
+    /// `UserDefaults.standard`, so an email change takes effect on the
+    /// next request without re-instantiating this client (which is shared
+    /// across `ClinikoPatientService`, `ClinikoAppointmentService`, and
+    /// `TreatmentNoteExporter`).
+    private let userAgentProvider: @Sendable () -> String
     private let retryPolicy: RetryPolicy
     private let decoder: JSONDecoder
     private let logger = Logger(subsystem: "com.speechtotext", category: "ClinikoClient")
@@ -105,15 +104,34 @@ public actor ClinikoClient {
     public init(
         credentials: ClinikoCredentials,
         session: URLSession = .shared,
-        userAgent: String = ClinikoClient.defaultUserAgent,
+        userAgentProvider: @escaping @Sendable () -> String = ClinikoUserAgent.defaultProvider(),
         retryPolicy: RetryPolicy = .default,
         decoder: JSONDecoder = ClinikoClient.defaultDecoder
     ) {
         self.credentials = credentials
         self.session = session
-        self.userAgent = userAgent
+        self.userAgentProvider = userAgentProvider
         self.retryPolicy = retryPolicy
         self.decoder = decoder
+    }
+
+    /// Convenience init for tests that pin a specific `User-Agent` string.
+    /// Wraps the literal in a `@Sendable` closure so call sites that don't
+    /// care about runtime UA reconfiguration stay terse.
+    public init(
+        credentials: ClinikoCredentials,
+        session: URLSession = .shared,
+        userAgent: String,
+        retryPolicy: RetryPolicy = .default,
+        decoder: JSONDecoder = ClinikoClient.defaultDecoder
+    ) {
+        self.init(
+            credentials: credentials,
+            session: session,
+            userAgentProvider: { userAgent },
+            retryPolicy: retryPolicy,
+            decoder: decoder
+        )
     }
 
     // MARK: - Public API
@@ -340,7 +358,7 @@ public actor ClinikoClient {
         var request = URLRequest(url: url)
         request.httpMethod = endpoint.method.rawValue
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue(userAgentProvider(), forHTTPHeaderField: "User-Agent")
         request.setValue(credentials.basicAuthHeaderValue, forHTTPHeaderField: "Authorization")
         request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         if let body = endpoint.body {

--- a/Sources/Services/Cliniko/ClinikoCredentialStore.swift
+++ b/Sources/Services/Cliniko/ClinikoCredentialStore.swift
@@ -27,6 +27,14 @@ public actor ClinikoCredentialStore {
     /// `UserDefaults` key for the shard rawValue. Non-PHI structural value.
     public static let shardUserDefaultsKey = "cliniko.shard"
 
+    /// `UserDefaults` key for the practitioner's contact email used in the
+    /// `User-Agent` header sent to Cliniko (issue #89). Non-secret, doctor
+    /// configurable from the Clinical Notes settings UI; lives alongside the
+    /// shard rather than in Keychain because it is not authentication
+    /// material — it is the contact reference Cliniko's docs require so they
+    /// can reach the integration owner about abuse / incident.
+    public static let contactEmailUserDefaultsKey = "cliniko.contactEmail"
+
     /// Errors surfaced from this store. Cases are semantic — callers can
     /// pattern-match on the operation that failed and inspect the wrapped
     /// `SecureStore` failure when they need the underlying `OSStatus`. This
@@ -146,6 +154,45 @@ public actor ClinikoCredentialStore {
     /// from the picker should not require an actor hop / `Task`.
     public nonisolated func updateShard(_ shard: ClinikoShard) {
         userDefaults.set(shard.rawValue, forKey: Self.shardUserDefaultsKey)
+    }
+
+    /// Returns the persisted contact email used in the Cliniko `User-Agent`
+    /// header, or `nil` if unset / empty after trim. Marked `nonisolated`
+    /// because the UA builder (called from inside `ClinikoClient` /
+    /// `ClinikoAuthProbe` actors per request) must read it without an actor
+    /// hop. Returning `nil` for whitespace-only input keeps the UA shape
+    /// rule "if you set an email, you get the email form" honest.
+    public nonisolated func loadContactEmail() -> String? {
+        return Self.loadContactEmail(from: userDefaults)
+    }
+
+    /// Static convenience for callers that need the contact email without
+    /// holding a `ClinikoCredentialStore` reference — used by
+    /// `ClinikoUserAgent.defaultProvider()` so the UA-builder path doesn't
+    /// instantiate a Keychain handle just to read a `UserDefaults` string.
+    /// Returns `nil` if unset or whitespace-only after trim.
+    public static func loadContactEmail(from userDefaults: UserDefaults) -> String? {
+        let raw = userDefaults.string(forKey: contactEmailUserDefaultsKey)
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Persist the practitioner's contact email. Pass `nil` (or whitespace-
+    /// only) to clear. Trims input. Marked `nonisolated` for the same reason
+    /// as `loadContactEmail` — the settings TextField commit binding stays
+    /// synchronous.
+    ///
+    /// Not cleared by `deleteCredentials`: the email is a preference about
+    /// who Cliniko should contact, not material tied to the API key. A
+    /// doctor who rotates their key shouldn't have to re-enter their own
+    /// contact.
+    public nonisolated func updateContactEmail(_ email: String?) {
+        let trimmed = email?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            userDefaults.removeObject(forKey: Self.contactEmailUserDefaultsKey)
+        } else {
+            userDefaults.set(trimmed, forKey: Self.contactEmailUserDefaultsKey)
+        }
     }
 
     /// Delete every Cliniko credential and forget the shard. The Keychain

--- a/Sources/Services/Cliniko/ClinikoUserAgent.swift
+++ b/Sources/Services/Cliniko/ClinikoUserAgent.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Builds the `User-Agent` header value Cliniko expects on every request
+/// (see https://docs.api.cliniko.com/ + `.claude/references/cliniko-api.md`).
+///
+/// Cliniko's docs warn:
+/// > "If your requests do not include a User-Agent that contains a name and
+/// > valid contact email, future requests may be automatically blocked."
+///
+/// To honour that without baking a single hardcoded address into the source
+/// (issue #89), the practitioner enters their own monitored email in the
+/// Clinical Notes settings; it lives in `UserDefaults` under
+/// `ClinikoCredentialStore.contactEmailUserDefaultsKey`. Two emitted shapes:
+///
+/// - **Configured (preferred):** `"mac-speech-to-text (user@example.com)"` —
+///   matches the canonical `APP_VENDOR_NAME (APP_VENDOR_EMAIL)` form in
+///   Cliniko's docs and the sibling reference integration
+///   (`EpcLetterGenerator (support@epclettergen.app)` from
+///   `epc-letter-generation`).
+/// - **Fallback (no email yet):** `"mac-speech-to-text/<version>
+///   (https://github.com/CloudbrokerAz/mac-speech-to-text)"`. The structural
+///   contract — non-empty name + a contact reference — stays satisfied while
+///   we wait for the doctor to set their email. The latent auto-block risk
+///   Cliniko's docs warn about therefore only applies in the un-configured
+///   window, not as a permanent regression.
+public enum ClinikoUserAgent {
+    /// App name component shared by both shapes. Centralised so a future
+    /// rename only happens here.
+    public static let appName = "mac-speech-to-text"
+
+    /// Public repo URL — only used by the no-email fallback.
+    public static let fallbackContactURL = "https://github.com/CloudbrokerAz/mac-speech-to-text"
+
+    /// Build the header value. `contactEmail` is the trimmed value the user
+    /// entered in Settings (or `nil` if unset). Whitespace-only inputs are
+    /// treated as `nil` so an accidentally-saved blank field doesn't emit
+    /// `"mac-speech-to-text ()"`.
+    public static func make(contactEmail: String?) -> String {
+        let trimmed = contactEmail?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmed.isEmpty {
+            return "\(appName) (\(trimmed))"
+        }
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+        return "\(appName)/\(version) (\(fallbackContactURL))"
+    }
+
+    /// `@Sendable` closure suitable for `ClinikoClient` /
+    /// `ClinikoAuthProbe`'s `userAgentProvider` parameter. Reads the email
+    /// from `userDefaults` *per call* so a settings change propagates to
+    /// the next request without re-instantiating either actor — important
+    /// because a single `ClinikoClient` is shared by
+    /// `ClinikoPatientService`, `ClinikoAppointmentService`, and
+    /// `TreatmentNoteExporter` (see
+    /// `AppState.configureClinikoExportPipelineIfNeeded`).
+    ///
+    /// The `userDefaults` parameter exists so tests can inject a per-suite
+    /// `UserDefaults` and avoid mutating the shared standard suite — that
+    /// would race `SessionStoreTests.lifecycle_doesNotTouchUserDefaults`
+    /// under `swift test --parallel`. Production callers take the default.
+    public static func defaultProvider(
+        userDefaults: UserDefaults = .standard
+    ) -> @Sendable () -> String {
+        return { @Sendable [userDefaults] in
+            ClinikoUserAgent.make(
+                contactEmail: ClinikoCredentialStore.loadContactEmail(from: userDefaults)
+            )
+        }
+    }
+}

--- a/Sources/Services/Cliniko/TreatmentNoteExporter.swift
+++ b/Sources/Services/Cliniko/TreatmentNoteExporter.swift
@@ -83,7 +83,10 @@ actor TreatmentNoteExporter {
 
     /// Marketing version for the active build, with a deterministic
     /// fallback when running outside an `.app` bundle (i.e. during
-    /// `swift test`). Mirrors `ClinikoClient.defaultUserAgent`.
+    /// `swift test`). Same `CFBundleShortVersionString` lookup the
+    /// `ClinikoUserAgent` fallback path uses, kept in lockstep so the
+    /// audit-ledger row's `app_version` matches what Cliniko sees in the
+    /// `User-Agent` header for the unconfigured-email case.
     static var defaultAppVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
     }

--- a/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
@@ -73,6 +73,8 @@ struct ClinicalNotesSection: View {
 
                 shardPickerSection
 
+                contactEmailEntrySection
+
                 actionButtons
 
                 if let message = viewModel.statusMessage {
@@ -408,6 +410,52 @@ struct ClinicalNotesSection: View {
         }
     }
 
+    // MARK: - Contact Email Entry (#89)
+
+    /// Editable email used in the Cliniko `User-Agent` header. Cliniko's
+    /// docs require a contact reference Cliniko ops can reach the
+    /// integration owner on; storing it as a settings value rather than
+    /// hardcoding it lets each practitioner publish their own address.
+    /// The value persists on every keystroke via the VM's `didSet` — no
+    /// explicit "save" gesture, mirroring how `selectedShard` commits
+    /// inline.
+    private var contactEmailEntrySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Contact email")
+                .font(.subheadline)
+                .fontWeight(.medium)
+                .foregroundStyle(.secondary)
+
+            TextField(
+                "you@yourclinic.example",
+                text: $viewModel.contactEmailDraft
+            )
+            .textFieldStyle(.roundedBorder)
+            .disableAutocorrection(true)
+            .textContentType(.emailAddress)
+            .accessibilityIdentifier("clinicalNotesSection.contactEmailField")
+
+            // Soft validation feedback only. A malformed entry still
+            // persists and goes out in the UA — Cliniko's docs request a
+            // "valid contact email" but don't policy-validate, and we'd
+            // rather not block save on our heuristic. The hint nudges the
+            // practitioner; the orange triangle matches the warm-minimalism
+            // colour story in `KeywordEditorSheet` for unsupported input.
+            let trimmedDraft = viewModel.contactEmailDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedDraft.isEmpty, !viewModel.isContactEmailDraftValid {
+                Label("That doesn't look like a valid email address", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .accessibilityIdentifier("clinicalNotesSection.contactEmailField.invalidHint")
+            }
+
+            Text("Cliniko's API requires a contact email so they can reach you about integration issues. This Mac sends it in the User-Agent header on every Cliniko request.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     // MARK: - Action Buttons
 
     private var actionButtons: some View {
@@ -604,6 +652,34 @@ final class ClinicalNotesSectionViewModel {
         }
     }
 
+    /// The practitioner's contact email (#89). Embedded in the Cliniko
+    /// `User-Agent` header so Cliniko ops can reach the integration owner
+    /// about abuse / incident. Persists to `UserDefaults` via
+    /// `ClinikoCredentialStore.updateContactEmail` on every change so the
+    /// value survives a quit even mid-typing — UserDefaults writes are
+    /// cheap and the worst-case cost is one stale partial during typing.
+    var contactEmailDraft: String = "" {
+        didSet {
+            guard oldValue != contactEmailDraft, !isApplyingExternalUpdate else { return }
+            credentialStore.updateContactEmail(contactEmailDraft)
+        }
+    }
+
+    /// Loose RFC 5321 sanity check — has at least one `@`, with non-empty
+    /// local + domain parts and a `.` somewhere in the domain. Cliniko
+    /// doesn't enforce a format (the docs say "valid contact email" but
+    /// don't policy-validate), so we only use this to drive a soft
+    /// orange-warning hint, never to block save. A malformed entry still
+    /// stores and emits in the UA — at worst Cliniko will eventually flag
+    /// the integration owner about it.
+    var isContactEmailDraftValid: Bool {
+        let trimmed = contactEmailDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true } // empty = unset, not invalid
+        let parts = trimmed.split(separator: "@", omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return false }
+        return parts[1].contains(".")
+    }
+
     private(set) var credentialState: CredentialLoadState = .unknown
     private(set) var verificationStatus: VerificationStatus = .absent
     private(set) var connectionStatus: ConnectionStatus = .idle
@@ -638,7 +714,23 @@ final class ClinicalNotesSectionViewModel {
     /// Called from `.task { … }` on the section view.
     func refreshState() async {
         let shard = credentialStore.loadShard()
-        applyExternalUpdate { self.selectedShard = shard }
+        let storedContactEmail = credentialStore.loadContactEmail() ?? ""
+        applyExternalUpdate {
+            self.selectedShard = shard
+            // Hydrate the contact-email draft from disk so the field shows
+            // the persisted value on next visit. The `applyExternalUpdate`
+            // guard prevents the didSet from echoing back to the store.
+            //
+            // Equality-guard the assignment so a future call site that
+            // re-runs `refreshState` while the field is focused (e.g.
+            // post-probe refresh) cannot clobber an in-flight draft that
+            // already matches disk. Today's only trigger is `.task` on
+            // view-appear, which fires before the field exists, so this
+            // is belt-and-braces against future regressions.
+            if self.contactEmailDraft != storedContactEmail {
+                self.contactEmailDraft = storedContactEmail
+            }
+        }
 
         do {
             let present = try await credentialStore.hasAPIKey()

--- a/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
+++ b/Sources/Views/MainView/Sections/ClinicalNotesSection.swift
@@ -441,8 +441,9 @@ struct ClinicalNotesSection: View {
             // rather not block save on our heuristic. The hint nudges the
             // practitioner; the orange triangle matches the warm-minimalism
             // colour story in `KeywordEditorSheet` for unsupported input.
-            let trimmedDraft = viewModel.contactEmailDraft.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmedDraft.isEmpty, !viewModel.isContactEmailDraftValid {
+            // VM owns the policy via `shouldShowContactEmailInvalidHint` so
+            // the trim + validity rules live in one place (DRY — Gemini #137).
+            if viewModel.shouldShowContactEmailInvalidHint {
                 Label("That doesn't look like a valid email address", systemImage: "exclamationmark.triangle.fill")
                     .font(.caption)
                     .foregroundStyle(.orange)
@@ -672,12 +673,26 @@ final class ClinicalNotesSectionViewModel {
     /// orange-warning hint, never to block save. A malformed entry still
     /// stores and emits in the UA — at worst Cliniko will eventually flag
     /// the integration owner about it.
+    ///
+    /// Empty / whitespace-only is treated as "unset" (returns `true` — not
+    /// invalid). Pair with `shouldShowContactEmailInvalidHint` to drive UI
+    /// — that combined property is what the view binds to so the hint logic
+    /// lives in one place.
     var isContactEmailDraftValid: Bool {
         let trimmed = contactEmailDraft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return true } // empty = unset, not invalid
         let parts = trimmed.split(separator: "@", omittingEmptySubsequences: false)
         guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return false }
         return parts[1].contains(".")
+    }
+
+    /// Drives the orange-triangle warning under the contact-email field.
+    /// Combines "user has typed something" + "it doesn't look valid", so
+    /// the view doesn't need to re-trim or re-check (DRY — keeps the
+    /// hint policy in the VM where the format rule lives).
+    var shouldShowContactEmailInvalidHint: Bool {
+        let trimmed = contactEmailDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && !isContactEmailDraftValid
     }
 
     private(set) var credentialState: CredentialLoadState = .unknown

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAuthProbeTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoAuthProbeTests.swift
@@ -59,13 +59,72 @@ final class ClinikoAuthProbeTests: XCTestCase {
         XCTAssertEqual(decoded, "MS-test-au1:", "Cliniko Basic auth: API key as username + empty password")
     }
 
-    func test_defaultUserAgent_includesAppNameAndContactReference() {
-        // Pins the User-Agent shape required by `.claude/references/cliniko-api.md`:
-        // app name + version + a contact reference (we use the public repo URL).
-        let ua = ClinikoAuthProbe.defaultUserAgent
+    // MARK: - User-Agent shape
+
+    func test_userAgent_emailFormUsedWhenContactEmailConfigured() {
+        // AC item 1 of #89: when the practitioner has set a contact email
+        // in Clinical Notes settings, the UA emits the canonical Cliniko
+        // `APP_VENDOR_NAME (APP_VENDOR_EMAIL)` form (matches the docs
+        // example + the `epc-letter-generation` reference integration).
+        let ua = ClinikoUserAgent.make(contactEmail: "doctor@example.test")
+        XCTAssertEqual(ua, "mac-speech-to-text (doctor@example.test)")
+    }
+
+    func test_userAgent_fallbackUsedWhenContactEmailMissing() {
+        // Fallback contract: until the doctor sets an email, we must still
+        // emit a non-empty UA carrying app name + a contact reference, so
+        // the structural pinning in `.claude/references/cliniko-api.md`
+        // and Cliniko's docs-required name+contact rule both stay
+        // satisfied.
+        let ua = ClinikoUserAgent.make(contactEmail: nil)
         XCTAssertTrue(ua.hasPrefix("mac-speech-to-text/"), "got \(ua)")
         XCTAssertTrue(ua.contains("github.com/CloudbrokerAz/mac-speech-to-text"),
-                      "User-Agent must embed a contact reference; got \(ua)")
+                      "fallback User-Agent must embed a contact reference; got \(ua)")
+    }
+
+    func test_userAgent_whitespaceOnlyEmailTreatedAsMissing() {
+        // Defensive: a whitespace-only saved value must not produce
+        // `"mac-speech-to-text ()"`. We treat it as unset and fall back.
+        let ua = ClinikoUserAgent.make(contactEmail: "   \t  ")
+        XCTAssertTrue(ua.contains("github.com/CloudbrokerAz/mac-speech-to-text"),
+                      "whitespace-only email must trigger the URL fallback; got \(ua)")
+    }
+
+    func test_userAgent_trimsLeadingAndTrailingWhitespace() {
+        // The UI commit binding trims, but the helper trims defensively too
+        // so a programmatic caller can't accidentally emit
+        // `"mac-speech-to-text ( doctor@example.test )"`.
+        let ua = ClinikoUserAgent.make(contactEmail: "  doctor@example.test  ")
+        XCTAssertEqual(ua, "mac-speech-to-text (doctor@example.test)")
+    }
+
+    func test_defaultProvider_readsContactEmailFromUserDefaultsLive() throws {
+        // Pins the read-per-request behaviour: a contact-email update in
+        // `UserDefaults` must propagate to the next provider() call without
+        // reseating the closure. This is the load-bearing property that
+        // lets the shared ClinikoClient/AuthProbe instances pick up a
+        // settings change without re-instantiation (see #89 plan).
+        //
+        // Uses a per-test `UserDefaults` suite (NOT `.standard`) so this
+        // test does not race `SessionStoreTests.lifecycle_doesNotTouchUserDefaults`
+        // — that test snapshots `UserDefaults.standard.dictionaryRepresentation()`
+        // and would flake if a parallel test mutated the shared suite mid-window.
+        let suiteName = "ClinikoUserAgentTests-\(UUID().uuidString)"
+        let suite = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { suite.removePersistentDomain(forName: suiteName) }
+        let key = ClinikoCredentialStore.contactEmailUserDefaultsKey
+
+        suite.set("first@example.test", forKey: key)
+        let provider = ClinikoUserAgent.defaultProvider(userDefaults: suite)
+        XCTAssertEqual(provider(), "mac-speech-to-text (first@example.test)")
+
+        suite.set("second@example.test", forKey: key)
+        XCTAssertEqual(provider(), "mac-speech-to-text (second@example.test)",
+                       "provider must re-read UserDefaults each call so a settings change propagates without re-instantiation")
+
+        suite.removeObject(forKey: key)
+        XCTAssertTrue(provider().contains("github.com/CloudbrokerAz/mac-speech-to-text"),
+                      "clearing the email must fall back to URL form; got \(provider())")
     }
 
     func test_ping_succeedsOn200() async throws {

--- a/Tests/SpeechToTextTests/Services/Cliniko/ClinikoCredentialStoreTests.swift
+++ b/Tests/SpeechToTextTests/Services/Cliniko/ClinikoCredentialStoreTests.swift
@@ -183,6 +183,85 @@ struct ClinikoCredentialStoreTests {
         #expect(storedShard == "uk2", "shard must be retained when Keychain delete fails")
     }
 
+    // MARK: - Contact email (#89)
+
+    @Test("loadContactEmail returns nil when nothing is stored")
+    func loadContactEmailEmpty() {
+        let store = makeStore()
+        #expect(store.loadContactEmail() == nil)
+    }
+
+    @Test("updateContactEmail + loadContactEmail round-trip")
+    func contactEmailRoundTrip() {
+        let userDefaults = makeUserDefaults()
+        let store = makeStore(userDefaults: userDefaults)
+
+        store.updateContactEmail("doctor@example.test")
+        #expect(store.loadContactEmail() == "doctor@example.test")
+        #expect(userDefaults.string(forKey: ClinikoCredentialStore.contactEmailUserDefaultsKey)
+                == "doctor@example.test")
+    }
+
+    @Test("updateContactEmail trims whitespace before storing")
+    func contactEmailTrims() {
+        let userDefaults = makeUserDefaults()
+        let store = makeStore(userDefaults: userDefaults)
+
+        store.updateContactEmail("  doctor@example.test  \n")
+        #expect(store.loadContactEmail() == "doctor@example.test")
+    }
+
+    @Test("updateContactEmail with nil clears the stored value")
+    func contactEmailNilClears() {
+        let userDefaults = makeUserDefaults()
+        let store = makeStore(userDefaults: userDefaults)
+
+        store.updateContactEmail("doctor@example.test")
+        store.updateContactEmail(nil)
+        #expect(store.loadContactEmail() == nil)
+        #expect(userDefaults.object(forKey: ClinikoCredentialStore.contactEmailUserDefaultsKey) == nil)
+    }
+
+    @Test("updateContactEmail with whitespace-only clears the stored value")
+    func contactEmailWhitespaceClears() {
+        let userDefaults = makeUserDefaults()
+        let store = makeStore(userDefaults: userDefaults)
+
+        store.updateContactEmail("doctor@example.test")
+        store.updateContactEmail("   \t\n  ")
+        // Whitespace-only must be treated the same as nil — otherwise the
+        // UA builder would emit `"mac-speech-to-text (   )"`.
+        #expect(store.loadContactEmail() == nil)
+    }
+
+    @Test("static loadContactEmail(from:) reads the same key as the instance method")
+    func contactEmailStaticReadMatchesInstance() {
+        let userDefaults = makeUserDefaults()
+        let store = makeStore(userDefaults: userDefaults)
+
+        store.updateContactEmail("ops@example.test")
+        // The static convenience is what `ClinikoUserAgent.defaultProvider()`
+        // calls — it must agree with the instance method that the UI uses
+        // to write, otherwise the UA would diverge from what the user typed.
+        #expect(ClinikoCredentialStore.loadContactEmail(from: userDefaults) == "ops@example.test")
+    }
+
+    @Test("deleteCredentials does NOT clear the contact email")
+    func deleteCredentialsPreservesContactEmail() async throws {
+        // The contact email is a preference about who Cliniko should contact,
+        // not material tied to the API key. Rotating credentials shouldn't
+        // make the doctor re-enter their own contact.
+        let userDefaults = makeUserDefaults()
+        let store = makeStore(userDefaults: userDefaults)
+        try await store.saveCredentials(apiKey: "k", shard: .au1)
+        store.updateContactEmail("doctor@example.test")
+
+        try await store.deleteCredentials()
+
+        #expect(store.loadContactEmail() == "doctor@example.test",
+                "contact email should survive credential removal")
+    }
+
     // MARK: - Service / account constants are pinned
 
     @Test("service + account constants match the Cliniko reference doc")
@@ -190,6 +269,7 @@ struct ClinikoCredentialStoreTests {
         #expect(ClinikoCredentialStore.serviceName == "com.speechtotext.cliniko")
         #expect(ClinikoCredentialStore.apiKeyAccount == "api_key")
         #expect(ClinikoCredentialStore.shardUserDefaultsKey == "cliniko.shard")
+        #expect(ClinikoCredentialStore.contactEmailUserDefaultsKey == "cliniko.contactEmail")
     }
 
     // MARK: - SecureStore failure surfacing

--- a/Tests/SpeechToTextTests/Views/ClinicalNotesSectionRenderTests.swift
+++ b/Tests/SpeechToTextTests/Views/ClinicalNotesSectionRenderTests.swift
@@ -212,7 +212,7 @@ final class ClinicalNotesSectionRenderTests: XCTestCase {
         )
     }
 
-    func test_contactEmailDraft_persistsThroughCredentialStore() async throws {
+    func test_contactEmailDraft_didSetPersistsThroughCredentialStore() async throws {
         let userDefaults = makeUserDefaults()
         let store = ClinikoCredentialStore(
             secureStore: InMemorySecureStore(),
@@ -225,12 +225,52 @@ final class ClinicalNotesSectionRenderTests: XCTestCase {
 
         // The didSet writes through synchronously via the nonisolated update.
         XCTAssertEqual(store.loadContactEmail(), "doctor@example.test")
+    }
 
-        // Refresh hydrates the draft back from the store.
-        viewModel.contactEmailDraft = "stale"
+    func test_contactEmailDraft_rehydratesFromStoreOnRefresh() async throws {
+        let userDefaults = makeUserDefaults()
+        let store = ClinikoCredentialStore(
+            secureStore: InMemorySecureStore(),
+            userDefaults: userDefaults
+        )
+        let probe = ClinikoAuthProbe(session: .shared)
+        let viewModel = ClinicalNotesSectionViewModel(credentialStore: store, authProbe: probe)
+
+        // Simulate an external write (a different settings tab / process /
+        // earlier session that persisted a value before the VM was created).
+        // A direct `store.updateContactEmail` skips the VM's didSet, so the
+        // VM has no in-memory record of the change until refreshState reloads
+        // from disk. This is the actual flow `refreshState` exists to support
+        // — the VM can't simulate it via its own didSet (which auto-saves
+        // and would overwrite, not diverge from, the disk value).
+        store.updateContactEmail("doctor@example.test")
+        XCTAssertEqual(viewModel.contactEmailDraft, "",
+                       "VM has not loaded yet; draft remains empty")
+
         await viewModel.refreshState()
         XCTAssertEqual(viewModel.contactEmailDraft, "doctor@example.test",
-                       "refreshState should reload the persisted email, replacing any unsaved local draft")
+                       "refreshState should hydrate the draft from the persisted store value")
+    }
+
+    func test_contactEmailDraft_refreshStateSkipsRedundantAssignment() async throws {
+        // The equality-guard in `refreshState` is belt-and-braces against a
+        // future trigger-graph addition that re-runs refresh while the field
+        // is focused. Pin the property: when the on-disk value already
+        // matches the in-memory draft, refreshState must not reassign (the
+        // assignment would be a no-op semantically, but we want the guard
+        // to remain wired in case the didSet logic gets richer).
+        let userDefaults = makeUserDefaults()
+        let store = ClinikoCredentialStore(
+            secureStore: InMemorySecureStore(),
+            userDefaults: userDefaults
+        )
+        let probe = ClinikoAuthProbe(session: .shared)
+        let viewModel = ClinicalNotesSectionViewModel(credentialStore: store, authProbe: probe)
+
+        viewModel.contactEmailDraft = "doctor@example.test"
+        await viewModel.refreshState()
+        XCTAssertEqual(viewModel.contactEmailDraft, "doctor@example.test",
+                       "draft already matches store; refreshState must not corrupt it")
     }
 
     // MARK: - #91 Conflict-guard validator

--- a/Tests/SpeechToTextTests/Views/ClinicalNotesSectionRenderTests.swift
+++ b/Tests/SpeechToTextTests/Views/ClinicalNotesSectionRenderTests.swift
@@ -174,6 +174,65 @@ final class ClinicalNotesSectionRenderTests: XCTestCase {
         )
     }
 
+    // MARK: - #89 Contact email field
+
+    func test_contactEmailField_isPresent() throws {
+        let viewModel = makeViewModel()
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesSection.contactEmailField")
+        )
+    }
+
+    func test_contactEmailField_invalidHintHiddenForEmptyDraft() throws {
+        let viewModel = makeViewModel()
+        viewModel.contactEmailDraft = ""
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
+        XCTAssertThrowsError(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesSection.contactEmailField.invalidHint"),
+            "Empty input is unset, not invalid — the hint should not appear"
+        )
+    }
+
+    func test_contactEmailField_invalidHintAppearsForMalformedInput() throws {
+        let viewModel = makeViewModel()
+        viewModel.contactEmailDraft = "not-an-email"
+        let view = ClinicalNotesSection(
+            viewModel: viewModel,
+            settingsService: makeSettingsService()
+        )
+        XCTAssertNoThrow(
+            try view.inspect().find(viewWithAccessibilityIdentifier: "clinicalNotesSection.contactEmailField.invalidHint")
+        )
+    }
+
+    func test_contactEmailDraft_persistsThroughCredentialStore() async throws {
+        let userDefaults = makeUserDefaults()
+        let store = ClinikoCredentialStore(
+            secureStore: InMemorySecureStore(),
+            userDefaults: userDefaults
+        )
+        let probe = ClinikoAuthProbe(session: .shared)
+        let viewModel = ClinicalNotesSectionViewModel(credentialStore: store, authProbe: probe)
+
+        viewModel.contactEmailDraft = "doctor@example.test"
+
+        // The didSet writes through synchronously via the nonisolated update.
+        XCTAssertEqual(store.loadContactEmail(), "doctor@example.test")
+
+        // Refresh hydrates the draft back from the store.
+        viewModel.contactEmailDraft = "stale"
+        await viewModel.refreshState()
+        XCTAssertEqual(viewModel.contactEmailDraft, "doctor@example.test",
+                       "refreshState should reload the persisted email, replacing any unsaved local draft")
+    }
+
     // MARK: - #91 Conflict-guard validator
 
     /// The validator is a pure function over an explicit "bound chords" list.


### PR DESCRIPTION
Closes #89.

## Why

Cliniko's [docs](https://docs.api.cliniko.com/) require:

> `User-Agent` format: `APP_VENDOR_NAME (APP_VENDOR_EMAIL)` — "If your requests do not include a User-Agent that contains a name and valid contact email, future requests may be automatically blocked."

We were emitting `mac-speech-to-text/<v> (https://github.com/...)` — a URL, not an email. Per the user's update on the issue, rather than hardcode a single project email, **the practitioner enters their own monitored address in the Clinical Notes settings**. Each install can publish its own contact.

## Plumbing

- **New `ClinikoUserAgent` enum** ([`Sources/Services/Cliniko/ClinikoUserAgent.swift`](Sources/Services/Cliniko/ClinikoUserAgent.swift)) — single source of truth for the two emitted shapes:
  - **Configured:** `mac-speech-to-text (user@example.com)` — matches Cliniko's docs example + the sibling `epc-letter-generation` reference (`EpcLetterGenerator (support@epclettergen.app)`).
  - **Fallback (no email yet):** existing `mac-speech-to-text/<v> (https://github.com/CloudbrokerAz/mac-speech-to-text)` — keeps the name+contact-reference contract satisfied, latent auto-block risk only applies in the un-configured window.
- **Storage:** `ClinikoCredentialStore` gains `cliniko.contactEmail` UserDefaults key with `loadContactEmail` / `updateContactEmail` (`nonisolated`, mirrors the existing `cliniko.shard` pattern). Not in Keychain — it's a contact reference, not auth material. Not cleared on `deleteCredentials` — rotating an API key shouldn't make the doctor re-enter their own email.
- **Concurrency:** replaced `let userAgent: String` on `ClinikoClient` / `ClinikoAuthProbe` with `let userAgentProvider: @Sendable () -> String`, called per request inside `buildRequest` / `ping`. The default provider reads UserDefaults each call, so a settings change propagates to the next request **without** re-instantiating the shared `ClinikoClient` (which is held across `ClinikoPatientService`, `ClinikoAppointmentService`, and `TreatmentNoteExporter` per `AppState.configureClinikoExportPipelineIfNeeded`). Convenience init `init(... userAgent: String, ...)` retained so existing tests that pin a fixed UA literal stay terse.
- **UI:** new "Contact email" `TextField` row in `ClinicalNotesSection`, between the shard picker and the action buttons. Auto-saves on every keystroke (cheap UserDefaults write, mirrors how `selectedShard` commits inline). Soft validation hint (orange triangle) for malformed input — never blocks save, since Cliniko doesn't policy-validate format.

## Tests

- New `ClinikoUserAgent` shape tests in `ClinikoAuthProbeTests` — email form, URL fallback, whitespace-only treated as missing, trim defence-in-depth, plus the load-bearing per-call read property (uses a per-test UserDefaults suite, not `.standard`, to avoid racing `SessionStoreTests.lifecycle_doesNotTouchUserDefaults` under `--parallel`).
- New `ClinikoCredentialStore` round-trip tests for `contactEmail` (set / load / clear / nil-clears / whitespace-clears / deleteCredentials preserves email).
- New ViewInspector render-crash tests for the new TextField + persistence pipeline (`ClinicalNotesSectionRenderTests`).
- Pinned the new UserDefaults key in `pinConstants`.

`swift test --parallel` → **460 tests in 44 suites pass** locally.

## Review pipeline

Followed the three-layer pre-PR review per `AGENTS.md`:
1. **Pre-PR:** parallel Opus subagents (`pr-review-toolkit:code-reviewer` + `pr-review-toolkit:silent-failure-hunter`). Found:
   - **Blocker:** the live-read test mutated `UserDefaults.standard`, which would race `SessionStoreTests.lifecycle_doesNotTouchUserDefaults` under `--parallel`. Fixed by adding a `defaultProvider(userDefaults:)` overload and routing the test through a per-suite `UserDefaults` instance.
   - **Nit:** added an equality guard in `refreshState` so a future call site that re-runs while the field is focused can't clobber a mid-typing draft.
2. **Automated (this PR):** Gemini Code Assist will run on open per `.gemini/config.yaml`.

## Doc

`.claude/references/cliniko-api.md` — User-Agent section now documents both shapes, the live-read property, and the un-configured fallback risk window. Added `cliniko.contactEmail` to the storage table and `ClinikoUserAgent.swift` to the related-files list.

## Test plan

- [x] `swift build`
- [x] `swift test --parallel` — all 460 tests pass
- [x] `pre-commit run` (SwiftLint --strict, gitleaks, etc.)
- [x] Pre-PR Opus review (code-reviewer + silent-failure-hunter)
- [ ] Gemini Code Assist (auto on open)
- [ ] Manual: Test connection in the Cliniko settings UI on a real tenant after entering a contact email — confirm Cliniko accepts the request and the audit ledger row's `app_version` still matches.

Awaiting CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)