### PR TITLE
chore(clinical-notes): remove temporary [#109-probe] chord-flow logs (#109 follow-up)

### DIFF
--- a/Sources/Services/HotkeyManager.swift
+++ b/Sources/Services/HotkeyManager.swift
@@ -176,10 +176,8 @@ class HotkeyManager {
     private func setupClinicalNotesHotkey() {
         KeyboardShortcuts.enable(.clinicalNotesRecord)
         AppLogger.app.debug("HotkeyManager: Enabled .clinicalNotesRecord shortcut")
-        AppLogger.app.info("[#109-probe] setupClinicalNotesHotkey: post-enable isEnabled=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public)")
 
         KeyboardShortcuts.onKeyDown(for: .clinicalNotesRecord) { [weak self] in
-            AppLogger.app.info("[#109-probe] onKeyDown fired for .clinicalNotesRecord (Carbon → KeyboardShortcuts dispatcher reached)")
             Task { @MainActor in
                 await self?.handleClinicalNotesKeyPress()
             }
@@ -225,11 +223,8 @@ class HotkeyManager {
     /// dedicated state flag so the chord cannot interleave with hold-to-record /
     /// toggle-recording sessions.
     func handleClinicalNotesKeyPress() async {
-        AppLogger.app.info("[#109-probe] handleClinicalNotesKeyPress entered: isRecordingClinicalNotes=\(self.isRecordingClinicalNotes, privacy: .public) isProcessing=\(self.isProcessing, privacy: .public) isEnabled=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public)")
-
         // If a clinical-notes session is active, stop it.
         if isRecordingClinicalNotes {
-            AppLogger.app.info("[#109-probe] handleClinicalNotesKeyPress → STOP branch (chord state was active)")
             isRecordingClinicalNotes = false
             await onClinicalNotesRecordingStop?()
             return
@@ -242,7 +237,6 @@ class HotkeyManager {
             return
         }
 
-        AppLogger.app.info("[#109-probe] handleClinicalNotesKeyPress → START branch (firing onClinicalNotesRecordingStart)")
         isRecordingClinicalNotes = true
         await onClinicalNotesRecordingStart?()
     }
@@ -259,7 +253,6 @@ class HotkeyManager {
     /// the user perceives the chord as broken until they press it again.
     /// Idempotent — safe to call from any close path.
     func clinicalNotesSessionEnded() {
-        AppLogger.app.info("[#109-probe] clinicalNotesSessionEnded entered: was isRecordingClinicalNotes=\(self.isRecordingClinicalNotes, privacy: .public) isEnabled=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public)")
         if isRecordingClinicalNotes {
             isRecordingClinicalNotes = false
             AppLogger.app.debug("HotkeyManager: clinicalNotesSessionEnded - state reset")

--- a/Sources/SpeechToTextApp/AppDelegate.swift
+++ b/Sources/SpeechToTextApp/AppDelegate.swift
@@ -1036,7 +1036,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let contentView = LiquidGlassRecordingModal(viewModel: viewModel)
             .onDisappear { [weak self] in
                 AppLogger.app.debug("showRecordingModal: LiquidGlassRecordingModal disappeared")
-                AppLogger.app.info("[#109-probe] modal.onDisappear: isEnabled(.clinicalNotesRecord)=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public) clinicalMode=\(clinicalMode, privacy: .public)")
                 // Belt: trigger the same cleanup the willClose observer runs.
                 // Either path may fire first; the cleanup is idempotent.
                 // .onDisappear is the SwiftUI-native path but is unreliable
@@ -1135,8 +1134,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     /// first; the second is a fast no-op once `recordingWindow` is nil. #109.
     @MainActor
     private func cleanupAfterRecordingModalClose(reason: String) {
-        AppLogger.app.info("[#109-probe] cleanupAfterRecordingModalClose: reason=\(reason, privacy: .public) recordingWindow==nil=\(self.recordingWindow == nil, privacy: .public) isEnabled(.clinicalNotesRecord)=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public)")
-
         // Drop the willClose observer first so a re-entrant close (e.g.
         // .onDisappear → window.close() → willClose fires after we already
         // ran via .onDisappear) can't queue a second cleanup.

--- a/Sources/Views/ClinicalNotes/ReviewWindow.swift
+++ b/Sources/Views/ClinicalNotes/ReviewWindow.swift
@@ -14,7 +14,6 @@
 
 import AppKit
 import Foundation
-import KeyboardShortcuts
 import OSLog
 import SwiftUI
 
@@ -66,8 +65,6 @@ final class ReviewWindow: NSObject, NSWindowDelegate {
     // MARK: - NSWindowDelegate
 
     func windowWillClose(_ notification: Notification) {
-        AppLogger.app.info("[#109-probe] ReviewWindow.windowWillClose entered: isEnabled(.clinicalNotesRecord)=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public)")
-
         // PHI chokepoint. Whatever path closed the window (Cancel, ⎋,
         // title-bar X, or a future export-flow auto-close), the session
         // does not survive the visible surface. `SessionStore.clear()`
@@ -85,8 +82,6 @@ final class ReviewWindow: NSObject, NSWindowDelegate {
         window?.delegate = nil
         window = nil
         NotificationCenter.default.post(name: .reviewScreenDidDismiss, object: nil)
-
-        AppLogger.app.info("[#109-probe] ReviewWindow.windowWillClose exited: isEnabled(.clinicalNotesRecord)=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public)")
     }
 
     // MARK: - Private
@@ -287,8 +282,6 @@ final class ReviewWindowController {
     // MARK: - Private
 
     private func handleDismissNotification() {
-        AppLogger.app.info("[#109-probe] ReviewWindowController.handleDismissNotification: window=\(self.window == nil ? "nil" : "non-nil", privacy: .public) isEnabled(.clinicalNotesRecord)=\(KeyboardShortcuts.isEnabled(for: .clinicalNotesRecord), privacy: .public)")
-
         // Two paths converge here:
         //   1. User-driven cancel via `ReviewViewModel.cancelReview` —
         //      window is still alive, we must close it. `close()` fires


### PR DESCRIPTION
## Why

The chord-flow probes added in #109 (PR #110, merge SHA `f9d6e8c1863184dd1705c1098c6c855154822595`) have soaked for 2 weeks in real clinical sessions **without regression**:

- Issue #109 remains `closed` (state_reason: completed) — no reopen, no follow-up bug report.
- Eight PRs (#129 → #137) have merged into `main` since the #110 fix landed; each pre- and post-merge CI run on `main` has been green.

The probes were one-shot diagnostics for narrowing the chord-stuck-after-first-session bug. Their job is done; OSLog noise on every chord press / modal close / review-window close in production is no longer worth its weight.

## What

Removes the 10 `[#109-probe]` info-level log lines across three files:

| File | Probes removed |
|---|---|
| `Sources/Services/HotkeyManager.swift` | `setupClinicalNotesHotkey` post-enable; `onKeyDown` Carbon dispatcher reached; `handleClinicalNotesKeyPress` entry / STOP branch / START branch; `clinicalNotesSessionEnded` entry |
| `Sources/SpeechToTextApp/AppDelegate.swift` | `modal.onDisappear` entry; `cleanupAfterRecordingModalClose` entry |
| `Sources/Views/ClinicalNotes/ReviewWindow.swift` | `ReviewWindow.windowWillClose` entry + exit; `ReviewWindowController.handleDismissNotification` entry |

Also drops the now-orphaned `import KeyboardShortcuts` from `ReviewWindow.swift` (the only references were inside the removed probe lines).

Diff: 17 deletions across 3 files, **zero logic change** — every `if`/`guard`/state mutation is untouched, every surrounding `.debug` log preserved.

## What is intentionally **kept**

```swift
// Sources/SpeechToTextApp/AppDelegate.swift:1099
AppLogger.app.warning("[#109-probe] showRecordingModal: stale willClose observer found on entry — previous modal closed without cleanup, possible regression of #109 in a new path")
```

This is a **permanent regression-detector**, not a one-shot probe. It only fires if a future code path lets the recording modal close without running cleanup — exactly the failure family that produced #109 in the first place. A future bug report citing the chord going dead after a session can be cross-referenced against this OSLog `warning` to confirm whether the same root cause has resurfaced via a different path.

Post-cleanup, `grep "\[#109-probe\]" Sources/` returns **exactly one match** — that warning.

## Test plan

- **Local verification could not run in this remote-agent environment** (no Swift toolchain on the Linux container — this project is macOS-only). The diff is mechanical removal of OSLog `.info` calls and one orphaned import; no logic, types, public API, or test fixtures were touched.
- **CI is the authoritative gate.** On open this PR will run:
  - SwiftLint --strict
  - pre-commit hooks
  - Build and Test (macOS runner)
  - codecov/patch
- Manual smoke test (chord → modal → review → close → chord again) is **optional** — chord-flow behaviour is unchanged; only the OSLog noise level on that flow changed. Anyone wanting to confirm can run a clinical-notes session pre/post merge and watch Console.app filtered to subsystem `com.speechtotext` — the only difference should be far fewer `[#109-probe]` lines on each chord press.

## Refs

- Closes the #109 follow-up loop (no separate issue — this is the agreed 2-week-soak cleanup).
- Original fix: PR #110, merge SHA `f9d6e8c1863184dd1705c1098c6c855154822595`.
- Issue #109 (closed, state_reason: completed).

## Not auto-merge

Leaving this for human review — even on a 17-line deletion, the constitutional rule on this repo is human-reviewed merges.

---

🤖 Generated as a 2-week-soak cleanup follow-up to PR #110 (see issue #109 comment thread).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PLq6aHjf24bpfMk6d6ebS2)_